### PR TITLE
Custom directives added letter by letter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,3 @@
-4.1.12 - TODO
-
 4.1.11 - Enhancements, New Features, Documentation, and Bug Fixes
 =================================================================
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+4.1.12 - TODO
+
 4.1.11 - Enhancements, New Features, Documentation, and Bug Fixes
 =================================================================
 
@@ -155,4 +157,3 @@ Autosubmit supports much larger workflows in this version and has improved perfo
 - Added the previous keyword.
 - Fixed an issue with the historical db.
 - Fixed an issue with historical db logs.
-

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1436,7 +1436,9 @@ class Job(object):
             parameters[f"CURRENT_{key.upper()}"] = value
         for key, value in as_conf.jobs_data[self.section].items():
             parameters[f"CURRENT_{key.upper()}"] = value
+
         return parameters
+
     def update_platform_parameters(self,as_conf,parameters,job_platform):
         if not job_platform:
             submitter = job_utils._get_submitter(as_conf)
@@ -1458,7 +1460,7 @@ class Job(object):
         parameters['CURRENT_LOGDIR'] = job_platform.get_files_path()
         return parameters
 
-    def process_scheduler_parameters(self,as_conf,parameters,job_platform,chunk):
+    def process_scheduler_parameters(self, job_platform, chunk):
         """
         Parsers yaml data stored in the dictionary
         and calculates the components of the heterogeneous job if any
@@ -1687,40 +1689,35 @@ class Job(object):
         self.wallclock = increase_wallclock_by_chunk(
             self.wallclock, self.wchunkinc, chunk)
 
-    def update_platform_associated_parameters(self,as_conf, parameters, job_platform, chunk):
-        job_data = as_conf.jobs_data[self.section]
-        platform_data = as_conf.platforms_data.get(job_platform.name,{})
-        self.x11_options = str(as_conf.jobs_data[self.section].get("X11_OPTIONS", as_conf.platforms_data.get(job_platform.name,{}).get("X11_OPTIONS","")))
-
-        self.ec_queue = str(job_data.get("EC_QUEUE", platform_data.get("EC_QUEUE","")))
-        self.executable = job_data.get("EXECUTABLE", platform_data.get("EXECUTABLE",""))
-        self.total_jobs = job_data.get("TOTALJOBS",job_data.get("TOTAL_JOBS", job_platform.total_jobs))
-        self.max_waiting_jobs = job_data.get("MAXWAITINGJOBS",job_data.get("MAX_WAITING_JOBS", job_platform.max_waiting_jobs))
-        self.processors = job_data.get("PROCESSORS",platform_data.get("PROCESSORS","1"))
-        self.shape = job_data.get("SHAPE",platform_data.get("SHAPE",""))
-        self.processors_per_node = job_data.get("PROCESSORS_PER_NODE",as_conf.platforms_data.get(job_platform.name,{}).get("PROCESSORS_PER_NODE","1"))
-        self.nodes = job_data.get("NODES",platform_data.get("NODES",""))
-        self.exclusive = job_data.get("EXCLUSIVE",platform_data.get("EXCLUSIVE",False))
-        self.threads = job_data.get("THREADS",platform_data.get("THREADS","1"))
-        self.tasks = job_data.get("TASKS",platform_data.get("TASKS","0"))
-        self.reservation = job_data.get("RESERVATION",as_conf.platforms_data.get(job_platform.name, {}).get("RESERVATION", ""))
-        self.hyperthreading = job_data.get("HYPERTHREADING",platform_data.get("HYPERTHREADING","none"))
-        self.queue = job_data.get("QUEUE",platform_data.get("QUEUE",""))
-        self.partition = job_data.get("PARTITION",platform_data.get("PARTITION",""))
-        self.scratch_free_space = int(job_data.get("SCRATCH_FREE_SPACE",platform_data.get("SCRATCH_FREE_SPACE",0)))
-
-        self.memory = job_data.get("MEMORY",platform_data.get("MEMORY",""))
-        self.memory_per_task = job_data.get("MEMORY_PER_TASK",platform_data.get("MEMORY_PER_TASK",""))
-        self.wallclock = job_data.get("WALLCLOCK",
-                                                             as_conf.platforms_data.get(self.platform_name, {}).get(
-                                                                 "MAX_WALLCLOCK", None))
-        self.custom_directives = job_data.get("CUSTOM_DIRECTIVES", "")
-
-        self.process_scheduler_parameters(as_conf,parameters,job_platform,chunk)
-        if self.het.get('HETSIZE',1) > 1:
+    def update_platform_associated_parameters(self, as_conf, parameters, job_platform, chunk):
+        self.x11_options = str(parameters.get("CURRENT_X11_OPTIONS", ""))
+        self.ec_queue = str(parameters.get("CURRENT_EC_QUEUE", ""))
+        self.executable = parameters.get("CURRENT_EXECUTABLE", "")
+        self.total_jobs = parameters.get("CURRENT_TOTALJOBS",
+                                         parameters.get("CURRENT_TOTAL_JOBS", job_platform.total_jobs))
+        self.max_waiting_jobs = parameters.get("CURRENT_MAXWAITINGJOBS", parameters.get("CURRENT_MAX_WAITING_JOBS",
+                                                                                        job_platform.max_waiting_jobs))
+        self.processors = parameters.get("CURRENT_PROCESSORS", "1")
+        self.shape = parameters.get("CURRENT_SHAPE", "")
+        self.processors_per_node = parameters.get("CURRENT_PROCESSORS_PER_NODE", "1")
+        self.nodes = parameters.get("CURRENT_NODES", "")
+        self.exclusive = parameters.get("CURRENT_EXCLUSIVE", False)
+        self.threads = parameters.get("CURRENT_THREADS", "1")
+        self.tasks = parameters.get("CURRENT_TASKS", "0")
+        self.reservation = parameters.get("CURRENT_RESERVATION", "")
+        self.hyperthreading = parameters.get("CURRENT_HYPERTHREADING", "none")
+        self.queue = parameters.get("CURRENT_QUEUE", "")
+        self.partition = parameters.get("CURRENT_PARTITION", "")
+        self.scratch_free_space = int(parameters.get("CURRENT_SCRATCH_FREE_SPACE", 0))
+        self.memory = parameters.get("CURRENT_MEMORY", "")
+        self.memory_per_task = parameters.get("CURRENT_MEMORY_PER_TASK", parameters.get("CURRENT_MEMORY_PER_TASK", ""))
+        self.wallclock = parameters.get("CURRENT_WALLCLOCK", parameters.get("CURRENT_MAX_WALLCLOCK", None))
+        self.custom_directives = parameters.get("CURRENT_CUSTOM_DIRECTIVES", "")
+        self.process_scheduler_parameters(job_platform, chunk)
+        if self.het.get('HETSIZE', 1) > 1:
             for name, components_value in self.het.items():
                 if name != "HETSIZE":
-                    for indx,component in enumerate(components_value):
+                    for indx, component in enumerate(components_value):
                         if indx == 0:
                             parameters[name.upper()] = component
                         parameters[f'{name.upper()}_{indx}'] = component
@@ -1752,7 +1749,8 @@ class Job(object):
             parameters['EXTENDED_HEADER'] = self.read_header_tailer_script(self.ext_header_path, as_conf, True)
             parameters['EXTENDED_TAILER'] = self.read_header_tailer_script(self.ext_tailer_path, as_conf, False)
         elif self.ext_header_path or self.ext_tailer_path:
-            Log.warning("An extended header or tailer is defined in {0}, but it is ignored in dummy projects.", self._section)
+            Log.warning("An extended header or tailer is defined in {0}, but it is ignored in dummy projects.",
+                        self._section)
         else:
             parameters['EXTENDED_HEADER'] = ""
             parameters['EXTENDED_TAILER'] = ""
@@ -1760,7 +1758,6 @@ class Job(object):
         parameters['RESERVATION'] = self.reservation
         parameters['CURRENT_EC_QUEUE'] = self.ec_queue
         parameters['PARTITION'] = self.partition
-
 
         return parameters
 
@@ -1963,16 +1960,16 @@ class Job(object):
                 parameters['CHUNK_LAST'] = 'FALSE'
         return parameters
 
-    def update_job_parameters(self,as_conf, parameters):
+    def update_job_parameters(self, as_conf, parameters):
         if self.splits == "auto":
-            self.splits = as_conf.jobs_data[self.section].get("SPLITS", None)
-        self.delete_when_edgeless = as_conf.jobs_data[self.section].get("DELETE_WHEN_EDGELESS", True)
-        self.check = as_conf.jobs_data[self.section].get("CHECK", False)
-        self.check_warnings = as_conf.jobs_data[self.section].get("CHECK_WARNINGS", False)
-        self.shape = as_conf.jobs_data[self.section].get("SHAPE", "")
-        self.script = as_conf.jobs_data[self.section].get("SCRIPT", "")
-        self.x11 = False if str(as_conf.jobs_data[self.section].get("X11", False)).lower() == "false" else True
-        self.notify_on = as_conf.jobs_data[self.section].get("NOTIFY_ON", [])
+            self.splits = parameters.get("CURRENT_SPLITS", None)
+        self.delete_when_edgeless = parameters.get("CURRENT_DELETE_WHEN_EDGELESS", True)
+        self.check = parameters.get("CURRENT_CHECK", False)
+        self.check_warnings = parameters.get("CURRENT_CHECK_WARNINGS", False)
+        self.shape = parameters.get("CURRENT_SHAPE", "")
+        self.script = parameters.get("CURRENT_SCRIPT", "")
+        self.x11 = False if str(parameters.get("CURRENT_X11", False)).lower() == "false" else True
+        self.notify_on = parameters.get("CURRENT_NOTIFY_ON", [])
         self.update_stat_file()
         if self.checkpoint: # To activate placeholder sustitution per <empty> in the template
             parameters["AS_CHECKPOINT"] = self.checkpoint
@@ -1994,7 +1991,7 @@ class Job(object):
         parameters = self.calendar_chunk(parameters)
         parameters = self.calendar_split(as_conf,parameters)
         parameters['NUMMEMBERS'] = len(as_conf.get_member_list())
-        self.dependencies = as_conf.jobs_data[self.section].get("DEPENDENCIES", "")
+        self.dependencies = parameters.get("CURRENT_DEPENDENCIES", "")
         self.dependencies  = str(self.dependencies)
         parameters['JOB_DEPENDENCIES'] = self.dependencies
         parameters['EXPORT'] = self.export
@@ -2065,13 +2062,13 @@ class Job(object):
         parameters['PROJDIR'] = as_conf.get_project_dir()
         # Set parameters dictionary
         # Set final value
-        parameters = self.update_current_parameters(as_conf, parameters)
-        parameters = self.update_job_parameters(as_conf, parameters)
         parameters = self.update_platform_parameters(as_conf, parameters, self._platform)
-        parameters = self.update_platform_associated_parameters(as_conf, parameters, self._platform, parameters['CHUNK'])
-        parameters = self.update_wrapper_parameters(as_conf, parameters)
+        parameters = self.update_current_parameters(as_conf, parameters)
         parameters = as_conf.deep_read_loops(parameters)
         parameters = as_conf.substitute_dynamic_variables(parameters,80)
+        parameters = self.update_job_parameters(as_conf, parameters)
+        parameters = self.update_platform_associated_parameters(as_conf, parameters, self._platform, parameters['CHUNK'])
+        parameters = self.update_wrapper_parameters(as_conf, parameters)
         self.update_job_variables_final_values(parameters)
         # For some reason, there is return but the assignee is also necessary
         self.parameters = parameters

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1434,6 +1434,7 @@ class Job(object):
         """
         for key, value in as_conf.platforms_data.get(self.platform_name, {}).items():
             parameters[f"CURRENT_{key.upper()}"] = value
