### PR TITLE
Add DbManager factory function

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1538,8 +1538,7 @@ class Autosubmit:
             safetysleeptime = as_conf.get_safetysleeptime()
             Log.debug("The Experiment name is: {0}", expid)
             Log.debug("Sleep: {0}", safetysleeptime)
-            packages_persistence = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                                         "job_packages_" + expid)
+            packages_persistence = JobPackagePersistence(expid)
             os.chmod(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid,
                                   "pkl", "job_packages_" + expid + ".db"), 0o644)
 
@@ -2033,8 +2032,7 @@ class Autosubmit:
         Log.debug("Loading job packages")
         # Packages == wrappers and jobs inside wrappers. Name is also misleading.
         try:
-            packages_persistence = JobPackagePersistence(os.path.join(
-                BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"), "job_packages_" + expid)
+            packages_persistence = JobPackagePersistence(expid)
         except IOError as e:
             raise AutosubmitError(
                 "job_packages not found", 6016, str(e))
@@ -2708,8 +2706,7 @@ class Autosubmit:
         try:
             if len(as_conf.experiment_data.get("WRAPPERS", {})) > 0 and check_wrapper:
                 # Class constructor creates table if it does not exist
-                packages_persistence = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                                             "job_packages_" + expid)
+                packages_persistence = JobPackagePersistence(expid)
                 # Permissions
                 os.chmod(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl", "job_packages_" + expid + ".db"), 0o644)
                 # Database modification
@@ -2721,11 +2718,9 @@ class Autosubmit:
                                                            packages_persistence, True)
 
                 packages = packages_persistence.load(True)
-                packages += JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                                  "job_packages_" + expid).load()
+                packages += JobPackagePersistence(expid).load()
             else:
-                packages = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                                 "job_packages_" + expid).load()
+                packages = JobPackagePersistence(expid).load()
         except BaseException as e:
             if profile:
                 profiler.stop()
@@ -3039,8 +3034,7 @@ class Autosubmit:
             raise AutosubmitCritical("Couldn't restore the experiment workflow", 7040, str(e))
 
         try:
-            packages = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                             "job_packages_" + expid).load()
+            packages = JobPackagePersistence(expid).load()
 
             groups_dict = dict()
             if group_by:
@@ -4560,8 +4554,7 @@ class Autosubmit:
                     job_list.save()
                     as_conf.save()
                     try:
-                        packages_persistence = JobPackagePersistence(
-                            os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"), "job_packages_" + expid)
+                        packages_persistence = JobPackagePersistence(expid)
                         packages_persistence.reset_table()
                         packages_persistence.reset_table(True)
                     except Exception:
@@ -5377,9 +5370,7 @@ class Autosubmit:
                 if not noplot:
                     from .monitor.monitor import Monitor
                     if as_conf.get_wrapper_type() != 'none' and check_wrapper:
-                        packages_persistence = JobPackagePersistence(
-                            os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                            "job_packages_" + expid)
+                        packages_persistence = JobPackagePersistence(expid)
                         os.chmod(os.path.join(BasicConfig.LOCAL_ROOT_DIR,
                                               expid, "pkl", "job_packages_" + expid + ".db"), 0o775)
                         packages_persistence.reset_table(True)
@@ -5391,8 +5382,7 @@ class Autosubmit:
 
                         packages = packages_persistence.load(True)
                     else:
-                        packages = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                                         "job_packages_" + expid).load()
+                        packages = JobPackagePersistence(expid).load()
                     groups_dict = dict()
                     if group_by:
                         status = list()
@@ -5550,8 +5540,7 @@ class Autosubmit:
         if storage_type == 'pkl':
             return JobListPersistencePkl()
         elif storage_type == 'db':
-            return JobListPersistenceDb(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                        "job_list_" + expid)
+            return JobListPersistenceDb(expid)
         raise AutosubmitCritical('Storage type not known', 7014)
 
     @staticmethod

--- a/autosubmit/database/db_manager.py
+++ b/autosubmit/database/db_manager.py
@@ -19,14 +19,14 @@
 
 import sqlite3
 import os
-from typing import Dict, Iterable, List, Protocol, Union, cast
+from typing import Any, Dict, Iterable, List, Protocol, Union, cast
 
 class DbManager(object):
     """
     Class to manage an SQLite database.
     """
 
-    def __init__(self, root_path, db_name, db_version):
+    def __init__(self, root_path: str, db_name: str, db_version: int):
         self.root_path = root_path
         self.db_name = db_name
         self.db_version = db_version
