### PR TITLE
GH-2065: Correct join character for jobs in wrapper (was &, is now _)

### DIFF
--- a/autosubmit/job/job_packages.py
+++ b/autosubmit/job/job_packages.py
@@ -54,7 +54,7 @@ def jobs_in_wrapper_str(as_conf, current_wrapper):
     else:
         jobs_in_wrapper = jobs_in_wrapper.split(" ")
     jobs_in_wrapper = [job.strip(" ,") for job in jobs_in_wrapper]
-    return "&".join(jobs_in_wrapper)
+    return "_".join(jobs_in_wrapper)
 class JobPackageBase(object):
     """
     Class to manage the package of jobs to be submitted by autosubmit

--- a/test/unit/test_job_package.py
+++ b/test/unit/test_job_package.py
@@ -215,4 +215,4 @@ def test_jobs_in_wrapper_str(mock_as_conf):
     # Arrange
     current_wrapper = "current_wrapper"
     result = jobs_in_wrapper_str(mock_as_conf, current_wrapper)
-    assert result == "job1&job2&job3"
+    assert result == "job1_job2_job3"


### PR DESCRIPTION
Closes #2065 

It's pending that I write a test that fails if we ever change it, accidentally, again to `&`.