### PR TITLE
(DEV VERSION ) Fix issue with the wrapper attribute

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -266,7 +266,7 @@ class Job(object):
         Adjusts job parameters for compatibility with newer added attributes.
         """
         # This function is always called at the start of a new run ( from update_parameters )
-        if not hasattr(self, 'is_wrapper') or not hasattr(self, 'wrapper_name'): # Added in 4.1.12
+        if not hasattr(self, 'is_wrapper'): # Added in 4.1.12
             if not self.packed:
                 self.is_wrapper = False
                 self.wrapper_name = self.name

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -261,6 +261,19 @@ class Job(object):
         self.wrapper_name = None
         self.is_wrapper = False
 
+    def _adjust_new_parameters(self) -> None:
+        """
+        Adjusts job parameters for compatibility with newer added attributes.
+        """
+        # This function is always called at the start of a new run ( from update_parameters )
+        if not hasattr(self, 'is_wrapper') or not hasattr(self, 'wrapper_name'): # Added in 4.1.12
+            if not self.packed:
+                self.is_wrapper = False
+                self.wrapper_name = self.name
+            else:
+                self.is_wrapper = True
+                self.wrapper_name = "wrapped"
+
     def _init_runtime_parameters(self):
         # hetjobs
         self.het = {'HETSIZE': 0}
@@ -2030,6 +2043,7 @@ class Job(object):
         :type parameters: dict
         """
         as_conf.reload()
+        self._adjust_new_parameters()
         self._init_runtime_parameters()
         if hasattr(self, "start_time"):
             self.start_time = time.time()

--- a/test/unit/test_job_pytest.py
+++ b/test/unit/test_job_pytest.py
@@ -148,3 +148,19 @@ def test_update_parameters_attributes(autosubmit_config, experiment_data, attrib
     for attr in attributes_to_check:
         assert hasattr(job, attr)
         assert getattr(job, attr) == attributes_to_check[attr]
+
+@pytest.mark.parametrize('test_packed', [
+    False,
+    True,
+], ids=["Simple job", "Wrapped job"])
+def test_adjust_new_parameters(test_packed):
+    job = Job('dummy', '1', 0, 1)
+    del job.is_wrapper
+    del job.wrapper_name
+    job.packed = test_packed
+    job._adjust_new_parameters()
+    assert job.is_wrapper == test_packed
+    if test_packed:
+        assert job.wrapper_name == "wrapped"
+    else:
+        assert job.wrapper_name == "dummy"


### PR DESCRIPTION
Discovered in the t-suite week 50 

What happens? 

* Autosubmit 4.1.12 dev crash in local jobs if the job was exiting from an older version

How to reproduce it

* Create a list of jobs with the local platform with 4.1.11 or older. autosubmit create $expid
* Change version, and perform autosubmit run $expid 

