### PR TITLE
Import certain packages only when necessary to consume less memory (was 78.7 MB, is now 37.3 MB)

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -22,13 +22,13 @@ import platform
 import threading
 from bscearth.utils.date import date2str
 from configparser import ConfigParser
-from distutils.util import strtobool
 from pathlib import Path
 from ruamel.yaml import YAML
 from typing import Dict, Set, Tuple, Union, Any, List, Optional
 
 from autosubmit.database.db_common import update_experiment_descrip_version
 from autosubmit.helpers.parameters import PARAMETERS
+from autosubmit.helpers.utils import strtobool
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
 from autosubmitconfigparser.config.yamlparser import YAMLParserFactory
@@ -48,7 +48,6 @@ from .job.job_list_persistence import JobListPersistencePkl
 from .job.job_package_persistence import JobPackagePersistence
 from .job.job_packager import JobPackager
 from .job.job_utils import SubJob, SubJobManager
-from .profiler.profiler import Profiler
 from .notifications.mail_notifier import MailNotifier
 from .notifications.notifier import Notifier
 from .platforms.paramiko_submitter import ParamikoSubmitter
@@ -2153,6 +2152,7 @@ class Autosubmit:
         """
         # Start profiling if the flag has been used
         if profile:
+            from .profiler.profiler import Profiler
             profiler = Profiler(expid)
             profiler.start()
 
@@ -2617,6 +2617,7 @@ class Autosubmit:
 
         # Start profiling if the flag has been used
         if profile:
+            from .profiler.profiler import Profiler
             profiler = Profiler(expid)
             profiler.start()
 
@@ -4481,6 +4482,7 @@ class Autosubmit:
         """
         # Start profiling if the flag has been used
         if profile:
+            from .profiler.profiler import Profiler
             profiler = Profiler(expid)
             profiler.start()
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -50,7 +50,6 @@ from .job.job_package_persistence import JobPackagePersistence
 from .job.job_packager import JobPackager
 from .job.job_utils import SubJob, SubJobManager
 from .profiler.profiler import Profiler
-from .monitor.monitor import Monitor
 from .notifications.mail_notifier import MailNotifier
 from .notifications.notifier import Notifier
 from .platforms.paramiko_submitter import ParamikoSubmitter
@@ -2615,6 +2614,8 @@ class Autosubmit:
         :type detail: bool
 
         """
+        from .monitor.monitor import Monitor
+
         # Start profiling if the flag has been used
         if profile:
             profiler = Profiler(expid)
@@ -2809,6 +2810,8 @@ class Autosubmit:
         :param db: Use database to get the statistics
         :type db: bool
         """
+        from .monitor.monitor import Monitor
+
         try:
             Log.info("Loading jobs...")
             as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
