### PR TITLE
Add PIP version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ HOW TO DEPLOY/SETUP AUTOSUBMIT FRAMEWORK
    * CCA (ECMWF machine)
    * ARCHER (EPCC machine)
 
-- Pre-requisites: These packages (bash, python2, sqlite3, git-scm > 1.8.2, subversion, dialog*) must be available at local
+- Pre-requisites: These packages (bash, python2, sqlite3, git-scm > 1.8.2, subversion, pip >= 24.0, dialog*) must be available at local
   machine. These packages (argparse, dateutil, pyparsing, numpy, pydotplus, matplotlib, paramiko,
   python2-pythondialog*, mock, portalocker) must be available for python runtime. And the machine is also able to access
   HPC platforms via password-less ssh.
+  Pip must be availbale with version `>= 24.0`.
 
   *: optional
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ HOW TO DEPLOY/SETUP AUTOSUBMIT FRAMEWORK
   machine. These packages (argparse, dateutil, pyparsing, numpy, pydotplus, matplotlib, paramiko,
   python2-pythondialog*, mock, portalocker) must be available for python runtime. And the machine is also able to access
   HPC platforms via password-less ssh.
-  Pip must be availbale with version `>= 24.0`.
+  Pip must be available with version `>= 24.0`.
 
   *: optional
 

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -7,9 +7,10 @@ How to install
 
 The Autosubmit code is hosted in Git, at the BSC GitHub public repository. The Autosubmit Python package is available through PyPI, the primary source for Python packages.
 
-- Pre-requisites: bash, python3, sqlite3, git-scm > 1.8.2, subversion, dialog, curl, python-tk(tkinter in centOS), graphviz >= 2.41, pip3, rsync
+- Pre-requisites: bash, python3, sqlite3, git-scm > 1.8.2, subversion, pip >= 24.0, dialog, curl, python-tk(tkinter in centOS), graphviz >= 2.41, rsync
 
 .. important:: (SYSTEM) Graphviz version must be >= 2.38 except 2.40(not working). You can check the version using dot -v.
+.. important:: (SYSTEM) Pip version must be >= 24.0. You can check the version using dot -v.
 
 - Python dependencies: configobj>=5.0.6, argparse>=1.4.0 , python-dateutil>=2.8.2, matplotlib==3.4.3, numpy==1.21.6, py3dotplus>=1.1.0, pyparsing>=3.0.7, paramiko>=2.9.2, mock>=4.0.3, six>=1.10, portalocker>=2.3.2, networkx==2.6.3, requests>=2.27.1, bscearth.utils>=0.5.2, cryptography>=36.0.1, setuptools>=60.8.2, xlib>=0.21, pip>=22.0.3, ruamel.yaml, pythondialog, pytest, nose, coverage, PyNaCl==1.4.0, six>=1.10.0, requests, xlib, Pygments, packaging==19, typing>=3.7, autosubmitconfigparser
 

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -10,7 +10,7 @@ The Autosubmit code is hosted in Git, at the BSC GitHub public repository. The A
 - Pre-requisites: bash, python3, sqlite3, git-scm > 1.8.2, subversion, pip >= 24.0, dialog, curl, python-tk(tkinter in centOS), graphviz >= 2.41, rsync
 
 .. important:: (SYSTEM) Graphviz version must be >= 2.38 except 2.40(not working). You can check the version using dot -v.
-.. important:: (SYSTEM) Pip version must be >= 24.0. You can check the version using dot -v.
+.. important:: (SYSTEM) Pip version must be >= 24.0. You can check the version using dot -V.
 
 - Python dependencies: configobj>=5.0.6, argparse>=1.4.0 , python-dateutil>=2.8.2, matplotlib==3.4.3, numpy==1.21.6, py3dotplus>=1.1.0, pyparsing>=3.0.7, paramiko>=2.9.2, mock>=4.0.3, six>=1.10, portalocker>=2.3.2, networkx==2.6.3, requests>=2.27.1, bscearth.utils>=0.5.2, cryptography>=36.0.1, setuptools>=60.8.2, xlib>=0.21, pip>=22.0.3, ruamel.yaml, pythondialog, pytest, nose, coverage, PyNaCl==1.4.0, six>=1.10.0, requests, xlib, Pygments, packaging==19, typing>=3.7, autosubmitconfigparser
 

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -10,7 +10,7 @@ The Autosubmit code is hosted in Git, at the BSC GitHub public repository. The A
 - Pre-requisites: bash, python3, sqlite3, git-scm > 1.8.2, subversion, pip >= 24.0, dialog, curl, python-tk(tkinter in centOS), graphviz >= 2.41, rsync
 
 .. important:: (SYSTEM) Graphviz version must be >= 2.38 except 2.40(not working). You can check the version using dot -v.
-.. important:: (SYSTEM) Pip version must be >= 24.0. You can check the version using dot -V.
+.. important:: (SYSTEM) Pip version must be >= 24.0. You can check the version using pip -V.
 
 - Python dependencies: configobj>=5.0.6, argparse>=1.4.0 , python-dateutil>=2.8.2, matplotlib==3.4.3, numpy==1.21.6, py3dotplus>=1.1.0, pyparsing>=3.0.7, paramiko>=2.9.2, mock>=4.0.3, six>=1.10, portalocker>=2.3.2, networkx==2.6.3, requests>=2.27.1, bscearth.utils>=0.5.2, cryptography>=36.0.1, setuptools>=60.8.2, xlib>=0.21, pip>=22.0.3, ruamel.yaml, pythondialog, pytest, nose, coverage, PyNaCl==1.4.0, six>=1.10.0, requests, xlib, Pygments, packaging==19, typing>=3.7, autosubmitconfigparser
 


### PR DESCRIPTION
At installation time, pip must have version `>=24.0` to correctly install with only the `pyproject.toml` file

Closes #2180 