### PR TITLE
Adjust log_path  for existing job_list

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -274,6 +274,9 @@ class Job(object):
                 self.is_wrapper = True
                 self.wrapper_name = "wrapped"
 
+        if not hasattr(self, "_log_path"):  # Added in 4.1.12
+            self._log_path = Path(f"{self._tmp_path}/LOG_{self.expid}")
+
     def _init_runtime_parameters(self):
         # hetjobs
         self.het = {'HETSIZE': 0}

--- a/test/unit/test_job_pytest.py
+++ b/test/unit/test_job_pytest.py
@@ -157,14 +157,17 @@ def test_update_parameters_attributes(autosubmit_config, experiment_data, attrib
         assert hasattr(job, attr)
         assert getattr(job, attr) == attributes_to_check[attr]
 
+
 @pytest.mark.parametrize('test_packed', [
     False,
     True,
 ], ids=["Simple job", "Wrapped job"])
 def test_adjust_new_parameters(test_packed):
     job = Job('dummy', '1', 0, 1)
+    stored_log_path = job._log_path
     del job.is_wrapper
     del job.wrapper_name
+    del job._log_path
     job.packed = test_packed
     job._adjust_new_parameters()
     assert job.is_wrapper == test_packed
@@ -172,6 +175,7 @@ def test_adjust_new_parameters(test_packed):
         assert job.wrapper_name == "wrapped"
     else:
         assert job.wrapper_name == "dummy"
+    assert job._log_path == stored_log_path
 
 
 @pytest.mark.parametrize('custom_directives, test_type, result_by_lines', [


### PR DESCRIPTION
This branches fixes a bug related with recovery + log_path when it continues the run with a job_list of a previous version. 

Ready to review