### PR TITLE
Fixed the sleep to actually sleep

### DIFF
--- a/log/log.py
+++ b/log/log.py
@@ -198,12 +198,12 @@ class Log:
 
         level = levels.get(str(level).upper(),"DEBUG")
 
-        max_retrials = 3
-        retrials = 0
+        max_retries = 3
+        retries = 1
         timeout = 5
 
-        while not os.path.exists(file_path) and retrials < max_retrials:
-            sleep(timeout*retrials)
+        while not os.path.exists(file_path) and retries < max_retries:
+            sleep(timeout*retries)
             try:
                 directory, filename = os.path.split(file_path)
                 if not os.path.exists(directory):


### PR DESCRIPTION
While investigating why autosubmit spends a surprising amount of CPU on hammering the LOG_<expid> directory by 
listing files again and again, I stumbled upon log/log.py:
 ```
    max_retrials = 3
    retrials = 0
    timeout = 5

    while not os.path.exists(file_path) and retrials < max_retrials:
        sleep(timeout*retrials)
        try:
            directory, filename = os.path.split(file_path)
            if not os.path.exists(directory):
                os.mkdir(directory)
            files = [f for f in os.listdir(directory) if os.path.isfile

```
The sleep() was hardcoded as 0. 

This PR fixes that to 1 second (*3), while at the same time fixes the 
"retrials" to the correct "retries".
