### PR TITLE
Timestamps fixes

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1143,10 +1143,10 @@ class Job(object):
             int: Value in the index position, or 0 if the file or index does not exist.
         """
         if fail_count == -1:
-            logname = os.path.join(self._tmp_path, f"{self.stat_file}0")
+            logname = os.path.join(self._log_path, f"{self.stat_file}0")
         else:
             fail_count = str(fail_count)
-            logname = os.path.join(self._tmp_path, f"{self.stat_file}{fail_count}")
+            logname = os.path.join(self._log_path, f"{self.stat_file}{fail_count}")
         if os.path.exists(logname):
             lines = open(logname).readlines()
             if len(lines) >= index + 1:
@@ -1353,8 +1353,8 @@ class Job(object):
             self.update_local_logs(update_submit_time=False)
             self.platform.get_stat_file(self)
             self.write_submit_time()
-            self.write_start_time()
-            self.write_end_time(self.status == Status.COMPLETED)
+            self.write_start_time(count=self.fail_count)
+            self.write_end_time(self.status == Status.COMPLETED, self.fail_count)
             # Update the logs with Autosubmit Job ID Brand
             try:
                 for local_log in self.local_logs:

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -243,7 +243,7 @@ class Job(object):
         self._local_logs = ('', '')
         self._remote_logs = ('', '')
         self.script_name = self.name + ".cmd"
-        self.stat_file = self.script_name[:-4] + "_STAT_0"
+        self.stat_file = self.script_name[:-4] + "_STAT_"
         self._status = None
         self.status = status
         self.prev_status = status

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1143,10 +1143,10 @@ class Job(object):
             int: Value in the index position, or 0 if the file or index does not exist.
         """
         if fail_count == -1:
-            logname = os.path.join(self._tmp_path, self.stat_file)
+            logname = os.path.join(self._tmp_path, f"{self.stat_file}0")
         else:
             fail_count = str(fail_count)
-            logname = os.path.join(self._tmp_path, self.name + '_STAT_' + fail_count)
+            logname = os.path.join(self._tmp_path, f"{self.stat_file}{fail_count}")
         if os.path.exists(logname):
             lines = open(logname).readlines()
             if len(lines) >= index + 1:
@@ -1154,6 +1154,7 @@ class Job(object):
             else:
                 return 0
         else:
+            Log.warning(f"Log file {logname} does not exist")
             return 0
 
     def _get_from_total_stats(self, index):

--- a/test/integration/test_run_command_integration.py
+++ b/test/integration/test_run_command_integration.py
@@ -226,9 +226,9 @@ def check_db_fields(run_tmpdir, expected_entries, final_status) -> dict:
         db_check_list["JOB_DATA_FIELDS"][row_dict["job_name"]][str(counter_by_name[row_dict["job_name"]])][
             "empty_fields"] = " ".join(empty_fields)
         counter_by_name[row_dict["job_name"]] += 1
-        last_times[row_dict["job_name"]]["submit"] = row_dict["submit"]
-        last_times[row_dict["job_name"]]["start"] = row_dict["start"]
-        last_times[row_dict["job_name"]]["finish"] = row_dict["finish"]
+        last_times[row_dict["job_name"]]["submit"] = int(row_dict["submit"])
+        last_times[row_dict["job_name"]]["start"] = int(row_dict["start"])
+        last_times[row_dict["job_name"]]["finish"] = int(row_dict["finish"])
     print_db_results(db_check_list, rows_as_dicts, run_tmpdir)
     c.close()
     conn.close()

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -459,7 +459,7 @@ CONFIG:
                 experiment_data.flush()
             # For could be added here to cover more configurations options
             with open(Path(temp_dir, f'{expid}/conf/hetjob.yml'), 'w+') as hetjob:
-                hetjob.write(dedent(f'''\
+                hetjob.write(dedent('''\
                             JOBS:
                                 HETJOB_A:
                                     FILE: a
@@ -905,7 +905,7 @@ CONFIG:
                     template_content, additional_templates = job.update_content(config, parameters)
                     assert not additional_templates
 
-                    assert f'#SBATCH --reservation' not in template_content
+                    assert '#SBATCH --reservation' not in template_content
                 else:
                     assert reservation == parameters['JOBS.A.RESERVATION']
 

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -1898,17 +1898,16 @@ def test_get_from_stat(tmpdir, file_exists, index_timestamp, fail_count, expecte
 
     job = Job("dummy", 1, Status.WAITING, 0)
     assert job.stat_file == f"{job.name}_STAT_"
-    job._tmp_path = Path(tmpdir)
-    job._tmp_path.mkdir(parents=True, exist_ok=True)
+    job._log_path = Path(tmpdir)
+    job._log_path.mkdir(parents=True, exist_ok=True)
 
     # Generating the timestamp file
     if file_exists:
-        with open(job._tmp_path.joinpath(f"{job.stat_file}0"), "w") as stat_file:
+        with open(job._log_path.joinpath(f"{job.stat_file}0"), "w") as stat_file:
             stat_file.write("19704923\n19704924\n")
-        with open(job._tmp_path.joinpath(f"{job.stat_file}1"), "w") as stat_file:
+        with open(job._log_path.joinpath(f"{job.stat_file}1"), "w") as stat_file:
             stat_file.write("29704923\n29704924\n")
 
-    # Act
     if fail_count is None:
         result = job._get_from_stat(index_timestamp)
     else:

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -1895,12 +1895,13 @@ def _check_parents_array(job, assertions, jobs):
     ],
 )
 def test_get_from_stat(tmpdir, file_exists, index_timestamp, fail_count, expected):
-    # Arrange
+
     job = Job("dummy", 1, Status.WAITING, 0)
     assert job.stat_file == f"{job.name}_STAT_"
     job._tmp_path = Path(tmpdir)
     job._tmp_path.mkdir(parents=True, exist_ok=True)
 
+    # Generating the timestamp file
     if file_exists:
         with open(job._tmp_path.joinpath(f"{job.stat_file}0"), "w") as stat_file:
             stat_file.write("19704923\n19704924\n")
@@ -1913,5 +1914,4 @@ def test_get_from_stat(tmpdir, file_exists, index_timestamp, fail_count, expecte
     else:
         result = job._get_from_stat(index_timestamp, fail_count)
 
-    # Assert
     assert result == expected


### PR DESCRIPTION
Instead of getting the job start and finish timestamp from the timestamp files, Autosubmit was always using the fallback values.

~This was happening only when job.fail_count == 0~ 

EDIT: For retrials, it was looking at tmp folder instead of tmp/Log_$expid

Closes #2275 