+
         for key, value in as_conf.jobs_data[self.section].items():
             parameters[f"CURRENT_{key.upper()}"] = value
 

--- a/test/unit/test_job_pytest.py
+++ b/test/unit/test_job_pytest.py
@@ -1,3 +1,6 @@
+import os
+import pwd
+import re
 from datetime import datetime, timedelta
 import pytest
 
@@ -5,8 +8,10 @@ from autosubmit.job.job import Job
 from autosubmit.platforms.psplatform import PsPlatform
 from pathlib import Path
 
+from autosubmit.platforms.slurmplatform import SlurmPlatform
 
-def create_job_and_update_parameters(autosubmit_config, experiment_data):
+
+def create_job_and_update_parameters(autosubmit_config, experiment_data, platform_type="ps"):
     as_conf = autosubmit_config("test-expid", experiment_data)
     as_conf.experiment_data = as_conf.deep_normalize(as_conf.experiment_data)
     as_conf.experiment_data = as_conf.normalize_variables(as_conf.experiment_data, must_exists=True)
@@ -15,11 +20,14 @@ def create_job_and_update_parameters(autosubmit_config, experiment_data):
     as_conf.experiment_data = as_conf.parse_data_loops(as_conf.experiment_data)
     # Create some jobs
     job = Job('A', '1', 0, 1)
