### PR TITLE
Better traceback

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -26,7 +26,7 @@ from configparser import ConfigParser
 from distutils.util import strtobool
 from pathlib import Path
 from ruamel.yaml import YAML
-from typing import Dict, Set, Tuple, Union, Any
+from typing import Dict, Set, Tuple, Union, Any, List, Optional
 
 from autosubmit.database.db_common import update_experiment_descrip_version
 from autosubmit.helpers.parameters import PARAMETERS
@@ -81,7 +81,6 @@ from portalocker.exceptions import BaseLockException
 from pyparsing import nestedExpr
 from .history.experiment_status import ExperimentStatus
 from .history.experiment_history import ExperimentHistory
-from typing import List
 import autosubmit.history.utils as HUtils
 import autosubmit.helpers.autosubmit_helper as AutosubmitHelper
 import autosubmit.statistics.utils as StatisticsUtils
@@ -177,9 +176,14 @@ class Autosubmit:
         os.environ['PYTHONUNBUFFERED'] = 'true'
 
     @staticmethod
-    def parse_args():
+    def parse_args() -> Tuple[int, Optional[argparse.Namespace]]:
         """
-        Parse arguments given to an executable and start execution of command given
+        Parse arguments given to an executable and start execution of command given.
+
+        Returns a tuple with the exit code (``status``), and an optional list of
+        arguments for ``argparse``. The list of arguments is only ever returned
+        when the arguments are valid for the execution of a subcommand. Otherwise,
+        they will be ``None``.
         """
         Autosubmit.environ_init()
         try:
@@ -692,16 +696,16 @@ class Autosubmit:
             args, unknown = parser.parse_known_args()
             if args.version:
                 Log.info(Autosubmit.autosubmit_version)
-                return 0
-            if unknown or args.command is None:
+                return 0, None
+            elif unknown or args.command is None:
                 parser.print_help()
-                return 1
-        except SystemExit as e:
-            return 1
+                return 1, None
+
+            return 0, args
+        except SystemExit:
+            return 1, None
         except BaseException as e:
-            raise AutosubmitCritical(
-                "Incorrect arguments for this command", 7011)
-        return args
+            raise AutosubmitCritical(f"Incorrect arguments for this command: {str(e)}", 7011)
 
     @staticmethod
     def run_command(args):

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -175,6 +175,7 @@ class Autosubmit:
         # Python output buffering delays appearance of stdout and stderr
         # when output is not directed to a terminal
         os.environ['PYTHONUNBUFFERED'] = 'true'
