### PR TITLE
Added ready_date when swapping versions

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -282,6 +282,10 @@ class Job(object):
             self._wallclock_in_seconds = None
             self.wallclock = self.wallclock  # also sets the wallclock in seconds
 
+        if not hasattr(self, "ready_date"):
+            self.ready_date = None
+            self.recover_last_ready_date()
+
     def _init_runtime_parameters(self):
         # hetjobs
         self.het = {'HETSIZE': 0}

--- a/test/unit/test_job_pytest.py
+++ b/test/unit/test_job_pytest.py
@@ -170,8 +170,10 @@ def test_adjust_new_parameters(test_packed):
     del job.wrapper_name
     del job._wallclock_in_seconds
     del job._log_path
+    del job.ready_date
     job.packed = test_packed
     job._adjust_new_parameters()
+    assert job.ready_date is None
     assert job.is_wrapper == test_packed
     assert int(job._wallclock_in_seconds) == int(60*1.3)
     if test_packed:


### PR DESCRIPTION
This adds the missing ready_date attribute when swapping AS version from <4.1.12 to 4.1.12*.

Ready to review: @kinow , @isimo00 ( should be fast )


Fyi: @Lerriola


 