### PR TITLE
Update Docker build instructions (load) and use 4.1.12

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,8 +22,8 @@ into `id_rsa.pub`. Also copy the public key into `authorized_keys`.
 ## Build
 
 ```bash
-$ export AUTOSUBMIT_VERSION=4.1.9
-$ docker build \
+$ export AUTOSUBMIT_VERSION=4.1.12
+$ docker build load \
   --build-arg AUTOSUBMIT_VERSION=${AUTOSUBMIT_VERSION} \
   -t ${USER}/autosubmit:${AUTOSUBMIT_VERSION}-bullseye-slim \
   -t ${USER}/autosubmit:latest \


### PR DESCRIPTION
Docker has a new backend, BuildKit, which improves build process but also avoids loading images built automatically into the local registry.

So you must remember to [use `docker build load`](https://docs.docker.com/reference/cli/docker/buildx/build/#load) so that the image is available in `docker images` or when you run it.

Also updated the container version in the docs, although we don't have to do that for every release, as the `Dockerfile` is parametrized.