@@ -153,7 +153,7 @@ class DbManager(object):
         if os.path.exists(self._get_db_filepath()):
             os.remove(self._get_db_filepath())
 
-    def _get_db_filepath(self):
+    def _get_db_filepath(self) -> str:
         """
         Returns the path of the .db file
         :return path: int
@@ -173,7 +173,7 @@ class DbManager(object):
         self.insert(options_table_name, columns, ['name', self.db_name])
         self.insert(options_table_name, columns, ['version', self.db_version])
 
-    def _select_with_all_fields(self, table_name, where=[]):
+    def _select_with_all_fields(self, table_name: str, where: List[str] = []) -> sqlite3.Cursor:
         """
         Returns the cursor of the select command with the given parameters
         :param table_name: str
@@ -190,7 +190,7 @@ class DbManager(object):
     """
 
     @staticmethod
-    def generate_create_table_command(table_name, fields):
+    def generate_create_table_command(table_name: str, fields: List[str]) -> str:
         create_command = 'CREATE TABLE IF NOT EXISTS ' + table_name + ' (' + fields.pop(0)
         for field in fields:
             create_command += (', ' + field)
@@ -198,12 +198,14 @@ class DbManager(object):
         return create_command
 
     @staticmethod
-    def generate_drop_table_command(table_name):
+    def generate_drop_table_command(table_name: str) -> str:
         drop_command = 'DROP TABLE IF EXISTS ' + table_name
         return drop_command
 
     @staticmethod
-    def generate_insert_command(table_name, columns, values):
+    def generate_insert_command(
+        table_name: str, columns: List[str], values: List[str]
+    ) -> str:
         insert_command = 'INSERT INTO ' + table_name + '(' + columns.pop(0)
         for column in columns:
             insert_command += (', ' + column)
@@ -214,7 +216,7 @@ class DbManager(object):
         return insert_command
 
     @staticmethod
-    def generate_insert_many_command(table_name, num_of_values):
+    def generate_insert_many_command(table_name: str, num_of_values: int) -> str:
         insert_command = 'INSERT INTO ' + table_name + ' VALUES (?'
         num_of_values -= 1
         while num_of_values > 0:
@@ -224,12 +226,12 @@ class DbManager(object):
         return insert_command
 
     @staticmethod
-    def generate_count_command(table_name):
+    def generate_count_command(table_name: str) -> str:
         count_command = 'SELECT count(*) FROM ' + table_name
         return count_command
 
     @staticmethod
-    def generate_select_command(table_name, where=[]):
+    def generate_select_command(table_name: str, where: List[str] = []) -> str:
         basic_select = 'SELECT * FROM ' + table_name
         select_command = basic_select if len(where) == 0 else basic_select + ' WHERE ' + where.pop(0)
         for condition in where:
@@ -237,7 +239,7 @@ class DbManager(object):
         return select_command
     
     @staticmethod
-    def generate_delete_command(table_name: str, where: list[str] = []):
+    def generate_delete_command(table_name: str, where: List[str] = []) -> str:
         delete_command = "DELETE FROM " + table_name + " WHERE " + where.pop(0)
         for condition in where:
             delete_command += " AND " + condition
@@ -260,11 +262,11 @@ class DatabaseManager(Protocol):
     def insert(self, table_name: str, columns: List[str], values: List[str]): ...
     def insertMany(self, table_name: str, data: List[Union[Iterable, Dict]]): ...
     def delete_where(self, table_name: str, where: List[str]): ...
-    def select_first(self, table_name: str): ...
-    def select_first_where(self, table_name: str, where: List[str]): ...
-    def select_all(self, table_name: str): ...
-    def select_all_where(self, table_name: str, where: List[str]): ...
-    def count(self, table_name: str): ...
+    def select_first(self, table_name: str) -> List[Any]: ...
+    def select_first_where(self, table_name: str, where: List[str]) -> List[Any]: ...
+    def select_all(self, table_name: str) -> List[List[Any]]: ...
+    def select_all_where(self, table_name: str, where: List[str]) -> List[List[Any]]: ...
+    def count(self, table_name: str) -> int: ...
     def drop(self): ...
 
 

--- a/autosubmit/job/job_list.py
+++ b/autosubmit/job/job_list.py
@@ -3205,14 +3205,12 @@ class JobList(object):
         # monitor = Monitor()
         packages = None
         try:
-            packages = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),
-                                             "job_packages_" + expid).load(wrapper=False)
+            packages = JobPackagePersistence(expid).load(wrapper=False)
         except Exception as ex:
             print("Wrapper table not found, trying packages.")
             packages = None
             try:
-                packages = JobPackagePersistence(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid,
-                                                "pkl"), "job_packages_" + expid).load(wrapper=True)
+                packages = JobPackagePersistence(expid).load(wrapper=True)
             except Exception as exp2:
                 packages = None
                 pass

--- a/autosubmit/job/job_list_persistence.py
+++ b/autosubmit/job/job_list_persistence.py
@@ -20,9 +20,11 @@ import os
 import pickle
 from sys import setrecursionlimit, getrecursionlimit
 import shutil
-from autosubmit.database.db_manager import DbManager
+from autosubmit.database.db_manager import create_db_manager
 from log.log import AutosubmitCritical, Log
 from contextlib import suppress
+from autosubmitconfigparser.config.basicconfig import BasicConfig
+from pathlib import Path
 
 
 class JobListPersistence(object):
@@ -140,8 +142,14 @@ class JobListPersistenceDb(JobListPersistence):
         "wrapper_type",
     ]
 
-    def __init__(self, persistence_path, persistence_file):
-        self.db_manager = DbManager(persistence_path, persistence_file, self.VERSION)
+    def __init__(self, expid: str):
+        options = {
+            "root_path": str(Path(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl")),
+            "db_name": f"job_list_{expid}",
+            "db_version": self.VERSION
+        }
+        self.expid = expid
+        self.db_manager = create_db_manager(BasicConfig.DATABASE_BACKEND, **options)
 
     def load(self, persistence_path, persistence_file):
         """

