### PR TITLE
(LOGS) Inner jobs retrial for vertical wrapper are not displayed closes #2039

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1263,6 +1263,12 @@ class Job(object):
                 raise AutosubmitCritical("Failed to retrieve logs for job {0}".format(self.name), 6000)
         else:
             self.write_stats(last_retrial)
+            if self.wrapper_type == "vertical":
+                for retrial in range(0, last_retrial + 1):
+                    Log.result(f"{platform.name}(log_recovery) Successfully recovered log for job '{self.name}' and retry '{retrial}'.")
+            else:
+                Log.result(f"{platform.name}(log_recovery) Successfully recovered log for job '{self.name}' and retry '{self.fail_count}'.")
+
 
     def parse_time(self,wallclock):
         regex = re.compile(r'(((?P<hours>\d+):)((?P<minutes>\d+)))(:(?P<seconds>\d+))?')

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -952,8 +952,6 @@ class Platform(object):
                 job._log_recovery_retries = 0  # Reset the log recovery retries.
                 try:
                     job.retrieve_logfiles(self, raise_error=True)
-                    Log.result(
-                        f"{identifier} Successfully recovered log for job '{job.name}' and retry '{job.fail_count}'.")
                 except:
                     jobs_pending_to_process.add(job)
                     job._log_recovery_retries += 1


### PR DESCRIPTION
The fix involves moving the Log.result message to the right place. During the log retrieval process 

What does this fixes:

master branch:

* Run an experiment with a wrapper that fails. 

A result message is displayed similar to:

```
2024-12-17 13:16:34,376 LUMI(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_3_LUMI_SLURM_FAILED' and retry '6'.
```



This branch:

* Run an experiment with a wrapper. 

A result message is displayed similar to:

```
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '0'.
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '1'.
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '2'.
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '3'.
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '4'.
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '5'.
MARENOSTRUM5(log_recovery) Successfully recovered log for job 'a000_20221101_fc0_1_MN5_WRAPPED_FAILED' and retry '6'.
```
test file

```yaml

CONFIG:
  # Current version of autosubmit.
  AUTOSUBMIT_VERSION: "4.1.11"
  # Maximum number of jobs permitted in the waiting status.
  MAXWAITINGJOBS: 20
  # Total number of jobs in the workflow.
  TOTALJOBS: 20
  SAFETYSLEEPTIME: 0
MAIL:
  NOTIFICATIONS: False
  TO:
STORAGE:
  TYPE: pkl
  COPY_REMOTE_LOGS: true

EXPERIMENT:
  DATELIST: 20221101
  MEMBERS: fc0
  CHUNKSIZEUNIT: month
  CHUNKSIZE: 2
  NUMCHUNKS: 3
  CHUNKINI: ''
  CALENDAR: standard
PROJECT:
  # Type of the project.
  PROJECT_TYPE: none
  # Folder to hold the project sources.
  PROJECT_DESTINATION: git_project
GIT:
  PROJECT_ORIGIN: "blabla"
  PROJECT_BRANCH: "blabla"
  PROJECT_COMMIT: ''
  PROJECT_SUBMODULES: ''
  FETCH_SINGLE_BRANCH: true
PLATFORMS:
  MARENOSTRUM5:
    TYPE: slurm
    HOST:  # fill
    PROJECT: bsc32
    USER: # fill
    QUEUE: gp_debug
    SCRATCH_DIR: /gpfs/scratch
    ADD_PROJECT_TO_HOST: false
    MAX_WALLCLOCK: 02:00
    TEMP_DIR: ''
    MAX_PROCESSORS: 99999
    PROCESSORS_PER_NODE: 112
JOBS:
    mn5_wrapped_failed:
        SCRIPT: |
            decho "Hello World with id=Failed + wrappers"
        RUNNING: chunk
        DEPENDENCIES:
          mn5_wrapped_failed-1:
        wallclock: 00:01
        PLATFORM: marenostrum5
        retrials: 6


wrappers:
  mn5_wrapper_failed:
      JOBS_IN_WRAPPER: mn5_wrapped_failed
      TYPE: vertical
```

related to #2035 