### PR TITLE
hotfix: add master to action trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   # lint: # Turn on when linting issues are resolved


### PR DESCRIPTION
Since we decided to rename to main later