### PR TITLE
Add PyPI publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Build distribution
         run: python -m build
 
-      - name: Test Publish
-        uses: pypa/gh-action-pypi-publish@v1.12.3
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          attestations: false
+      # - name: Test Publish
+      #   uses: pypa/gh-action-pypi-publish@v1.12.3
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/
+      #     attestations: false
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.12.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - created # Trigger on release creation
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install build dependencies
+        run: |
+          pip install --upgrade pip
+          pip install build
+          pip install -e .[all]
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Test Publish
+        uses: pypa/gh-action-pypi-publish@v1.12.3
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: false
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.12.3


### PR DESCRIPTION
Closes #2498 

PR to include the automated publication of packages on PyPI

This new GitHub Action will:

1. Triggered only when a release is created (from a tag)
2. Build the package
3. Upload to TestPyPI first as a sanity check
4. Upload to PyPI

This has been tested in the https://github.com/BSC-ES/autosubmit-api repo but it [failed on the PyPI upload](https://github.com/BSC-ES/autosubmit-api/actions/runs/12985914728/attempts/1#summary-36211685137) because of the attestation created on the TestPyPI publish. Theoretically, this should be solved by adding:

```yaml
        with:
          attestations: false
```

Since there is no way to test it properly, this PR could wait until the next API release to be merged but feel free to merge and test it.