### PR TITLE
Draft: Reduce duplication in the environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,44 +4,9 @@ channels:
 
 dependencies:
 - python=3.7
-- nose
-- nose-cov
-- paramiko
 - graphviz
-- python-dateutil
-- pyparsing
-- numpy<1.22
-- matplotlib
-- bcrypt
 - pip
-- mock
-- portalocker
-- networkx
 - sqlite
 - pip:
-  - autosubmitconfigparser
-  - argparse>=1.4.0
-  - bcrypt>=3.2.0
-  - python-dateutil>=2.8.2
-  - matplotlib>=3.5.1
-  - numpy<1.22
-  - py3dotplus>=1.1.0
-  - pyparsing>=3.0.7
-  - paramiko>=2.9.2
-  - mock>=4.0.3
-  - portalocker>=2.3.2
-  - networkx>=2.6.3
-  - requests>=2.27.1
-  - bscearth.utils>=0.5.2
-  - cryptography>=36.0.1
-  - setuptools>=60.8.2
-  - six>=1.10.0
-  - xlib>=0.21
-  - ruamel.yaml
-  - pythondialog
-  - pytest
-  - nose
-  - coverage
-  - requests
-  - configobj
+  - -e .
 


### PR DESCRIPTION
In GitLab by @kinow on Jul 31, 2023, 10:54

Part of #864 

This needs more testing, both locally and with the CICD worker (can't recall if that uses `environment.yml`).

I also think that `nosecov` is only installed in `environment.yml`.