### PR TITLE
logs-when-vertical-job-not-packed

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1239,7 +1239,7 @@ class Job(object):
 
         """
         # Write stats for vertical wrappers
-        if self.wrapper_type == "vertical":  # Disable AS retrials for vertical wrappers to use internal ones
+        if self.packed and self.wrapper_type == "vertical":  # Disable AS retrials for vertical wrappers to use internal ones
             for i in range(0, int(last_retrial + 1)):
                 self.platform.get_stat_file(self, count=i)
                 self.write_vertical_time(i)
@@ -1279,7 +1279,7 @@ class Job(object):
             Dict[str, int]: Dictionary with finish timestamps per job.
         """
         backup_logname = copy.copy(self.local_logs)
-        if self.wrapper_type == "vertical":
+        if self.packed and self.wrapper_type == "vertical":
             last_retrial = self.retrieve_internal_retrials_logfiles(platform)
         else:
             self.retrieve_external_retrials_logfiles(platform)
@@ -1290,7 +1290,7 @@ class Job(object):
                 raise AutosubmitCritical("Failed to retrieve logs for job {0}".format(self.name), 6000)
         else:
             self.write_stats(last_retrial)
-            if self.wrapper_type == "vertical":
+            if self.packed and self.wrapper_type == "vertical":
                 for retrial in range(0, last_retrial + 1):
                     Log.result(f"{platform.name}(log_recovery) Successfully recovered log for job '{self.name}' and retry '{retrial}'.")
             else:

--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -1314,7 +1314,7 @@ class ParamikoPlatform(Platform):
         :return: header to use
         :rtype: str
         """
-        if str(job.wrapper_type).lower() != "vertical":
+        if not job.packed or str(job.wrapper_type).lower() != "vertical":
             out_filename = "{0}.cmd.out.{1}".format(job.name,job.fail_count)
             err_filename = "{0}.cmd.err.{1}".format(job.name,job.fail_count)
         else:

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -45,7 +45,7 @@ class UniqueQueue(Queue):
             block (bool): Whether to block when the queue is full. Defaults to True.
             timeout (float): Timeout for blocking operations. Defaults to None.
         """
-        if job.wrapper_type == "vertical": # We gather all retrials at once
+        if job.packed and job.wrapper_type == "vertical": # We gather all retrials at once
             unique_name = job.name
         else:
             unique_name = job.name+str(job.fail_count) # We gather retrial per retrial


### PR DESCRIPTION


I noticed that when you put an invalid wrapper configuration in the flexible policy or the job is loaded the job.wrapper_type may be filled.

When this happens, Autosubmit is entering the vertical code logic when it shouldn't which lead to job recovery not recovering the logs.