-    platform = PsPlatform(expid='a000', name='DUMMY_PLATFORM', config=as_conf.experiment_data)
+    if platform_type == "ps":
+        platform = PsPlatform(expid='test-expid', name='DUMMY_PLATFORM', config=as_conf.experiment_data)
+    else:
+        platform = SlurmPlatform(expid='test-expid', name='DUMMY_PLATFORM', config=as_conf.experiment_data)
     job.section = 'RANDOM-SECTION'
     job.platform = platform
-    job.update_parameters(as_conf, {})
-    return job
+    job.update_parameters(as_conf, as_conf.load_parameters())
+    return job, as_conf
 
 
 @pytest.mark.parametrize('experiment_data, expected_data', [(
@@ -164,3 +172,72 @@ def test_adjust_new_parameters(test_packed):
         assert job.wrapper_name == "wrapped"
     else:
         assert job.wrapper_name == "dummy"
+
+
+@pytest.mark.parametrize('custom_directives, test_type, result_by_lines', [
+    ("test_str a", "platform", ["test_str a"]),
+    (['test_list', 'test_list2'], "platform", ['test_list', 'test_list2']),
+    (['test_list', 'test_list2'], "job", ['test_list', 'test_list2']),
+    ("test_str", "job", ["test_str"]),
+    (['test_list', 'test_list2'], "both", ['test_list', 'test_list2']),
+    ("test_str", "both", ["test_str"]),
+    (['test_list', 'test_list2'], "current_directive", ['test_list', 'test_list2']),
+    (['test_str_list', 'test_str_list2'], "job", ['test_str_list', 'test_str_list2']),
+], ids=["Test str - platform", "test_list - platform", "test_list - job", "test_str - job", "test_list - both", "test_str - both", "test_list - job - current_directive", "test_str_list - current_directive"])
+def test_custom_directives(tmpdir, custom_directives, test_type, result_by_lines, mocker, autosubmit_config):
+    file_stat = os.stat(f"{tmpdir.strpath}")
+    file_owner_id = file_stat.st_uid
+    tmpdir.owner = pwd.getpwuid(file_owner_id).pw_name
+    tmpdir_path = Path(tmpdir.strpath)
+    project = "whatever"
+    user = tmpdir.owner
+    scratch_dir = f"{tmpdir.strpath}/scratch"
+    full_path = f"{scratch_dir}/{project}/{user}"
+    experiment_data = {
+        'JOBS': {
+            'RANDOM-SECTION': {
+                'SCRIPT': "echo 'Hello World!'",
+                'PLATFORM': 'DUMMY_PLATFORM',
+            },
+        },
+        'PLATFORMS': {
+            'dummy_platform': {
+                "type": "slurm",
+                "host": "127.0.0.1",
+                "user": f"{user}",
+                "project": f"{project}",
+                "scratch_dir": f"{scratch_dir}",
+                "QUEUE": "gp_debug",
+                "ADD_PROJECT_TO_HOST": False,
+                "MAX_WALLCLOCK": "48:00",
+                "TEMP_DIR": "",
+                "MAX_PROCESSORS": 99999,
+                "PROCESSORS_PER_NODE": 123,
+                "DISABLE_RECOVERY_THREADS": True
+            },
+        },
+        'ROOTDIR': f"{full_path}",
+        'LOCAL_TMP_DIR': f"{full_path}",
+        'LOCAL_ROOT_DIR': f"{full_path}",
+        'LOCAL_ASLOG_DIR': f"{full_path}",
+    }
+    tmpdir_path.joinpath(f"{scratch_dir}/{project}/{user}").mkdir(parents=True)
+    tmpdir_path.joinpath("test-expid").mkdir(parents=True)
+    tmpdir_path.joinpath("test-expid/tmp/LOG_test-expid").mkdir(parents=True)
+
+    if test_type == "platform":
+        experiment_data['PLATFORMS']['dummy_platform']['CUSTOM_DIRECTIVES'] = custom_directives
+    elif test_type == "job":
+        experiment_data['JOBS']['RANDOM-SECTION']['CUSTOM_DIRECTIVES'] = custom_directives
+    elif test_type == "both":
+        experiment_data['PLATFORMS']['dummy_platform']['CUSTOM_DIRECTIVES'] = custom_directives
+        experiment_data['JOBS']['RANDOM-SECTION']['CUSTOM_DIRECTIVES'] = custom_directives
+    elif test_type == "current_directive":
+        experiment_data['PLATFORMS']['dummy_platform']['APP_CUSTOM_DIRECTIVES'] = custom_directives
+        experiment_data['JOBS']['RANDOM-SECTION']['CUSTOM_DIRECTIVES'] = "%CURRENT_APP_CUSTOM_DIRECTIVES%"
+    job, as_conf = create_job_and_update_parameters(autosubmit_config, experiment_data, "slurm")
+    mocker.patch('autosubmitconfigparser.config.configcommon.AutosubmitConfig.reload')
+    template_content, _ = job.update_content(as_conf)
+    for directive in result_by_lines:
+        pattern = r'^\s*' + re.escape(directive) + r'\s*$' # Match Start line, match directive, match end line
+        assert re.search(pattern, template_content, re.MULTILINE) is not None

--- a/test/unit/test_job_pytest.py
+++ b/test/unit/test_job_pytest.py
@@ -62,7 +62,7 @@ def create_job_and_update_parameters(autosubmit_config, experiment_data, platfor
     }
 )])
 def test_update_parameters_current_variables(autosubmit_config, experiment_data, expected_data):