@@ -2877,6 +2880,8 @@ class Autosubmit:
         :param plot: set True to delete outdated plots
         :param stats: set True to delete outdated stats
         """
+        from .monitor.monitor import Monitor
+
         try:
             exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
 
@@ -3053,6 +3058,7 @@ class Autosubmit:
                 groups_dict = job_grouping.group_jobs()
 
             if not noplot:
+                from .monitor.monitor import Monitor
                 Log.info("\nPlotting the jobs list...")
                 monitor_exp = Monitor()
                 monitor_exp.generate_output(expid,
@@ -4605,6 +4611,7 @@ class Autosubmit:
                             Log.warning(
                                 "Couldn't recover the Historical database, AS will continue without it, GUI may be affected")
                     if not noplot:
+                        from .monitor.monitor import Monitor
                         if group_by:
                             status = list()
                             if expand_status:
@@ -5380,6 +5387,7 @@ class Autosubmit:
                         "Changes NOT saved to the JobList!!!!:  use -s option to save", 3000)
                 #Visualization stuff that should be in a function common to monitor , create, -cw flag, inspect and so on
                 if not noplot:
+                    from .monitor.monitor import Monitor
                     if as_conf.get_wrapper_type() != 'none' and check_wrapper:
                         packages_persistence = JobPackagePersistence(
                             os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl"),

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -17,7 +17,6 @@
 import collections
 import locale
 import platform
-import requests
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 import threading
@@ -3216,6 +3215,7 @@ class Autosubmit:
                     "Unable to gather the parameters from config files, check permissions.", 7012)
             # Performance Metrics call
             try:
+                import requests
                 BasicConfig.read()
                 request = requests.get(
                     "{0}/performance/{1}".format(BasicConfig.AUTOSUBMIT_API_URL, expid))

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -229,3 +229,20 @@ class NaturalSort:
                 return False
         return False
 
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Original code: from distutils.util import strtobool
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/autosubmit/job/job_list.py
+++ b/autosubmit/job/job_list.py
@@ -27,17 +27,12 @@ from threading import Thread
 from typing import List, Dict, Tuple, Any
 from pathlib import Path
 
-import math
-import networkx as nx
-from bscearth.utils.date import date2str, parse_date
-from networkx import DiGraph
-from time import localtime, strftime, mktime
+from time import strftime
 
 import math
-import networkx as nx
 from bscearth.utils.date import date2str, parse_date
 from networkx import DiGraph
-from time import localtime, mktime, time
+from time import localtime, mktime
 
 import autosubmit.database.db_structure as DbStructure
 from autosubmit.helpers.data_transfer import JobRow
@@ -48,7 +43,6 @@ from autosubmit.job.job_package_persistence import JobPackagePersistence
 from autosubmit.job.job_packages import JobPackageThread
 from autosubmit.job.job_utils import Dependency, _get_submitter
 from autosubmit.job.job_utils import transitive_reduction
-from autosubmit.platforms.platform import Platform
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
 from log.log import AutosubmitCritical, AutosubmitError, Log
@@ -222,11 +216,11 @@ class JobList(object):
         try:
             self.graph = self.load(create)
             if type(self.graph) is not DiGraph:
-                self.graph = nx.DiGraph()
+                self.graph = DiGraph()
         except AutosubmitCritical:
             raise
         except Exception:
-            self.graph = nx.DiGraph()
+            self.graph = DiGraph()
         self._dic_jobs = DicJobs(date_list, member_list, chunk_list, date_format, default_retrials, as_conf)
         self._dic_jobs.graph = self.graph
         if len(self.graph.nodes) > 0:

--- a/autosubmit/platforms/locplatform.py
+++ b/autosubmit/platforms/locplatform.py
@@ -21,7 +21,6 @@ import os
 from pathlib import Path
 from xml.dom.minidom import parseString
 import subprocess
-from matplotlib.patches import PathPatch
 from autosubmit.platforms.paramiko_platform import ParamikoPlatform
 from autosubmit.platforms.headers.local_header import LocalHeader
 from autosubmit.platforms.wrappers.wrapper_factory import LocalWrapperFactory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "pyparsing==3.1.1",
     "matplotlib<=3.8.3",
     "packaging<=23.2",
-    "typing_extensions<=4.9.0",
+    "typing_extensions==4.*",
     "typing<=3.7.4.3",
     "psutil<=7.0.0",
     "py3dotplus==1.1.0",

--- a/test/unit/helpers/test_utils.py
+++ b/test/unit/helpers/test_utils.py
@@ -1,0 +1,39 @@
+import pytest
+
+from autosubmit.helpers.utils import strtobool
+
+
+@pytest.mark.parametrize(
+    'val,expected',
+    [
+        # yes
+        ('y', 1),
+        ('yes', 1),
+        ('t', 1),
+        ('true', 1),
+        ('on', 1),
+        ('1', 1),
+        ('YES', 1),
+        ('TrUE', 1),
+        # no
+        ('no', 0),
+        ('n', 0),
+        ('f', 0),
+        ('F', 0),
+        ('false', 0),
+        ('off', 0),
+        ('OFF', 0),
+        ('0', 0),
+        # invalid
+        ('Yay', ValueError),
+        ('Nay', ValueError),
+        ('Nah', ValueError),
+        ('2', ValueError),
+    ]
+)
+def test_strtobool(val, expected):
+    if expected is ValueError:
+        with pytest.raises(expected):
+            strtobool(val)
+    else:
+        assert expected == strtobool(val)


### PR DESCRIPTION
I  used [Sciagraph](https://www.sciagraph.com/) to proflie Autosubmit for #2160 and found that that profiler was helpful actually in providing the detailed memory usage of the imports in our code.

To install and configure it, I ran `pip install sciagraph` and then did the account set up at https://account.sciagraph.com/ui/ (for the free version, they have paid plans too).

Sciagraph uses pydantic, which relies on typing_extensions >= 4.12, but we had a fixed range for ==4.9.0. I replaced it by `==4.*` as I think the typing extensions shouldn't break between major/minor updates for us.

Then I launched sciagraph with this command:

```bash
$ autosubmit create -v -f -np...
$ python -m sciagraph run /home/bdepaula/mambaforge/envs/autosubmit4/bin/autosubmit -lc DEBUG run a00g
```

I let it run a few iterations, like up to `90 out of 96 jobs` or earlier, and then `CTRL+C`'ed it. See below some screenshots from Sciagraph.

![Screenshot from 2025-03-04 12-38-22](https://github.com/user-attachments/assets/2b288330-4dfe-4551-83a2-fed6a4416fd3)

![Screenshot from 2025-03-04 12-39-24](https://github.com/user-attachments/assets/71d1015d-a828-4999-93d8-5b63d89bae83)

As you can see, `autosubmit run` had a peak of 78.7 MB of memory (internal). Within that amount, `20MB` of memory allocated when `autosubmit.monitor` is imported. `10MB` are from matplotlib.

In the image below, you can see `PathPatch` from `matplotlib` bringing another `13MB`. This is from the `locplatform`, for local jobs. 

![Screenshot from 2025-03-04 12-42-22](https://github.com/user-attachments/assets/9c6a823a-1d09-4678-a722-9d3c23e9ae51)

But the interesting part is that `PathPatch` is never actually used in `locplatform`. An unused import brings `13MB` of memory unnecessarily -- this could have been fixed by fixing our unused imports with a linter like pylint/ruff/pycharm/etc..

I separated in commits what I did, so that it'd be easier to review it (I can squash everything to a single commit, or two if we want to leave the dependency change in a separate commit). To recap, here's how the profiler found `master`:

![image](https://github.com/user-attachments/assets/7ad9e9a1-cfd5-485c-b098-8cb234112e6f)

Removing the imports for `Monitor`, `requests`, and `matplotlib` and moving them to only the functions that actually where `Monitor` is used, went from 78.7 to 43.8 (-34.9):

![image](https://github.com/user-attachments/assets/3638897f-8507-44fd-8a97-d1f3b153a430)

Then some other smaller imports that were bringing `distutils` and importing all `networkx as nx` and also `from networkx.nx import DiGraph` (can be simplified) it went down to 37.3 (-6.5 MB).

![image](https://github.com/user-attachments/assets/a527ab7a-cbdd-42f1-ad9d-f8c5449b064c)

Overall that's 37.3 MB instead of 78.7 MB, so less than half of the initial memory.

I used `memory_profiler` to run a test experiment #2160 for `240` seconds. This is the plog using `master` early this morning for #2157 :

![image](https://github.com/user-attachments/assets/e00696e3-7a37-4be5-bfaf-0c7fe907fe50)

And this is running the same test with this branch:

![Figure_1](https://github.com/user-attachments/assets/22266b59-5d9b-4fba-83ed-edd32abe62be)

Plotted together to make comparing them easier. Black is `master`, blue this branch:

![Figure_1](https://github.com/user-attachments/assets/0a4848ec-e085-4fe0-9604-876648bf1d70)
