### PR TITLE
Fixes wrapper warning message at the end

### DIFF
--- a/autosubmit/job/job_packager.py
+++ b/autosubmit/job/job_packager.py
@@ -612,6 +612,7 @@ class JobPackager(object):
                 built_packages_tmp = self._build_vertical_packages(jobs, wrapper_limits, wrapper_info=current_info)
             if len(built_packages_tmp) > 0:
                 Log.result(f"Built {len(built_packages_tmp)} wrappers for {wrapper_name}")
+            self._propagate_inner_jobs_ready_date(built_packages_tmp)
             packages_to_submit, max_jobs_to_submit = self.check_packages_respect_wrapper_policy(built_packages_tmp, packages_to_submit, max_jobs_to_submit, wrapper_limits, any_simple_packages)
 
         # Now, prepare the packages for non-wrapper jobs
@@ -640,6 +641,18 @@ class JobPackager(object):
             package.hold = self.hold
 
         return packages_to_submit
+
+    @staticmethod
+    def _propagate_inner_jobs_ready_date(built_packages_tmp):
+        """
+        Propagate the ready date of the inner jobs to the wrapper job.
+
+        :param built_packages_tmp: List of built packages.
+        """
+        for package in built_packages_tmp:
+            if len(package.jobs) > 1:
+                for job in package.jobs[1:]:
+                    job.ready_date = package.jobs[0].ready_date
 
     def _divide_list_by_section(self, jobs_list):
         """

--- a/test/unit/test_job_packager.py
+++ b/test/unit/test_job_packager.py
@@ -1,0 +1,27 @@
+import time
+import pytest
+
+from autosubmit.job.job import Job
+from autosubmit.job.job_common import Status
+from autosubmit.job.job_packages import JobPackageVertical
+from autosubmit.job.job_packager import JobPackager
+
+
+@pytest.fixture
+def setup(autosubmit_config, tmpdir, mocker):
+    job1 = Job("SECTION1", 1, Status.READY, 0)
+    job2 = Job("SECTION1", 1, Status.READY, 0)
+    job3 = Job("SECTION1", 1, Status.READY, 0)
+    wrapper_jobs = [job1, job2, job3]
+    packages = [mocker.MagicMock(spec=JobPackageVertical)]
+    packages[0].jobs = wrapper_jobs
+    yield packages, wrapper_jobs
+
+
+def test_propagate_inner_jobs_ready_date(setup):
+    packages, wrapper_jobs = setup
+    current_time = time.time()
+    wrapper_jobs[0].ready_date = current_time
+    JobPackager._propagate_inner_jobs_ready_date(packages)
+    for job in wrapper_jobs:
+        assert job.ready_date == current_time


### PR DESCRIPTION
The fix consists of propagating the ready_date of the first wrapped job to the rest.

What does this fixes:

master branch:

* Run an experiment with a wrapper. 

A warning message will be issued, complaining that some jobs couldn't recover the logs. At the end of the run.

This branch:

* Run an experiment with a wrapper. 

All logs recovered

test file

```yaml

CONFIG:
  # Current version of autosubmit.
  AUTOSUBMIT_VERSION: "4.1.11"
  # Maximum number of jobs permitted in the waiting status.
  MAXWAITINGJOBS: 20
  # Total number of jobs in the workflow.
  TOTALJOBS: 20
  SAFETYSLEEPTIME: 0
MAIL:
  NOTIFICATIONS: False
  TO:
STORAGE:
  TYPE: pkl
  COPY_REMOTE_LOGS: true

EXPERIMENT:
  DATELIST: 20221101
  MEMBERS: fc0
  CHUNKSIZEUNIT: month
  CHUNKSIZE: 2
  NUMCHUNKS: 3
  CHUNKINI: ''
  CALENDAR: standard
PROJECT:
  # Type of the project.
  PROJECT_TYPE: none
  # Folder to hold the project sources.
  PROJECT_DESTINATION: git_project
GIT:
  PROJECT_ORIGIN: "blabla"
  PROJECT_BRANCH: "blabla"
  PROJECT_COMMIT: ''
  PROJECT_SUBMODULES: ''
  FETCH_SINGLE_BRANCH: true
PLATFORMS:
  MARENOSTRUM5:
    TYPE: slurm
    HOST:  # fill
    PROJECT: bsc32
    USER: # fill
    QUEUE: gp_debug
    SCRATCH_DIR: /gpfs/scratch
    ADD_PROJECT_TO_HOST: false
    MAX_WALLCLOCK: 02:00
    TEMP_DIR: ''
    MAX_PROCESSORS: 99999
    PROCESSORS_PER_NODE: 112
JOBS:
    mn5_slurm_failed:
        SCRIPT: |
            decho "Hello World"
        RUNNING: chunk
        wallclock: 00:01
        PLATFORM: MARENOSTRUM5
        retrials: 6
    mn5_wrapped_success:
        SCRIPT: |
            echo "Hello World "
        RUNNING: chunk
        DEPENDENCIES:
          mn5_wrapped_success-1:
        wallclock: 00:01
        PLATFORM: MARENOSTRUM5
    mn5_wrapped_failed:
        SCRIPT: |
            decho "Hello World with id=Failed + wrappers"
        RUNNING: chunk
        DEPENDENCIES:
          mn5_wrapped_failed-1:
        wallclock: 00:01
        PLATFORM: marenostrum5
        retrials: 6


wrappers:
  mn5_wrapper_success:
    JOBS_IN_WRAPPER: mn5_wrapped_success
    TYPE: vertical
  mn5_wrapper_failed:
      JOBS_IN_WRAPPER: mn5_wrapped_failed
      TYPE: vertical
```