+
     @staticmethod
     def parse_args():
         """
@@ -700,7 +701,10 @@ class Autosubmit:
         except BaseException as e:
             raise AutosubmitCritical(
                 "Incorrect arguments for this command", 7011)
+        return args
 
+    @staticmethod
+    def run_command(args):
         expid = "None"
         if hasattr(args, 'expid'):
             expid = args.expid

--- a/bin/autosubmit
+++ b/bin/autosubmit
@@ -23,6 +23,8 @@ import os
 import sys
 from typing import Optional
 
+from exceptiongroup import suppress
+
 script_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
 sys.path.append(script_dir)
 sys.path.append(os.path.normpath(os.path.join(script_dir, os.pardir)))
@@ -43,18 +45,20 @@ def main():
         delete_lock_file()
     except BaseException as e:
         delete_lock_file()
+        command = "<no command provided>"
+        expid = "<no expid provided>"
+        version = "<no version found>"
         if args:
-            Log.debug(f"Error in arguments: {args}")
-            if args.command:
-                Log.error(f"Error in command: {args.command}")
-            if args.expid:
-                Log.error(f"Error in experiment: {args.expid}")
-                try:
+            if 'command' in args and args.command:
+                command = f"<{args.command}>"
+            if 'expid' in args and args.expid:
+                expid = f"<{args.expid}>"
+                with suppress(BaseException):
                     as_conf = AutosubmitConfig(args.expid)
                     as_conf.reload()
-                    Log.error(f"Experiment version: {as_conf.experiment_data.get('CONFIG', {}).get('AUTOSUBMIT_VERSION', 'unknown')}")
-                except BaseException as e2:
-                    Log.debug(f"Invalid Autosubmit configuration: {e2}")
+                    version = f"{as_conf.experiment_data.get('CONFIG', {}).get('AUTOSUBMIT_VERSION', 'unknown')}"
+        Log.error(f"Arguments provided: {str(args)}")
+        Log.error(f"This is the experiment: {expid} which had an issue with the command: {command} and it is currently using the Autosubmit Version: {version}.")
         return_value = exit_from_error(e)
     return return_value
 

--- a/bin/autosubmit
+++ b/bin/autosubmit
@@ -23,8 +23,7 @@ import os
 import sys
 from typing import Optional
 
-from exceptiongroup import suppress
-
+from contextlib import suppress
 script_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
 sys.path.append(script_dir)
 sys.path.append(os.path.normpath(os.path.join(script_dir, os.pardir)))

--- a/bin/autosubmit
+++ b/bin/autosubmit
@@ -18,8 +18,10 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 """Script for handling experiment monitoring"""
+import argparse
 import os
 import sys
+from typing import Optional
 
 script_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
 sys.path.append(script_dir)
@@ -33,14 +35,11 @@ from autosubmitconfigparser.config.configcommon import AutosubmitConfig  # noqa:
 
 # noinspection PyProtectedMember
 def main():
-    args = None
+    args = Optional[argparse.Namespace]
     try:
-        args = Autosubmit.parse_args()
-        if type(args) is not int:
+        return_value, args = Autosubmit.parse_args()
+        if args:
             return_value = Autosubmit.run_command(args)
-        else:
-            return_value = args
-        return_value = return_value if type(return_value) is int else 0
         delete_lock_file()
     except BaseException as e:
         delete_lock_file()

--- a/bin/autosubmit
+++ b/bin/autosubmit
@@ -25,22 +25,41 @@ script_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
 sys.path.append(script_dir)
 sys.path.append(os.path.normpath(os.path.join(script_dir, os.pardir)))
 # noinspection PyUnresolvedReferences
-from log.log import Log, AutosubmitCritical, AutosubmitError
-from autosubmit import delete_lock_file, exit_from_error
-from autosubmit.autosubmit import Autosubmit
+from log.log import Log, AutosubmitCritical, AutosubmitError  # noqa: E402
+from autosubmit import delete_lock_file, exit_from_error  # noqa: E402
+from autosubmit.autosubmit import Autosubmit  # noqa: E402
+from autosubmitconfigparser.config.configcommon import AutosubmitConfig  # noqa: E402
 
 
 # noinspection PyProtectedMember
 def main():
+    args = None
     try:
-        return_value = Autosubmit.parse_args()
-        delete_lock_file()
+        args = Autosubmit.parse_args()
+        if type(args) is not int:
+            return_value = Autosubmit.run_command(args)
+        else:
+            return_value = args
         return_value = return_value if type(return_value) is int else 0
+        delete_lock_file()
     except BaseException as e:
+        delete_lock_file()
+        if args:
+            Log.debug(f"Error in arguments: {args}")
+            if args.command:
+                Log.error(f"Error in command: {args.command}")
+            if args.expid:
+                Log.error(f"Error in experiment: {args.expid}")
+                try:
+                    as_conf = AutosubmitConfig(args.expid)
+                    as_conf.reload()
+                    Log.error(f"Experiment version: {as_conf.experiment_data.get('CONFIG', {}).get('VERSION', 'unknown')}")
+                except BaseException as e2:
+                    Log.debug(f"Invalid Autosubmit configuration: {e2}")
         return_value = exit_from_error(e)
     return return_value
 
 
 if __name__ == "__main__":
     exit_code = main()
-    sys.exit(exit_code) # Sys.exit ensures a proper cleanup of the program, while os._exit() does not.
+    sys.exit(exit_code)  # Sys.exit ensures a proper cleanup of the program, while os._exit() does not.

--- a/bin/autosubmit
+++ b/bin/autosubmit
@@ -53,7 +53,7 @@ def main():
                 try:
                     as_conf = AutosubmitConfig(args.expid)
                     as_conf.reload()
-                    Log.error(f"Experiment version: {as_conf.experiment_data.get('CONFIG', {}).get('VERSION', 'unknown')}")
+                    Log.error(f"Experiment version: {as_conf.experiment_data.get('CONFIG', {}).get('AUTOSUBMIT_VERSION', 'unknown')}")
                 except BaseException as e2:
                     Log.debug(f"Invalid Autosubmit configuration: {e2}")
         return_value = exit_from_error(e)

--- a/test/unit/test_commands.py
+++ b/test/unit/test_commands.py
@@ -1,0 +1,49 @@
+# File: test/unit/test_commands.py
+import pytest
+from typing import Optional
+
+from autosubmit.autosubmit import Autosubmit
+from log.log import AutosubmitCritical
+
+
+@pytest.mark.parametrize(
+    'command,args',
+    [
+        ('create', ['--fail-this-command-please-sir']),
+        ('versioning', []),
+        ('', [])
+    ],
+    ids=[
+        'Invalid args for create',
+        'Invalid subcommand',
+        'No command provided'
+    ]
+)
+def test_invalid_commands(command, args, mocker):
+    """Test invalid usages of the ``autosubmit`` command and subcommands."""
+    mocker.patch('sys.argv', [command] + args)
+    status, args = Autosubmit.parse_args()
+
+    assert not args and status != 0
+
+
+@pytest.mark.parametrize(
+    'exception,raised,status',
+    [
+        (SystemExit, None, 1),
+        (BaseException, AutosubmitCritical, None),
+        (ValueError, AutosubmitCritical, None)
+    ]
+)
+def test_exceptions_raised(exception: BaseException, raised: BaseException, status: Optional[int], mocker):
+    """Test exceptions being raised (for whatever reason) when running commands."""
+    mocker.patch('autosubmit.autosubmit.MyParser', **{'side_effect': exception})
+
+    if raised:
+        with pytest.raises(raised):
+            Autosubmit.parse_args()
+            print('OK')
+    else:
+        assert status
+        status_returned, _ = Autosubmit.parse_args()
+        assert status_returned == status


### PR DESCRIPTION

Implements #2083

Outcome example: 

```python
/home/dbeltran/.venv39/bin/python /home/dbeltran/GIT_autosubmit/bin/autosubmit -lc DEBUG create a500 -cw -np -f 
Error in arguments: Namespace(version=False, logfile='DEBUG', logconsole='DEBUG', command='create', expid='a500', noplot=True, hide=False, detail=False, output=None, group_by=None, expand=None, expand_status=None, notransitive=False, check_wrapper=True, update_version=False, profile=False, force=True)
[ERROR] Error in command: create
[ERROR] Error in experiment: a500
Invalid Autosubmit configuration: Experiment a500 does not exist
Traceback (most recent call last):
  File "/home/dbeltran/GIT_autosubmit/bin/autosubmit", line 40, in main
    return_value = Autosubmit.run_command(args)
  File "/home/dbeltran/GIT_autosubmit/autosubmit/autosubmit.py", line 712, in run_command
    Autosubmit._init_logs(args, args.logconsole, args.logfile, expid)
  File "/home/dbeltran/GIT_autosubmit/autosubmit/autosubmit.py", line 863, in _init_logs
    as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
  File "/home/dbeltran/asconfig_source/autosubmitconfigparser/config/configcommon.py", line 60, in __init__
    raise IOError(f"Experiment {expid} does not exist")
OSError: Experiment a500 does not exist

 [CRITICAL] Unexpected error: Experiment a500 does not exist.
 Please report it to Autosubmit Developers through Git
More info at https://autosubmit.readthedocs.io/en/master/troubleshooting/error-codes.html

Process finished with exit code 88
```