-    job = create_job_and_update_parameters(autosubmit_config, experiment_data)
+    job,_ = create_job_and_update_parameters(autosubmit_config, experiment_data)
     for key, value in expected_data.items():
         assert job.parameters[key] == value
 
@@ -152,7 +152,7 @@ def test_recover_last_log_name(tmpdir, test_with_logfiles, file_timestamp_greate
     {'notify_on': ['COMPLETED']}
 )])
 def test_update_parameters_attributes(autosubmit_config, experiment_data, attributes_to_check):
-    job = create_job_and_update_parameters(autosubmit_config, experiment_data)
+    job, _ = create_job_and_update_parameters(autosubmit_config, experiment_data)
     for attr in attributes_to_check:
         assert hasattr(job, attr)
         assert getattr(job, attr) == attributes_to_check[attr]

--- a/test/unit/test_job_pytest.py
+++ b/test/unit/test_job_pytest.py
@@ -182,7 +182,7 @@ def test_adjust_new_parameters(test_packed):
     (['test_list', 'test_list2'], "both", ['test_list', 'test_list2']),
     ("test_str", "both", ["test_str"]),
     (['test_list', 'test_list2'], "current_directive", ['test_list', 'test_list2']),
-    (['test_str_list', 'test_str_list2'], "job", ['test_str_list', 'test_str_list2']),
+    ("['test_str_list', 'test_str_list2']", "job", ['test_str_list', 'test_str_list2']),
 ], ids=["Test str - platform", "test_list - platform", "test_list - job", "test_str - job", "test_list - both", "test_str - both", "test_list - job - current_directive", "test_str_list - current_directive"])
 def test_custom_directives(tmpdir, custom_directives, test_type, result_by_lines, mocker, autosubmit_config):
     file_stat = os.stat(f"{tmpdir.strpath}")


