### PR TITLE
gh-2054-logs-dead-revival

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2117,7 +2117,8 @@ class Autosubmit:
             job_list.update_log_status(job, as_conf, new_run)
 
     @staticmethod
-    def refresh_log_recovery_process(platforms, as_conf):
+    def refresh_log_recovery_process(platforms: List[Platform], as_conf: AutosubmitConfig) -> None:
+        """Relaunch the log recovery processes for each platform if necessary."""
         for p in platforms:  # Send keep_alive signal
             if not p.log_recovery_process or not p.log_recovery_process.is_alive():
                 p.clean_log_recovery_process()

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2117,6 +2117,15 @@ class Autosubmit:
             job_list.update_log_status(job, as_conf, new_run)
 
     @staticmethod
+    def refresh_log_retry_process(platforms, as_conf):
+        for p in platforms:  # Send keep_alive signal
+            if not p.log_recovery_process or not p.log_recovery_process.is_alive():
+                p.clean_log_recovery_process()
+                p.spawn_log_retrieval_process(as_conf)
+            p.work_event.set()
+
+
+    @staticmethod
     def run_experiment(expid, notransitive=False, start_time=None, start_after=None, run_only_members=None, profile=False):
         """
         Runs and experiment (submitting all the jobs properly and repeating its execution in case of failure).
@@ -2176,8 +2185,7 @@ class Autosubmit:
                 recovery_retrials = 0
                 Autosubmit.check_logs_status(job_list, as_conf, new_run=True)
                 while job_list.get_active():
-                    for platform in platforms_to_test:  # Send keep_alive signal
-                        platform.work_event.set()
+                    Autosubmit.refresh_log_retry_process(platforms_to_test, as_conf)
                     for job in [job for job in job_list.get_job_list() if job.status == Status.READY]:
                         job.update_parameters(as_conf, {})
                     did_run = True

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2117,13 +2117,12 @@ class Autosubmit:
             job_list.update_log_status(job, as_conf, new_run)
 
     @staticmethod
-    def refresh_log_retry_process(platforms, as_conf):
+    def refresh_log_recovery_process(platforms, as_conf):
         for p in platforms:  # Send keep_alive signal
             if not p.log_recovery_process or not p.log_recovery_process.is_alive():
                 p.clean_log_recovery_process()
                 p.spawn_log_retrieval_process(as_conf)
             p.work_event.set()
-
 
     @staticmethod
     def run_experiment(expid, notransitive=False, start_time=None, start_after=None, run_only_members=None, profile=False):
@@ -2185,7 +2184,7 @@ class Autosubmit:
                 recovery_retrials = 0
                 Autosubmit.check_logs_status(job_list, as_conf, new_run=True)
                 while job_list.get_active():
-                    Autosubmit.refresh_log_retry_process(platforms_to_test, as_conf)
+                    Autosubmit.refresh_log_recovery_process(platforms_to_test, as_conf)
                     for job in [job for job in job_list.get_job_list() if job.status == Status.READY]:
                         job.update_parameters(as_conf, {})
                     did_run = True

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -146,7 +146,8 @@ class Platform(object):
         cls.worker_events.append(event_worker)
 
     @classmethod
-    def remove_workers(cls, event_worker):
+    def remove_workers(cls, event_worker: Event) -> None:
+        """Remove the given even worker from the list of workers in this class."""
         if event_worker in cls.worker_events:
             cls.worker_events.remove(event_worker)
 
@@ -876,7 +877,8 @@ class Platform(object):
         """
         self.cleanup_event.set()  # Indicates to old child ( if reachable ) to finish.
         if self.log_recovery_process:
-            self.log_recovery_process.join(timeout=60)  # Waits for old child ( if reachable ) to finish. Timeout in case of it being blocked.
+            # Waits for old child ( if reachable ) to finish. Timeout in case of it being blocked.
+            self.log_recovery_process.join(timeout=60)
         # Resets everything related to the log recovery process.
         self.recovery_queue = UniqueQueue()
         self.log_retrieval_process_active = False

