### PR TITLE
Change scheduler is not installed exception.

### DIFF
--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -1179,7 +1179,12 @@ class ParamikoPlatform(Platform):
                     raise AutosubmitError(
                         'SSH Session not active, will restart the platforms', 6005)
                 if errorLine.find("command not found") != -1:
-                    raise AutosubmitCritical("scheduler is not installed.",7052,self._ssh_output_err)
+                    raise AutosubmitError(
+                        f"A platform command was not found. This may be a temporary issue. "
+                        f"Please verify that the correct scheduler is specified for this platform: '{self.name}.{self.type}'.",
+                        7052,
+                        self._ssh_output_err
+                    )
                 elif errorLine.find("syntax error") != -1:
                     raise AutosubmitCritical("Syntax error",7052,self._ssh_output_err)
                 elif errorLine.find("refused") != -1 or errorLine.find("slurm_persist_conn_open_without_init") != -1 or errorLine.find("slurmdbd") != -1 or errorLine.find("submission failed") != -1 or errorLine.find("git clone") != -1 or errorLine.find("sbatch: error: ") != -1 or errorLine.find("not submitted") != -1 or errorLine.find("invalid") != -1 or "[ERR.] PJM".lower() in errorLine:


### PR DESCRIPTION
This fixes #2102. 

For a month, there has been an issue with marenostrum5 in which the sacct, sbatch, or squeue commands are not found. 

I changed the exception to trigger the recovery platform code instead of stopping Autosubmit when it happens.

Initially, it was critical because this could be a user mistake in the platforms.yml.

Per example, %marenostrum5.type% = pjm"

We can just make this change for 4.1.12 and, in other versions ( if we don't have more time), add a new function ( for example, when checking the platform's connectivity) that checks if the command exists. 

So, if marenostrum5 is slurm, the commands of pjm wouldn't be found, raising a critical.
