### PR TITLE
Remove --init from docker README

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,7 +52,7 @@ can be used to submit jobs to the other nodes (as it is normally
 configured with VM's submitting jobs to remote Slurm, PBS, etc.).
 
 ```bash
-$ docker run --rm --init ${USER}/autosubmit:latest \
+$ docker run --rm ${USER}/autosubmit:latest \
   autosubmit --version
 ```
 
@@ -113,7 +113,7 @@ or remote hosts (always via `ssh`).
 To start with SSH (see prerequisites note about SSH keys):
 
 ```bash
-$ docker run --rm --init \
+$ docker run --rm \
   -ti \
   -p 2222:22 \
   -e DISPLAY=$DISPLAY \
@@ -138,7 +138,7 @@ $ autosubmit create a000
 $ autosubmit run a000
 ```
 
-It is important to remember to start the container with `--init`
+It is important to know that this container uses `tini` as the init process
 so that Autosubmit jobs do not become defunct (zombie) processes
 inside the container.
 


### PR DESCRIPTION
There is a warning when following the README file of Docker:

```
[WARN  tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.
Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
```

This is because when you run `docker run --init`, Docker will use `docker-init` as the init process instead of the one defined by the image, which in our case is `tini`. We don't have to use the `-init` flag to avoid that warning.

This is not critical since `docker-init` is backed up by `tini` but it is nice to not have this warning anymore.