### PR TITLE
ASLock implemented

### DIFF
--- a/autosubmit/database/repositories/locks.py
+++ b/autosubmit/database/repositories/locks.py
@@ -1,0 +1,204 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
+import json
+import sqlite3
+from typing import Optional
+from autosubmitconfigparser.config.basicconfig import BasicConfig
+
+
+@dataclass
+class LockModel:
+    """
+    Data model of the Autosubmit Lock
+    """
+
+    lock_id: str
+    hostname: str
+    pid: int
+    created: datetime = datetime.now(timezone.utc)
+
+
+class LocksRepository(ABC):
+    """
+    Interface for Autosubmit Locks Repository
+    """
+
+    @abstractmethod
+    def get_lock(self, lock_id: str) -> Optional[LockModel]:
+        """
+        Get the lock by lock_id. Return None if the lock does not exist.
+        """
+
+    @abstractmethod
+    def insert_lock_from_model(self, lock: LockModel):
+        """
+        Insert the lock
+        """
+
+    @abstractmethod
+    def insert_lock(self, lock_id: str, hostname: str, pid: int):
+        """
+        Insert the lock. Create a LockModel object first.
+        """
+
+    @abstractmethod
+    def delete_lock(self, lock_id: str):
+        """
+        Delete the lock
+        """
+
+
+class LocksFileRepository(LocksRepository):
+    """
+    Repository of Autosubmit Locks using files.
+    It creates a lock file for each lock which is stored in the directory.
+    """
+
+    def __init__(self, dir_path: str):
+        self.dir_path = dir_path
+        self._initialize()
+
+    def _initialize(self):
+        """
+        Create the locks directory if it does not exist
+        """
+        os.makedirs(self.dir_path, exist_ok=True)
+
+    def get_lock(self, lock_id: str) -> Optional[LockModel]:
+        """
+        Get the lock by lock_id. Return None if the lock does not exist.
+        """
+        lock_file = os.path.join(self.dir_path, lock_id)
+        if not os.path.exists(lock_file):
+            return None
+
+        # Load from JSON format
+        with open(lock_file, "r") as f:
+            lock_data = json.load(f)
+            return LockModel(
+                lock_data["lock_id"],
+                lock_data["hostname"],
+                lock_data["pid"],
+                datetime.fromisoformat(lock_data["created"]),
+            )
+
+    def insert_lock_from_model(self, lock: LockModel):
+        """
+        Insert the lock into the directory. Save content in JSON format.
+        """
+        lock_file = os.path.join(self.dir_path, lock.lock_id)
+        # Save in JSON format
+        with open(lock_file, "w") as f:
+            json.dump(
+                {
+                    "lock_id": lock.lock_id,
+                    "hostname": lock.hostname,
+                    "pid": lock.pid,
+                    "created": lock.created.isoformat(),
+                },
+                f,
+            )
+
+    def insert_lock(self, lock_id: str, hostname: str, pid: int):
+        """
+        Insert the lock into the directory. Create a LockModel object first.
+        """
+        new_lock = LockModel(lock_id, hostname, pid, datetime.now(timezone.utc))
+        self.insert_lock_from_model(new_lock)
+
+    def delete_lock(self, lock_id: str):
+        """
+        Delete the lock from the directory
+        """
+        lock_file = os.path.join(self.dir_path, lock_id)
+        os.remove(lock_file)
+
+
+class LocksDBRepository(LocksRepository):
+    """
+    Repository of Autosubmit Locks using SQLite
+    """
+
+    # TODO: Generalize with SQLAlchemy
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._initialize()
+
+    def _initialize(self):
+        """
+        Create the locks table if it does not exist
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS locks (
+                    lock_id TEXT PRIMARY KEY,
+                    hostname TEXT,
+                    pid INTEGER,
+                    created TEXT
+                )
+            """)
+            conn.commit()
+
+    def get_lock(self, lock_id: str) -> Optional[LockModel]:
+        """
+        Get the lock by lock_id
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT lock_id, hostname, pid, created FROM locks WHERE lock_id = ?",
+                (lock_id,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return LockModel(
+                row[0],  # lock_id
+                row[1],  # hostname
+                row[2],  # pid
+                datetime.fromisoformat(row[3]),  # created
+            )
+
+    def insert_lock_from_model(self, lock: LockModel):
+        """
+        Insert the lock into the database
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT INTO locks VALUES (?, ?, ?, ?)",
+                (lock.lock_id, lock.hostname, lock.pid, lock.created.isoformat()),
+            )
+            conn.commit()
+
+    def insert_lock(self, lock_id: str, hostname: str, pid: int):
+        """
+        Insert the lock into the database. Create a LockModel object first.
+        """
+        new_lock = LockModel(lock_id, hostname, pid, datetime.now(timezone.utc))
+        self.insert_lock_from_model(new_lock)
+
+    def delete_lock(self, lock_id: str):
+        """
+        Delete the lock from the database
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM locks WHERE lock_id = ?", (lock_id,))
+            conn.commit()
+
+
+def create_locks_repository() -> LocksRepository:
+    """
+    Factory function to create the LocksRepository.
+
+    """
+    basic_config = BasicConfig()
+    basic_config.read()
+
+    # TODO: Use the BasicConfig to determine the repository type. For now, it is hardcoded to use the file repository.
+
+    locks_dir_path = os.path.join(basic_config.LOCAL_ROOT_DIR, "locks")
+
+    return LocksFileRepository(locks_dir_path)

--- a/bin/autosubmit
+++ b/bin/autosubmit
@@ -39,8 +39,6 @@ def exit_from_error(e: BaseException):
         Log.debug(trace)
     except:
         print(trace)
-    with suppress(FileNotFoundError, PermissionError):
-        os.remove(os.path.join(Log.file_path, "autosubmit.lock"))
     if isinstance(e, (AutosubmitCritical, AutosubmitError)):
         e: Union[AutosubmitError, AutosubmitCritical] = e
         if e.trace:
@@ -57,8 +55,6 @@ def exit_from_error(e: BaseException):
 def main():
     try:
         return_value = Autosubmit.parse_args()
-        if os.path.exists(os.path.join(Log.file_path, "autosubmit.lock")):
-            os.remove(os.path.join(Log.file_path, "autosubmit.lock"))
         if type(return_value) is int:
             os._exit(return_value)
         os._exit(0)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,7 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
-autodoc_mock_imports = ["portalocker", "argparse", "python-dateutil", "py3dotplus", "pyparsing",
+autodoc_mock_imports = ["argparse", "python-dateutil", "py3dotplus", "pyparsing",
                         'numpy', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.gridspec', 'matplotlib.patches', 'paramiko',
                         'mock', "networkx", 'networkx.algorithms.dag', 'bscearth.utils', 'bscearth.utils.config_parser',
                         'bscearth.utils.date']

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -11,7 +11,7 @@ The Autosubmit code is hosted in Git, at the BSC GitLab public repository. The A
 
 .. important:: (SYSTEM) Graphviz version must be >= 2.38 except 2.40(not working). You can check the version using dot -v.
 
-- Python dependencies: configobj>=5.0.6, argparse>=1.4.0 , python-dateutil>=2.8.2, matplotlib==3.4.3, numpy==1.21.6, py3dotplus>=1.1.0, pyparsing>=3.0.7, paramiko>=2.9.2, mock>=4.0.3, six>=1.10, portalocker>=2.3.2, networkx==2.6.3, requests>=2.27.1, bscearth.utils>=0.5.2, cryptography>=36.0.1, setuptools>=60.8.2, xlib>=0.21, pip>=22.0.3, ruamel.yaml, pythondialog, pytest, nose, coverage, PyNaCl==1.4.0, six>=1.10.0, requests, xlib, Pygments, packaging==19, typing>=3.7, autosubmitconfigparser
+- Python dependencies: configobj>=5.0.6, argparse>=1.4.0 , python-dateutil>=2.8.2, matplotlib==3.4.3, numpy==1.21.6, py3dotplus>=1.1.0, pyparsing>=3.0.7, paramiko>=2.9.2, mock>=4.0.3, six>=1.10, networkx==2.6.3, requests>=2.27.1, bscearth.utils>=0.5.2, cryptography>=36.0.1, setuptools>=60.8.2, xlib>=0.21, pip>=22.0.3, ruamel.yaml, pythondialog, pytest, nose, coverage, PyNaCl==1.4.0, six>=1.10.0, requests, xlib, Pygments, packaging==19, typing>=3.7, autosubmitconfigparser
 
 .. important:: ``dot -v`` command should contain "dot", pdf, png, SVG, Xlib in the device section.
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ install_requires = [
     'bscearth.utils<=0.5.2',
     'requests<=2.31.0',
     'networkx<=2.6.3',
-    'portalocker<=2.7.0',
     'paramiko<=3.4',
     'pyparsing==3.1.1',
     'matplotlib<=3.8.3',

--- a/test/regression/local_check_details.py
+++ b/test/regression/local_check_details.py
@@ -41,10 +41,7 @@ def perform_test(expids):
     to_exclude = []
     for expid in expids:
         try:
-            start = time.time()
             output,error = run_test(expid)
-            end = time.time()
-            print(f"Time taken for {expid}: {end-start}")
             # output to str
             output = output.decode("UTF-8")
             output = output.split("Job list created successfully[0m[39m")[1]

--- a/test/regression/local_check_details.py
+++ b/test/regression/local_check_details.py
@@ -8,6 +8,7 @@ Works under local_computer TODO introduce in CI
 
 import os
 import subprocess
+import time
 BIN_PATH = '../../bin'
 ACTIVE_DOCS = True # Use autosubmit_docs database
 VERSION = 4.1 # 4.0 or 4.1
@@ -40,7 +41,10 @@ def perform_test(expids):
     to_exclude = []
     for expid in expids:
         try:
+            start = time.time()
             output,error = run_test(expid)
+            end = time.time()
+            print(f"Time taken for {expid}: {end-start}")
             # output to str
             output = output.decode("UTF-8")
             output = output.split("Job list created successfully[0m[39m")[1]
@@ -68,4 +72,8 @@ for experiment in os.listdir(f"{EXPERIMENTS_PATH}"):
             expids.append(experiment)
 # Force
 # expids = ["a001"]
+#General time
+start = time.time()
 perform_test(expids)
+end = time.time()
+print(f"Acc time taken: {end-start}")

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -2,6 +2,11 @@ import os
 import socket
 import pytest
 from pathlib import Path
+from autosubmit.database.repositories.locks import (
+    create_locks_repository,
+    LocksRepository,
+    LocksFileRepository,
+)
 from autosubmit.helpers.utils import ASLock
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from log.log import AutosubmitCritical
@@ -11,9 +16,11 @@ from log.log import AutosubmitCritical
 def utils_tmp_path(tmp_path_factory):
     return tmp_path_factory.mktemp("utils")
 
+
 class MockBasicConfig(BasicConfig):
     def read(self):
         pass
+
 
 @pytest.fixture
 def mock_basic_config(monkeypatch, utils_tmp_path):
@@ -21,42 +28,64 @@ def mock_basic_config(monkeypatch, utils_tmp_path):
     monkeypatch.setattr("autosubmit.helpers.utils.BasicConfig", MockBasicConfig)
     return MockBasicConfig
 
+
 def test_aslock(mock_basic_config):
-    expid = "test_expid"
+    """
+    Test acquiring and releasing the lock
+    """
+    lock_id = "test_aslock"
     current_hostname = socket.gethostname()
     current_pid = os.getpid()
-    lock_file_path = Path(MockBasicConfig.LOCAL_ROOT_DIR) / expid / "tmp" / "autosubmit.lock"
-
-    # Ensure the directory exists
-    lock_file_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Test acquiring the lock
-    with ASLock(expid):
-        assert lock_file_path.exists(), "Lock file should be created"
-        with open(lock_file_path, "r") as f:
-            content = f.read()
-            assert content == f"{current_hostname},{current_pid}", "Lock file content should match"
+    lock_type = None
+    with ASLock(lock_id) as locker:
+        assert isinstance(locker.locks_repository, LocksRepository)
+
+        if isinstance(locker.locks_repository, LocksFileRepository):
+            # Check the lock file
+            lock_type = "file"
+            lock_file_path = Path(locker.locks_repository.dir_path) / lock_id
+            assert lock_file_path.exists(), "Lock file should exist"
+            assert lock_file_path.is_file(), "Lock file should be a file"
+        # TODO: Add more lock types (SQLAlchemy)
+
+        # Get and check the lock
+        curr_lock = locker.locks_repository.get_lock(lock_id)
+        assert curr_lock.hostname == current_hostname, "Hostname should match"
+        assert curr_lock.pid == current_pid, "PID should match"
 
     # Test releasing the lock
-    assert not lock_file_path.exists(), "Lock file should be removed after releasing"
+    if lock_type == "file":
+        assert not lock_file_path.exists(), "Lock file should not exist"
+    # TODO: Add more lock types (SQLAlchemy)
+
+    locks_repository = create_locks_repository()
+    curr_lock = locks_repository.get_lock(lock_id)
+    assert curr_lock is None
+
 
 def test_aslock_error(mock_basic_config):
-    expid = "test_expid"
-    lock_file_path = Path(MockBasicConfig.LOCAL_ROOT_DIR) / expid / "tmp" / "autosubmit.lock"
-
-    # Ensure the directory exists
-    lock_file_path.parent.mkdir(parents=True, exist_ok=True)
+    """
+    Test acquiring the lock multiple times should raise an error
+    """
+    lock_id = "test_aslock_error"
 
     # Test acquiring the lock
-    with ASLock(expid):
-        assert lock_file_path.exists(), "Lock file should be created"
-        # Test acquiring the lock again
-        with pytest.raises(AutosubmitCritical):
-            with ASLock(expid):
-                pass
-        assert lock_file_path.exists(), "Lock file should still exist after failing to acquire the lock"
-        # Test another time
-        with pytest.raises(AutosubmitCritical):
-            with ASLock(expid):
-                pass
-        assert lock_file_path.exists(), "Lock file should still exist after the first failure"
+    with ASLock(lock_id):
+        # Snapshot the current lock
+        locks_repository = create_locks_repository()
+        lock_snapshot = locks_repository.get_lock(lock_id)
+
+        # Try creating lock multiple times
+        for i in range(10):
+            with pytest.raises(AutosubmitCritical):
+                with ASLock(lock_id):
+                    pass
+
+            curr_lock = locks_repository.get_lock(lock_id)
+            assert curr_lock.hostname == lock_snapshot.hostname, "Hostname should match"
+            assert curr_lock.pid == lock_snapshot.pid, "PID should match"
+            assert (
+                curr_lock.created == lock_snapshot.created
+            ), "Created datetime should match"

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -42,7 +42,7 @@ def test_aslock(mock_basic_config):
 
 def test_aslock_error(mock_basic_config):
     expid = "test_expid"
-    lock_file_path = Path("/tmp") / expid / "tmp" / "autosubmit.lock"
+    lock_file_path = Path(MockBasicConfig.LOCAL_ROOT_DIR) / expid / "tmp" / "autosubmit.lock"
 
     # Ensure the directory exists
     lock_file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,6 +1,5 @@
 import os
 import socket
-import psutil
 import pytest
 from pathlib import Path
 from autosubmit.helpers.utils import ASLock
@@ -13,7 +12,6 @@ def utils_tmp_path(tmp_path_factory):
     return tmp_path_factory.mktemp("utils")
 
 class MockBasicConfig(BasicConfig):
-
     def read(self):
         pass
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,55 @@
+import os
+import socket
+import psutil
+import pytest
+from pathlib import Path
+from autosubmit.helpers.utils import ASLock
+from autosubmitconfigparser.config.basicconfig import BasicConfig
+from log.log import AutosubmitCritical
+class MockBasicConfig(BasicConfig):
+    def read(self):
+        self.LOCAL_ROOT_DIR = "/tmp"
+
+@pytest.fixture
+def mock_basic_config(monkeypatch):
+    monkeypatch.setattr("autosubmit.helpers.utils.BasicConfig", MockBasicConfig)
+
+def test_aslock(mock_basic_config):
+    expid = "test_expid"
+    current_hostname = socket.gethostname()
+    current_pid = os.getpid()
+    lock_file_path = Path("/tmp") / expid / "tmp" / "autosubmit.lock"
+
+    # Ensure the directory exists
+    lock_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Test acquiring the lock
+    with ASLock(expid):
+        assert lock_file_path.exists(), "Lock file should be created"
+        with open(lock_file_path, "r") as f:
+            content = f.read()
+            assert content == f"{current_hostname},{current_pid}", "Lock file content should match"
+
+    # Test releasing the lock
+    assert not lock_file_path.exists(), "Lock file should be removed after releasing"
+
+def test_aslock_error(mock_basic_config):
+    expid = "test_expid"
+    lock_file_path = Path("/tmp") / expid / "tmp" / "autosubmit.lock"
+
+    # Ensure the directory exists
+    lock_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Test acquiring the lock
+    with ASLock(expid):
+        assert lock_file_path.exists(), "Lock file should be created"
+        # Test acquiring the lock again
+        with pytest.raises(AutosubmitCritical):
+            with ASLock(expid):
+                pass
+        assert lock_file_path.exists(), "Lock file should still exist after failing to acquire the lock"
+        # Test another time
+        with pytest.raises(AutosubmitCritical):
+            with ASLock(expid):
+                pass
+        assert lock_file_path.exists(), "Lock file should still exist after the first failure"

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -6,19 +6,28 @@ from pathlib import Path
 from autosubmit.helpers.utils import ASLock
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from log.log import AutosubmitCritical
-class MockBasicConfig(BasicConfig):
-    def read(self):
-        self.LOCAL_ROOT_DIR = "/tmp"
+
 
 @pytest.fixture
-def mock_basic_config(monkeypatch):
+def utils_tmp_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("utils")
+
+class MockBasicConfig(BasicConfig):
+
+    def read(self):
+        pass
+
+@pytest.fixture
+def mock_basic_config(monkeypatch, utils_tmp_path):
+    MockBasicConfig.LOCAL_ROOT_DIR = utils_tmp_path
     monkeypatch.setattr("autosubmit.helpers.utils.BasicConfig", MockBasicConfig)
+    return MockBasicConfig
 
 def test_aslock(mock_basic_config):
     expid = "test_expid"
     current_hostname = socket.gethostname()
     current_pid = os.getpid()
-    lock_file_path = Path("/tmp") / expid / "tmp" / "autosubmit.lock"
+    lock_file_path = Path(MockBasicConfig.LOCAL_ROOT_DIR) / expid / "tmp" / "autosubmit.lock"
 
     # Ensure the directory exists
     lock_file_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
In GitLab by @dbeltrankyl on Aug 7, 2024, 11:14

Implements #945.

This branch removes the portlocker library, and instead, it uses a new implementation without relying on libraries. 

This fixes the issue where the experiments could run multiple times, see the test to know how to use it, but it is similar to the portalocker ( use it with the with statement )

Ready to review @kinow @edgano, I don't know how much work you have right now as I was on holiday if nobody assigns itself I'll assign later one of you, thanks!.