### PR TITLE
Removed unneeded sleep

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1605,7 +1605,6 @@ class Autosubmit:
                     as_conf, job_list, jobs_cw, packages_persistence, False)
 
             Log.info("no more scripts to generate, now proceed to check them manually")
-            time.sleep(safetysleeptime)
         except AutosubmitCritical as e:
             raise
         except AutosubmitError as e:


### PR DESCRIPTION
In GitLab by @dbeltrankyl on Oct 10, 2024, 15:56

This removes an unnecessary sleep at the end of the inspect command.

This sleep is only meant to use to wait between loops in an autosubmit run