### PR TITLE
Draft: Run provenance

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2444,9 +2444,7 @@ class Autosubmit:
                 # Create rocrate object if requested
                 rocrate_data = as_conf.experiment_data.get("ROCRATE", None)
                 if rocrate_data:
-                    Autosubmit.provenance(expid, rocrate=True)
-                else:
-                    print("rocrate.yml not found in CONFIG. Can't create rocrate object. ")
+                        Autosubmit.provenance(expid, rocrate=True)
         except BaseLockException:
             terminate_child_process(expid)
             raise

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2445,6 +2445,8 @@ class Autosubmit:
                 rocrate_data = as_conf.experiment_data.get("ROCRATE", None)
                 if rocrate_data:
                     Autosubmit.provenance(expid, rocrate=True)
+                else:
+                    Log.warning("Can't find ROCRATE in YAML configuration")
         except BaseLockException:
             terminate_child_process(expid)
             raise

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2444,7 +2444,7 @@ class Autosubmit:
                 # Create rocrate object if requested
                 rocrate_data = as_conf.experiment_data.get("ROCRATE", None)
                 if rocrate_data:
-                        Autosubmit.provenance(expid, rocrate=True)
+                    Autosubmit.provenance(expid, rocrate=True)
         except BaseLockException:
             terminate_child_process(expid)
             raise

--- a/autosubmit/provenance/rocrate.py
+++ b/autosubmit/provenance/rocrate.py
@@ -23,6 +23,7 @@ import datetime
 import json
 import mimetypes
 import os
+import time
 import subprocess
 from pathlib import Path
 from textwrap import dedent
@@ -557,6 +558,7 @@ def create_rocrate_archive(
             crate.add_or_update_jsonld(jsonld_node)
 
     # Write RO-Crate ZIP.
-    crate.write_zip(Path(path, f"{expid}.zip"))
+    date = time.strftime("%Y%m%d%H%M%S", time.localtime(os.path.getmtime(path)))
+    crate.write_zip(Path(path, f"{expid}-{date}.zip"))
     Log.info(f'RO-Crate archive written to {experiment_path}')
     return crate

--- a/test/unit/test_provenance.py
+++ b/test/unit/test_provenance.py
@@ -1,0 +1,59 @@
+import pytest
+from pathlib import Path
+from autosubmit.autosubmit import Autosubmit
+from log.log import AutosubmitCritical
+import os
+from unittest.mock import patch
+
+@pytest.fixture
+def mock_paths(tmp_path):
+    """
+    Fixture to set temporary paths for BasicConfig values.
+    """
+    with patch('autosubmitconfigparser.config.basicconfig.BasicConfig.LOCAL_ROOT_DIR', str(tmp_path)), \
+         patch('autosubmitconfigparser.config.basicconfig.BasicConfig.LOCAL_TMP_DIR', 'tmp'), \
+         patch('autosubmitconfigparser.config.basicconfig.BasicConfig.LOCAL_ASLOG_DIR', 'ASLOGS'):
+        yield tmp_path  
+
+def test_provenance_rocrate_success(mock_paths):
+    """
+    Test the provenance function when rocrate=True and the process is successful.
+    """
+    with patch('autosubmit.autosubmit.Autosubmit.rocrate') as mock_rocrate, \
+         patch('log.log.Log.info') as mock_log_info:
+        
+        expid = "expid123"
+        exp_folder = os.path.join(str(mock_paths), expid)
+        tmp_folder = os.path.join(exp_folder, 'tmp')  
+        aslogs_folder = os.path.join(tmp_folder, 'ASLOGS')  
+        expected_aslogs_path = aslogs_folder  
+
+        Autosubmit.provenance(expid, rocrate=True)
+
+        mock_rocrate.assert_called_once_with(expid, Path(expected_aslogs_path))
+        mock_log_info.assert_called_once_with('RO-Crate ZIP file created!')
+
+def test_provenance_rocrate_failure():
+    """
+    Test the provenance function when Autosubmit.rocrate fails
+    """
+    with patch('autosubmit.autosubmit.Autosubmit.rocrate', side_effect=Exception("Mocked exception")) as mock_rocrate:
+        
+        with pytest.raises(AutosubmitCritical) as excinfo:
+            Autosubmit.provenance("expid123", rocrate=True)
+
+        assert "Error creating RO-Crate ZIP file: Mocked exception" in str(excinfo)
+
+        mock_rocrate.assert_called_once()
+
+
+def test_provenance_no_rocrate():
+    """
+    Test the provenance function when rocrate=False 
+    """
+    with patch('autosubmit.autosubmit.Autosubmit.rocrate') as mock_rocrate:
+        with pytest.raises(AutosubmitCritical) as excinfo:
+            Autosubmit.provenance("expid123", rocrate=False)
+
+        assert "Can not create RO-Crate ZIP file. Argument '--rocrate' required" in str(excinfo)
+        mock_rocrate.assert_not_called() 


### PR DESCRIPTION
In GitLab by @apuiggro on Dec 5, 2024, 12:18

When running an experiment, this feature detects if an rocrate.yml object exists in the config and automatically creates an rocrate object after the execution is finished. 

Pending on merge request: https://earth.bsc.es/gitlab/es/autosubmit/-/merge_requests/505. This feature can only work if provenance function is inlcuded in `autosubmit.py`.