--- a/test/unit/test_log_recovery.py
+++ b/test/unit/test_log_recovery.py
@@ -165,7 +165,6 @@ def test_log_recovery_recover_log(prepare_test, local, mocker, as_conf):
 def test_refresh_log_retry_process(prepare_test, local, as_conf, mocker):
     mocker.patch('autosubmit.platforms.platform.max', return_value=0)
     local.keep_alive_timeout = 20
-    mocker.patch('autosubmit.job.job.Job.write_stats')
     platforms = [local]
     Autosubmit.refresh_log_recovery_process(platforms, as_conf)
     assert local.log_recovery_process.is_alive()

--- a/test/unit/test_log_recovery.py
+++ b/test/unit/test_log_recovery.py
@@ -167,11 +167,11 @@ def test_refresh_log_retry_process(prepare_test, local, as_conf, mocker):
     local.keep_alive_timeout = 20
     mocker.patch('autosubmit.job.job.Job.write_stats')
     platforms = [local]
-    Autosubmit.refresh_log_retry_process(platforms, as_conf)
+    Autosubmit.refresh_log_recovery_process(platforms, as_conf)
     assert local.log_recovery_process.is_alive()
     assert local.work_event.is_set()
     local.cleanup_event.set()
     local.log_recovery_process.join(30)
     assert local.log_recovery_process.is_alive() is False
-    Autosubmit.refresh_log_retry_process(platforms, as_conf)
+    Autosubmit.refresh_log_recovery_process(platforms, as_conf)
     assert local.log_recovery_process.is_alive()

--- a/test/unit/test_log_recovery.py
+++ b/test/unit/test_log_recovery.py
@@ -3,6 +3,8 @@ import pytest
 from pathlib import Path
 import os
 import pwd
+
+from autosubmit.autosubmit import Autosubmit
 from autosubmit.job.job_common import Status
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
 from autosubmit.job.job import Job
@@ -158,3 +160,18 @@ def test_log_recovery_recover_log(prepare_test, local, mocker, as_conf):
     assert local.log_recovery_process.is_alive() is False
     assert Path(f"{prepare_test.strpath}/scratch/LOG_t000/t000.cmd.out.moved").exists()
     assert Path(f"{prepare_test.strpath}/scratch/LOG_t000/t000.cmd.err.moved").exists()
+
+
+def test_refresh_log_retry_process(prepare_test, local, as_conf, mocker):
+    mocker.patch('autosubmit.platforms.platform.max', return_value=0)
+    local.keep_alive_timeout = 20
+    mocker.patch('autosubmit.job.job.Job.write_stats')
+    platforms = [local]
+    Autosubmit.refresh_log_retry_process(platforms, as_conf)
+    assert local.log_recovery_process.is_alive()
+    assert local.work_event.is_set()
+    local.cleanup_event.set()
+    local.log_recovery_process.join(30)
+    assert local.log_recovery_process.is_alive() is False
+    Autosubmit.refresh_log_retry_process(platforms, as_conf)
+    assert local.log_recovery_process.is_alive()

--- a/test/unit/test_log_recovery.py
+++ b/test/unit/test_log_recovery.py
@@ -175,3 +175,5 @@ def test_refresh_log_retry_process(prepare_test, local, as_conf, mocker):
     assert local.log_recovery_process.is_alive() is False
     Autosubmit.refresh_log_recovery_process(platforms, as_conf)
     assert local.log_recovery_process.is_alive()
+    local.send_cleanup_signal()  # this is called by atexit function
+    assert local.log_recovery_process.is_alive() is False


### PR DESCRIPTION

This PR is to fix a corner case in which the log_recovery process is dead.

related to #2054

- Added refresh_log_recovery_process

Sets the worker or/and call to spawn a new log_recovery process

- Added log_recovery clean_up

Resets everything as if it were new