### PR TITLE
Autosubmit config compatibility

### DIFF
--- a/autosubmit/job/job_list.py
+++ b/autosubmit/job/job_list.py
@@ -987,6 +987,8 @@ class JobList(object):
             special_conditions = dict()
             special_conditions["STATUS"] = filters_to_apply_by_section[key].pop("STATUS", None)
             special_conditions["FROM_STEP"] = filters_to_apply_by_section[key].pop("FROM_STEP", None)
+            special_conditions["ANY_FINAL_STATUS_IS_VALID"] = filters_to_apply_by_section[key].pop("ANY_FINAL_STATUS_IS_VALID", False)
+
             for parent in list_of_parents:
                 self.add_special_conditions(job, special_conditions, filters_to_apply_by_section[key],
                                             parent)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ install_requires = [
     'py3dotplus==1.1.0',
     'numpy<2',
     'rocrate==0.*',
-    'autosubmitconfigparser==1.0.73',
+    'autosubmitconfigparser==1.0.75',
     'configparser',
     'setproctitle',
     'invoke>=2.0',


### PR DESCRIPTION
In GitLab by @dbeltrankyl on Nov 28, 2024, 14:28

related to https://github.com/BSC-ES/autosubmit-config-parser/pull/53 , !518 

To test that code, the configuration has to have any kind of filter, for example:


```yaml

DEFAULT:
  # Job experiment ID.
  EXPID: "a000"
  # Default HPC platform name.
  HPCARCH: "local"
CONFIG:
  # Current version of autosubmit.
  AUTOSUBMIT_VERSION: "4.1.11"
  # Maximum number of jobs permitted in the waiting status.
  MAXWAITINGJOBS: 20
  # Total number of jobs in the workflow.
  TOTALJOBS: 20
  SAFETYSLEEPTIME: 0
  RETRIALS: 0
MAIL:
  NOTIFICATIONS: False
  TO:
STORAGE:
  TYPE: pkl
  COPY_REMOTE_LOGS: true

EXPERIMENT:
  DATELIST: 20221101
  MEMBERS: fc0
  CHUNKSIZEUNIT: month
  CHUNKSIZE: 2
  NUMCHUNKS: 1
  CHUNKINI: ''
  CALENDAR: standard
PROJECT:
  # Type of the project.
  PROJECT_TYPE: none
  # Folder to hold the project sources.
  PROJECT_DESTINATION: git_project
GIT:
  PROJECT_ORIGIN: "blabla"
  PROJECT_BRANCH: "blabla"
  PROJECT_COMMIT: ''
  PROJECT_SUBMODULES: ''
  FETCH_SINGLE_BRANCH: true
PLATFORMS:
  dummy:
    USER: testuser

JOBS:
  A:
    SCRIPT: |
      echo "test"
  B:
    SCRIPT: |
      echo "test"
    DEPENDENCIES:
        A:
         STATUS: "COMPLETED"
    running: once

```

And perform: 

`autosubmit create $expid`


What happens without the fix and the last autosubmit config parser master: 

* Autosubmit crashes due boolean doesn't have .lower()