### PR DESCRIPTION
Note: this requires https://github.com/BSC-ES/autosubmit-config-parser/pull/59 changes. 

The issue:

I noticed that although the custom_directive is assigned to the variable, it is not assigned in the correct order. 

Some normalization or/and preparation stuff happens while the "custom_directive" is still assigned to a placeholder. Ex. CUSTOM_DIRECTIVE: "%current_something%

So it does nothing. 

Configuration:
https://github.com/BSC-ES/autosubmit-config-parser/pull/59#issuecomment-2575118765

Bug:

https://github.com/BSC-ES/autosubmit-config-parser/pull/59#issuecomment-2575298435

Solution: 

The solution consists in:

Instead of getting the value from job_data, it is now getting from the parameters dict based on CURRENT_ values. With this, we ensure to have the most updated variable, with all the %placeholders% substituted
Move the order of calculating stuff. 
Now, it updates the platform stuff and adds the CURRENT parameters associated only with it.
Then, it adds all the %CURRENT_% parameters that are set in the YAML platforms and jobs file.
Then, it substitutes all the placeholders in the parameters dict for the appropriated value.
Finally, according to the first point, it gets the updated value from the parameters dict instead of the raw job_data file.

I think it is ready to review (while doing the changes, some tests were complaining, so I think it is covered, but I will see the coverage tomorrow). I'll add one to check the $SBATCH of the directives similar to the one we have for the reservation