--- a/autosubmit/job/job_list_persistence.py
+++ b/autosubmit/job/job_list_persistence.py
@@ -146,7 +146,8 @@ class JobListPersistenceDb(JobListPersistence):
         options = {
             "root_path": str(Path(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl")),
             "db_name": f"job_list_{expid}",
-            "db_version": self.VERSION
+            "db_version": self.VERSION,
+            "schema": expid
         }
         self.expid = expid
         self.db_manager = create_db_manager(BasicConfig.DATABASE_BACKEND, **options)

--- a/autosubmit/job/job_package_persistence.py
+++ b/autosubmit/job/job_package_persistence.py
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
-from autosubmit.database.db_manager import DbManager
+from autosubmit.database.db_manager import create_db_manager
+from autosubmitconfigparser.config.basicconfig import BasicConfig
+from pathlib import Path
 from log.log import AutosubmitCritical
 from typing import Any, List
 
@@ -39,8 +41,14 @@ class JobPackagePersistence(object):
     WRAPPER_JOB_PACKAGES_TABLE = 'wrapper_job_package'
     TABLE_FIELDS = ['exp_id', 'package_name', 'job_name', 'wallclock' ]  # new field, needs a new autosubmit create
 
-    def __init__(self, persistence_path, persistence_file):
-        self.db_manager = DbManager(persistence_path, persistence_file, self.VERSION)
+    def __init__(self, expid: str):
+        options = {
+            'root_path': str(Path(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl")),
+            'db_name': f"job_packages_{expid}",
+            'db_version': self.VERSION,
+            'schema': expid
+        }
+        self.db_manager = create_db_manager(BasicConfig.DATABASE_BACKEND, **options)
         self.db_manager.create_table(self.JOB_PACKAGES_TABLE, self.TABLE_FIELDS)
         self.db_manager.create_table(self.WRAPPER_JOB_PACKAGES_TABLE, self.TABLE_FIELDS)
 

--- a/autosubmit/job/job_utils.py
+++ b/autosubmit/job/job_utils.py
@@ -264,8 +264,8 @@ def get_job_package_code(expid: str, job_name: str) -> int:
     try:
         basic_conf = BasicConfig()
         basic_conf.read()
-        packages_wrapper = JobPackagePersistence(os.path.join(basic_conf.LOCAL_ROOT_DIR, expid, "pkl"),"job_packages_" + expid).load(wrapper=True)
-        packages_wrapper_plus = JobPackagePersistence(os.path.join(basic_conf.LOCAL_ROOT_DIR, expid, "pkl"),"job_packages_" + expid).load(wrapper=False)
+        packages_wrapper = JobPackagePersistence(expid).load(wrapper=True)
+        packages_wrapper_plus = JobPackagePersistence(expid).load(wrapper=False)
         if packages_wrapper or packages_wrapper_plus:
             packages = packages_wrapper if len(packages_wrapper) > len(packages_wrapper_plus) else packages_wrapper_plus
             for exp, package_name, _job_name in packages:

--- a/test/unit/test_dependencies.py
+++ b/test/unit/test_dependencies.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-
 import mock
 import pytest
+from datetime import datetime
 from mock.mock import MagicMock
 from networkx import DiGraph  # type: ignore
 
@@ -19,6 +18,13 @@ _CHUNK_LIST = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 _SPLIT_LIST = [1, 2, 3, 4, 5]
 _DATE_LIST = ["20020201", "20020202", "20020203", "20020204", "20020205", "20020206", "20020207",
               "20020208", "20020209", "20020210"]
+
+_EXPID = 'a000'
+
+
+@pytest.fixture(autouse=True)
+def as_conf(autosubmit_config):
+    return autosubmit_config(_EXPID, experiment_data={})
 
 
 @pytest.fixture
@@ -124,7 +130,7 @@ def joblist(tmp_path):
     as_conf.experiment_data["JOBS"] = dict()
     as_conf.jobs_data = as_conf.experiment_data["JOBS"]
     as_conf.experiment_data["PLATFORMS"] = dict()
-    job_list_persistence = JobListPersistenceDb(str(tmp_path), 'db')
+    job_list_persistence = JobListPersistenceDb(_EXPID)
     joblist = JobList(experiment_id, as_conf, YAMLParserFactory(), job_list_persistence)
     joblist._date_list = _DATE_LIST
     joblist._member_list = _MEMBER_LIST
@@ -684,7 +690,7 @@ def test_add_special_conditions_chunks_to_once(mocker, joblist):
 
 def test_job_dict_get_jobs_filtered(mocker, joblist):
     # Test the get_jobs_filtered function
-    as_conf = mock.Mock()
+    as_conf = mocker.Mock()
     as_conf.experiment_data = dict()
     as_conf.experiment_data = {
         'CONFIG': {'AUTOSUBMIT_VERSION': '4.1.2', 'MAXWAITINGJOBS': 20, 'TOTALJOBS': 20, 'SAFETYSLEEPTIME': 10,
@@ -756,10 +762,7 @@ def test_job_dict_get_jobs_filtered(mocker, joblist):
     assert expected_output == result
 
 
-def test_normalize_auto_keyword(autosubmit_config, mocker):
-    as_conf = autosubmit_config('a000', experiment_data={
-
-    })
+def test_normalize_auto_keyword(as_conf, mocker):
     job_list = JobList(
         as_conf.expid,
         as_conf,
@@ -768,21 +771,21 @@ def test_normalize_auto_keyword(autosubmit_config, mocker):
     )
     dependency = Dependency("test")
 
-    job = Job("a000_20001010_fc1_2_1_test", 1, Status.READY, 1)
+    job = Job(f"{_EXPID}_20001010_fc1_2_1_test", 1, Status.READY, 1)
     job.running = "chunk"
     job.section = "test"
     job.date = "20001010"
     job.member = "fc1"
     job.splits = 5
 
-    job_minus = Job("a000_20001010_fc1_1_1_minus", 1, Status.READY, 1)
+    job_minus = Job(f"{_EXPID}_20001010_fc1_1_1_minus", 1, Status.READY, 1)
     job_minus.running = "chunk"
     job_minus.section = "minus"
     job_minus.date = "20001010"
     job_minus.member = "fc1"
     job_minus.splits = 40
 
-    job_plus = Job("a000_20001010_fc1_3_1_plus", 1, Status.READY, 1)
+    job_plus = Job(f"{_EXPID}_20001010_fc1_3_1_plus", 1, Status.READY, 1)
     job_plus.running = "chunk"
     job_plus.section = "plus"
     job_plus.date = "20001010"

--- a/test/unit/test_dic_jobs.py
+++ b/test/unit/test_dic_jobs.py
@@ -16,9 +16,8 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-from datetime import datetime
-
 import pytest
+from datetime import datetime
 from mock import Mock
 
 from autosubmit.job.job import Job

--- a/test/unit/test_job_graph.py
+++ b/test/unit/test_job_graph.py
@@ -47,7 +47,7 @@ def job_list(autosubmit_config, tmp_path):
         'JOBS': {},
         'PLATFORMS': {},
     })
-    job_list_persistence = JobListPersistenceDb(str(tmp_path), 'db')
+    job_list_persistence = JobListPersistenceDb(_EXPID)
     job_list = JobList(_EXPID, as_conf, YAMLParserFactory(), job_list_persistence)
     # Basic workflow with SETUP, INI, SIM, POST, CLEAN
     setup_job = _create_dummy_job('expid_SETUP', Status.READY)

--- a/test/unit/test_job_grouping.py
+++ b/test/unit/test_job_grouping.py
@@ -15,10 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
-from random import randrange
-
 import pytest
 from bscearth.utils.date import parse_date, date2str
+from random import randrange
 
 from autosubmit.job.job import Job
 from autosubmit.job.job_common import Status
@@ -47,7 +46,7 @@ def job_list(autosubmit_config, tmp_path):
         'JOBS': {},
         'PLATFORMS': {}
     })
-    job_list_persistence = JobListPersistenceDb(str(tmp_path), 'db')
+    job_list_persistence = JobListPersistenceDb('a000')
     job_list = JobList(as_conf.expid, as_conf, YAMLParserFactory(), job_list_persistence)
 
     # Basic workflow with SETUP, INI, SIM, POST, CLEAN

--- a/test/unit/test_job_package.py
+++ b/test/unit/test_job_package.py
@@ -106,7 +106,7 @@ def create_job_package_wrapper(jobs, as_conf):
 @pytest.fixture
 def joblist(tmp_path, as_conf):
     job_list = JobList('a000', as_conf, YAMLParserFactory(),
-                       JobListPersistenceDb(str(tmp_path), 'db'))
+                       JobListPersistenceDb(str(tmp_path)))
     job_list._ordered_jobs_by_date_member["WRAPPERS"] = dict()
     return job_list
 

--- a/test/unit/test_packages_persistence.py
+++ b/test/unit/test_packages_persistence.py
@@ -30,7 +30,7 @@ def test_load(mocker):
     mocker.patch('autosubmit.database.db_manager.DbManager.select_all').return_value = [
         ['random-id"', 'vertical-wrapper', 'dummy-job', '02:00']]
     mocker.patch('sqlite3.connect').return_value = mocker.MagicMock()
-    job_package_persistence = JobPackagePersistence('dummy/path', 'dummy/file')
+    job_package_persistence = JobPackagePersistence('dummy/expid')
     assert job_package_persistence.load(wrapper=True) == [['random-id"', 'vertical-wrapper', 'dummy-job', '02:00']]
     mocker.patch('autosubmit.database.db_manager.DbManager.select_all').return_value = [
         ['random-id"', 'vertical-wrapper', 'dummy-job']]

--- a/test/unit/test_wrappers.py
+++ b/test/unit/test_wrappers.py
@@ -15,17 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
+
 import copy
 import inspect
-import shutil
-import tempfile
-from collections import OrderedDict
-from pathlib import Path
-from random import randrange
-
 import mock
 import pytest
+import shutil
+import tempfile
 from mock import MagicMock
+from pathlib import Path
+from random import randrange
 
 import log.log
 from autosubmit.job.job import Job
@@ -195,8 +195,13 @@ class TestWrappers:
         self.as_conf.experiment_data["PLATFORMS"] = dict()
         self.as_conf.experiment_data["WRAPPERS"] = dict()
         self.temp_directory = tempfile.mkdtemp()
-        self.job_list = JobList(self.experiment_id, self.as_conf, YAMLParserFactory(),
-                                JobListPersistenceDb(self.temp_directory, 'db'))
+        # TODO: The ``MagicMock`` argument is replacing this old call:
+        #       ``JobListPersistenceDb(self.experiment_id)``. The reason is that we need the pytest
+        #       fixtures to mock the DB_PATH/DB_DIR/etc., but the ones we have are function-scoped.
+        #       Once this code gets ported to function-based, instead of class-based, we can use
+        #       those fixtures, removing that mock (we have plenty of other places testing already
+        #       ``JobList``, but less mocking is always better.
+        self.job_list = JobList(self.experiment_id, self.as_conf, YAMLParserFactory(), MagicMock())
 
         self.parser_mock = MagicMock(spec='SafeConfigParser')
 


### PR DESCRIPTION
Related to #1285 and PR #1914 

The idea of this PR is to include the code organization changes related to #1914. In this case:

* Adding the DbManager factory function
* Update JobListPersistenceDb and JobPackagePersistence `__init__` arguments
* Fix tests to mock the classes correctly changed above

These changes will make it easier to implement and review the changes needed to enable the support to Postgres.