### PR TITLE
File descriptors

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2384,6 +2384,7 @@ class Autosubmit:
                     if p.log_recovery_process:
                         p.cleanup_event.set() # Send cleanup event
                         p.log_recovery_process.join()
+                        Log.info(f"Log recovery process for {p.name} has finished")
                 for job in job_list.get_completed_failed_without_logs(): # update the info gathered from the childs
                     job_list.update_log_status(job, as_conf)
                 job_list.save()
@@ -2401,8 +2402,8 @@ class Autosubmit:
                         Autosubmit.database_fix(expid)
                     except Exception as e:
                         pass
-                for platform in platforms_to_test:
-                    platform.closeConnection()
+                for p in platforms_to_test:
+                    p.closeConnection()
                 if len(job_list.get_failed()) > 0:
                     Log.info("Some jobs have failed and reached maximum retrials")
                 else:

--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -95,6 +95,7 @@ class ParamikoPlatform(Platform):
         return self._wrapper
 
     def reset(self):
+        self.closeConnection()
         self.connected = False
         self._ssh = None
         self._ssh_config = None

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -995,4 +995,4 @@ class Platform(object):
                 break
         self.closeConnection()
         Log.info(f"{identifier} Exiting.")
-        _exit(0)  # Exit userspace, recommended for processes.
+        _exit(0)  # Exit userspace after manually closing ssh sockets, recommended for processes, the queue() and shared signals should be in charge of the main process.

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -1,6 +1,7 @@
 import atexit
 import multiprocessing
 import queue  # only for the exception
+from os import _exit
 import setproctitle
 import locale
 import os
@@ -992,4 +993,6 @@ class Platform(object):
             if self.cleanup_event.is_set():  # Check if the main process is waiting for this child to end.
                 self.recover_job_log(identifier, jobs_pending_to_process)
                 break
+        self.closeConnection()
         Log.info(f"{identifier} Exiting.")
+        _exit(0)  # Exit userspace, recommended for processes.

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -996,4 +996,4 @@ class Platform(object):
                 break
         self.closeConnection()
         Log.info(f"{identifier} Exiting.")
-        _exit(0)  # Exit userspace after manually closing ssh sockets, recommended for processes, the queue() and shared signals should be in charge of the main process.
+        _exit(0)  # Exit userspace after manually closing ssh sockets, recommended for child processes, the queue() and shared signals should be in charge of the main process.

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -883,6 +883,7 @@ class Platform(object):
                 Log.result(f"Process {self.log_recovery_process.name} started with pid {self.log_recovery_process.pid}")
                 # Cleanup will be automatically prompt on control + c or a normal exit
                 atexit.register(self.send_cleanup_signal)
+                atexit.register(self.closeConnection)
 
     def send_cleanup_signal(self) -> None:
         """


### PR DESCRIPTION
In GitLab by @dbeltrankyl on Dec 4, 2024, 17:38

Hello @kinow , @isimo00 

This branch is trying to fix the file descriptors issue (which was commented on early this week for 4.1.11). 

Changes: 

* Added platform.closeconnection() call in paramikoplatform.reset(). ( I think ) This is another reason for what could have happened with 4.1.11 alongside the terminate_child function that is not called anymore. This forces the close of every socket that the platform has before making a new connection (which was already being called at the end of autosubmit run )

* Added platform.closeconnection() call before exiting the child process.
* Added _exit(0) to the child process seems to be the UNIX way of doing it. 
* Registered platform.closeconnection() to be called atexit. 

I checked the FD with the log.fd_show.fd_table_status_str() function can't detect an anomaly. ( Just add it whenever you feel it convenient to test it, it is also available in 4.1.11 )

After calling this function, I saw that two FDs were removed. 


~~It seems that the pipeline is working after these changes.~~ Not anymore failed on a new proc, will check on Monday ( day off tomorrow). Edit: And it worked again on the next rerun without touching anything else. 



Target branch: 4.1.12-dev-branch