### PR TITLE
Rename submit_Script in platforms

### DIFF
--- a/autosubmit/platforms/ecplatform.py
+++ b/autosubmit/platforms/ecplatform.py
@@ -46,7 +46,7 @@ class EcPlatform(ParamikoPlatform):
     def get_checkAlljobs_cmd(self, jobs_id):
         pass
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         pass
 
     def __init__(self, expid, name, config, scheduler):

--- a/autosubmit/platforms/locplatform.py
+++ b/autosubmit/platforms/locplatform.py
@@ -36,7 +36,7 @@ class LocalPlatform(ParamikoPlatform):
     :type expid: str
     """
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         pass
 
     def parse_Alljobs_output(self, output, job_id):

--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -593,7 +593,7 @@ class ParamikoPlatform(Platform):
         self.send_command(check_energy_cmd)
         return self.get_ssh_output()
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         """
         Sends a Submitfile Script, exec in platform and retrieve the Jobs_ID.
         :param hold: send job hold

--- a/autosubmit/platforms/pbsplatform.py
+++ b/autosubmit/platforms/pbsplatform.py
@@ -37,7 +37,7 @@ class PBSPlatform(ParamikoPlatform):
     :type version: str
     """
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         pass
 
     def get_checkAlljobs_cmd(self, jobs_id):

--- a/autosubmit/platforms/pjmplatform.py
+++ b/autosubmit/platforms/pjmplatform.py
@@ -99,7 +99,7 @@ class PJMPlatform(ParamikoPlatform):
             valid_packages_to_submit = [ package for package in valid_packages_to_submit ]
             if len(valid_packages_to_submit) > 0:
                 try:
-                    jobs_id = self.submit_Script(hold=hold)
+                    jobs_id = self.submit_script_sbatch(hold=hold)
                 except AutosubmitError as e:
                     jobnames = [job.name for job in valid_packages_to_submit[0].jobs]
                     for jobname in jobnames:
@@ -189,7 +189,7 @@ class PJMPlatform(ParamikoPlatform):
         return None
 
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         # type: (bool) -> Union[List[str], str]
         """
         Sends a Submit file Script, execute it  in the platform and retrieves the Jobs_ID of all jobs at once.

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -812,7 +812,7 @@ class Platform(object):
         """ Opens Submit script file """
         raise NotImplementedError
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         # type: (bool) -> Union[List[str], str]
         """
         Sends a Submit file Script, execute it  in the platform and retrieves the Jobs_ID of all jobs at once.

--- a/autosubmit/platforms/psplatform.py
+++ b/autosubmit/platforms/psplatform.py
@@ -61,7 +61,7 @@ class PsPlatform(ParamikoPlatform):
     def create_a_new_copy(self):
         return PsPlatform(self.expid, self.name, self.config)
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         pass
 
     def update_cmds(self):

--- a/autosubmit/platforms/sgeplatform.py
+++ b/autosubmit/platforms/sgeplatform.py
@@ -62,7 +62,7 @@ class SgePlatform(ParamikoPlatform):
         self._pathdir = "\$HOME/LOG_" + self.expid
         self.update_cmds()
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         pass
 
     def update_cmds(self):

--- a/autosubmit/platforms/slurmplatform.py
+++ b/autosubmit/platforms/slurmplatform.py
@@ -105,7 +105,7 @@ class SlurmPlatform(ParamikoPlatform):
                 duplicated_jobs_already_checked = False
                 platform = valid_packages_to_submit[0].jobs[0].platform
                 try:
-                    jobs_id = self.submit_Script(hold=hold)
+                    jobs_id = self.submit_script_sbatch(hold=hold)
                 except AutosubmitError as e:
                     jobnames = []
                     duplicated_jobs_already_checked = True
@@ -259,7 +259,7 @@ class SlurmPlatform(ParamikoPlatform):
             else:
                 return None
 
-    def submit_Script(self, hold=False):
+    def submit_script_sbatch(self, hold=False):
         # type: (bool) -> Union[List[str], str]
         """
         Sends a Submit file Script, execute it  in the platform and retrieves the Jobs_ID of all jobs at once.

--- a/test/unit/test_pjm.py
+++ b/test/unit/test_pjm.py
@@ -174,9 +174,9 @@ def test_process_batch_ready_jobs_valid_packages_to_submit(mocker, pjm_platform,
     failed_packages = []
     pjm_platform.get_jobid_by_jobname = mocker.MagicMock()
     pjm_platform.send_command = mocker.MagicMock()
-    pjm_platform.submit_Script = mocker.MagicMock()
+    pjm_platform.submit_script_sbatch = mocker.MagicMock()
     jobs_id = [1, 2, 3]
-    pjm_platform.submit_Script.return_value = jobs_id
+    pjm_platform.submit_script_sbatch.return_value = jobs_id
     pjm_platform.process_batch_ready_jobs(valid_packages_to_submit, failed_packages)
     for i, package in enumerate(valid_packages_to_submit):
         for job in package.jobs:

--- a/test/unit/test_slurm_platform.py
+++ b/test/unit/test_slurm_platform.py
@@ -71,7 +71,7 @@ def test_slurm_platform_submit_script_raises_autosubmit_critical_with_trace(mock
     ]
 
     ae = AutosubmitError(message='invalid partition', code=123, trace='ERR!')
-    platform.submit_Script = mocker.MagicMock(side_effect=ae)
+    platform.submit_script_sbatch = mocker.MagicMock(side_effect=ae)
 
     # AS will handle the AutosubmitError above, but then raise an AutosubmitCritical.
     # This new error won't contain all the info from the upstream error.
@@ -155,9 +155,9 @@ def test_process_batch_ready_jobs_valid_packages_to_submit(mocker, slurm_platfor
     failed_packages = []
     slurm_platform.get_jobid_by_jobname = mocker.MagicMock()
     slurm_platform.send_command = mocker.MagicMock()
-    slurm_platform.submit_Script = mocker.MagicMock()
+    slurm_platform.submit_script_sbatch = mocker.MagicMock()
     jobs_id = [1, 2, 3]
-    slurm_platform.submit_Script.return_value = jobs_id
+    slurm_platform.submit_script_sbatch.return_value = jobs_id
     slurm_platform.process_batch_ready_jobs(valid_packages_to_submit, failed_packages)
     for i, package in enumerate(valid_packages_to_submit):
         for job in package.jobs:


### PR DESCRIPTION
Closes #2261. Avoids confusing naming of the `submit_Script` method in platforms, to not be confused with `submit_job`