### PR TITLE
Update details on expid/delete

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -26,6 +26,7 @@ from ruamel.yaml import YAML
 from typing import Dict, Set, Tuple, Union, Any, List, Optional
 
 from autosubmit.database.db_common import update_experiment_descrip_version
+from autosubmit.experiment.detail_updater import ExperimentDetails
 from autosubmit.helpers.utils import strtobool
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
@@ -1445,6 +1446,12 @@ class Autosubmit:
             except Exception:
                 pass
             raise AutosubmitCritical(f"Error while setting the default values: {str(e)}", 7011)
+        
+        # Try to update the experiment details
+        try:
+            ExperimentDetails(exp_id).save_update_details()
+        except Exception:
+            pass
 
         Log.result(f"Experiment {exp_id} created")
         return exp_id
@@ -1469,6 +1476,13 @@ class Autosubmit:
         if experiment_path.exists():
             if force or Autosubmit._user_yes_no_query(f"Do you want to delete {expid} ?"):
                 Log.debug('Enter Autosubmit._delete_expid {0}', expid)
+                
+                # Try to delete the experiment details
+                try:
+                    ExperimentDetails(expid).delete_details()
+                except Exception:
+                    pass
+
                 try:
                     return Autosubmit._delete_expid(expid, force)
                 except AutosubmitCritical as e:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1451,7 +1451,7 @@ class Autosubmit:
         try:
             ExperimentDetails(exp_id).save_update_details()
         except Exception:
-            pass
+            Log.warning(f"Could not update experiment details for {exp_id}. Omitting this step.")
 
         Log.result(f"Experiment {exp_id} created")
         return exp_id

--- a/autosubmit/experiment/detail_updater.py
+++ b/autosubmit/experiment/detail_updater.py
@@ -1,5 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
 import datetime
-import os
+import pwd
 from pathlib import Path
 import sqlite3
 from autosubmit.database.db_common import get_experiment_id
@@ -12,6 +31,13 @@ LOCAL_TZ = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
 
 
 class ExperimentDetailsRepository:
+    """
+    Class to manage the experiment details in a SQLite database.
+    This class is responsible for creating the database, creating the
+    table, and providing methods to insert, update, delete, and retrieve
+    experiment details.
+    """
+
     def __init__(self):
         self.db_path = Path(BasicConfig.DB_PATH)
 
@@ -95,6 +121,10 @@ class ExperimentDetailsRepository:
 
 
 class ExperimentDetails:
+    """
+    Class to manage the experiment details.
+    """
+
     def __init__(self, expid: str, init_reload: bool = True):
         self.expid = expid
         self._details_repo = ExperimentDetailsRepository()
@@ -102,6 +132,9 @@ class ExperimentDetails:
             self.reload()
 
     def reload(self):
+        """
+        Reload the necessary components to get the experiment details.
+        """
         # Build path stat
         self.exp_path = Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(self.expid)
         self.exp_dir_stat = self.exp_path.stat()
@@ -114,48 +147,69 @@ class ExperimentDetails:
         self.as_conf.reload()
 
     def save_update_details(self):
+        """
+        Save the details of the experiment to the database.
+        This method will upsert the details into the database.
+        """
         # Upsert the details into the database
         self._details_repo.upsert_details(
             self.exp_id, self.user, self.created, self.model, self.branch, self.hpc
         )
 
     def delete_details(self):
+        """
+        Delete the details of the experiment from the database.
+        """
         self._details_repo.delete_details(self.exp_id)
 
     @property
     def user(self) -> str:
-        stdout = os.popen("id -nu {0}".format(str(int(self.exp_dir_stat.st_uid))))
-        owner_name = stdout.read().strip()
-        return str(owner_name)
+        """
+        Get the user that created the experiment. This is obtained from the
+        experiment directory stat information.
+        """
+        return pwd.getpwuid(self.exp_dir_stat.st_uid).pw_name
 
     @property
     def created(self) -> str:
+        """
+        Get the creation date of the experiment. This is obtained from the
+        experiment directory stat information.
+        """
         return datetime.datetime.fromtimestamp(
             int(self.exp_dir_stat.st_ctime), tz=LOCAL_TZ
         ).isoformat()
 
     @property
     def model(self) -> str:
+        """
+        Get the model of the experiment. This is obtained from the
+        Autosubmit configuration.
+        """
         project_type = self.as_conf.get_project_type()
         if project_type == "git":
             return self.as_conf.get_git_project_origin()
-        elif project_type == "svn":
-            return self.as_conf.get_svn_project_url()
         else:
             return "NA"
 
     @property
     def branch(self) -> str:
+        """
+        Get the branch of the experiment. This is obtained from the
+        Autosubmit configuration.
+        """
         project_type = self.as_conf.get_project_type()
         if project_type == "git":
             return self.as_conf.get_git_project_branch()
-        elif project_type == "svn":
-            return self.as_conf.get_svn_project_url()
         else:
             return "NA"
 
     @property
     def hpc(self) -> str:
+        """
+        Get the HPC of the experiment. This is obtained from the
+        Autosubmit configuration.
+        """
         try:
             return self.as_conf.get_platform()
         except Exception:

--- a/autosubmit/experiment/detail_updater.py
+++ b/autosubmit/experiment/detail_updater.py
@@ -1,0 +1,158 @@
+import datetime
+import os
+from pathlib import Path
+import sqlite3
+from autosubmit.database.db_common import get_experiment_id
+from autosubmitconfigparser.config.configcommon import AutosubmitConfig
+from autosubmitconfigparser.config.basicconfig import BasicConfig
+from autosubmitconfigparser.config.yamlparser import YAMLParserFactory
+
+
+LOCAL_TZ = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+
+
+class ExperimentDetailsRepository:
+    def __init__(self):
+        self.db_path = Path(BasicConfig.DB_PATH)
+
+        with sqlite3.connect(self.db_path) as conn:
+            # Create the details table if it does not exist
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS details (
+                    exp_id INTEGER NOT NULL, 
+                    user TEXT NOT NULL, 
+                    created TEXT NOT NULL, 
+                    model TEXT NOT NULL, 
+                    branch TEXT NOT NULL, 
+                    hpc TEXT NOT NULL
+                );
+                """
+            )
+            conn.commit()
+
+    def get_details(self, exp_id: int):
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT exp_id, user, created, model, branch, hpc
+                FROM details
+                WHERE exp_id = ?;
+                """,
+                (exp_id,),
+            )
+
+            result = cursor.fetchone()
+            if result:
+                return {
+                    "exp_id": result[0],
+                    "user": result[1],
+                    "created": result[2],
+                    "model": result[3],
+                    "branch": result[4],
+                    "hpc": result[5],
+                }
+            else:
+                return None
+
+    def upsert_details(
+        self, exp_id: int, user: str, created: str, model: str, branch: str, hpc: str
+    ):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                DELETE FROM details
+                WHERE exp_id = ?;
+                """,
+                (exp_id,),
+            )
+            conn.execute(
+                """
+                INSERT INTO details (exp_id, user, created, model, branch, hpc)
+                VALUES (?, ?, ?, ?, ?, ?);
+                """,
+                (
+                    exp_id,
+                    user,
+                    created,
+                    model,
+                    branch,
+                    hpc,
+                ),
+            )
+            conn.commit()
+
+    def delete_details(self, exp_id: int):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                DELETE FROM details
+                WHERE exp_id = (?);
+                """,
+                (exp_id,),
+            )
+            conn.commit()
+
+
+class ExperimentDetails:
+    def __init__(self, expid: str, init_reload: bool = True):
+        self.expid = expid
+        self._details_repo = ExperimentDetailsRepository()
+        if init_reload:
+            self.reload()
+
+    def reload(self):
+        # Build path stat
+        self.exp_path = Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(self.expid)
+        self.exp_dir_stat = self.exp_path.stat()
+
+        # Get experiment id
+        self.exp_id: int = get_experiment_id(self.expid)
+
+        # Get experiment config
+        self.as_conf = AutosubmitConfig(self.expid, BasicConfig, YAMLParserFactory())
+
+    def save_update_details(self):
+        # Upsert the details into the database
+        self._details_repo.upsert_details(
+            self.exp_id, self.user, self.created, self.model, self.branch, self.hpc
+        )
+
+    def delete_details(self):
+        self._details_repo.delete_details(self.exp_id)
+
+    @property
+    def user(self) -> str:
+        stdout = os.popen("id -nu {0}".format(str(int(self.exp_dir_stat.st_uid))))
+        owner_name = stdout.read().strip()
+        return str(owner_name)
+
+    @property
+    def created(self) -> str:
+        return datetime.datetime.fromtimestamp(
+            int(self.exp_dir_stat.st_ctime), tz=LOCAL_TZ
+        ).isoformat()
+
+    @property
+    def model(self) -> str:
+        project_type = self.as_conf.get_project_type()
+        if project_type == "git":
+            return self.as_conf.get_git_project_origin()
+        elif project_type == "svn":
+            return self.as_conf.get_svn_project_url()
+        else:
+            return "NA"
+
+    @property
+    def branch(self) -> str:
+        project_type = self.as_conf.get_project_type()
+        if project_type == "git":
+            return self.as_conf.get_git_project_branch()
+        elif project_type == "svn":
+            return self.as_conf.get_svn_project_url()
+        else:
+            return "NA"
+
+    @property
+    def hpc(self) -> str:
+        return self.as_conf.get_platform()

--- a/autosubmit/experiment/detail_updater.py
+++ b/autosubmit/experiment/detail_updater.py
@@ -111,6 +111,7 @@ class ExperimentDetails:
 
         # Get experiment config
         self.as_conf = AutosubmitConfig(self.expid, BasicConfig, YAMLParserFactory())
+        self.as_conf.reload()
 
     def save_update_details(self):
         # Upsert the details into the database
@@ -155,4 +156,7 @@ class ExperimentDetails:
 
     @property
     def hpc(self) -> str:
-        return self.as_conf.get_platform()
+        try:
+            return self.as_conf.get_platform()
+        except Exception:
+            return "NA"

--- a/test/unit/test_detail_updater.py
+++ b/test/unit/test_detail_updater.py
@@ -23,12 +23,6 @@ def test_details_properties():
     assert exp_details.model == "my_git_origin"
     assert exp_details.branch == "my_git_branch"
 
-    mock_as_conf.get_project_type.return_value = "svn"
-    mock_as_conf.get_svn_project_url.return_value = "my_svn_origin"
-
-    assert exp_details.model == "my_svn_origin"
-    assert exp_details.branch == "my_svn_origin"
-
 
 def test_details_repository(tmpdir):
     with patch("autosubmit.experiment.detail_updater.BasicConfig") as mock_basic_config:

--- a/test/unit/test_detail_updater.py
+++ b/test/unit/test_detail_updater.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+from autosubmit.experiment.detail_updater import (
+    ExperimentDetails,
+    ExperimentDetailsRepository,
+)
+
+
+def test_details_properties():
+    exp_details = ExperimentDetails("a000", init_reload=False)
+
+    exp_details.exp_id = 0
+
+    mock_as_conf = MagicMock()
+    mock_as_conf.get_project_type.return_value = "git"
+    mock_as_conf.get_git_project_origin.return_value = "my_git_origin"
+    mock_as_conf.get_git_project_branch.return_value = "my_git_branch"
+    mock_as_conf.get_platform.return_value = "my_platform"
+
+    exp_details.as_conf = mock_as_conf
+
+    assert exp_details.hpc == "my_platform"
+
+    assert exp_details.model == "my_git_origin"
+    assert exp_details.branch == "my_git_branch"
+
+    mock_as_conf.get_project_type.return_value = "svn"
+    mock_as_conf.get_svn_project_url.return_value = "my_svn_origin"
+
+    assert exp_details.model == "my_svn_origin"
+    assert exp_details.branch == "my_svn_origin"
+
+
+def test_details_repository(tmpdir):
+    with patch("autosubmit.experiment.detail_updater.BasicConfig") as mock_basic_config:
+        mock_basic_config.DB_PATH = str(tmpdir / "test_details_repository.db")
+
+        details_repo = ExperimentDetailsRepository()
+
+        new_data = {
+            "exp_id": 10,
+            "user": "foo",
+            "created": "2024-04-11T13:34:41+02:00",
+            "model": "my_model",
+            "branch": "NA",
+            "hpc": "MN5",
+        }
+
+        # Insert data
+        details_repo.upsert_details(
+            exp_id=new_data["exp_id"],
+            user=new_data["user"],
+            created=new_data["created"],
+            model=new_data["model"],
+            branch=new_data["branch"],
+            hpc=new_data["hpc"],
+        )
+        result = details_repo.get_details(new_data["exp_id"])
+        assert result == new_data
+
+        # Update data
+        updated_data = {
+            "exp_id": 10,
+            "user": "bar",
+            "created": "2024-04-11T13:34:41+02:00",
+            "model": "my_model",
+            "branch": "NA",
+            "hpc": "MN5",
+        }
+        details_repo.upsert_details(
+            exp_id=updated_data["exp_id"],
+            user=updated_data["user"],
+            created=updated_data["created"],
+            model=updated_data["model"],
+            branch=updated_data["branch"],
+            hpc=updated_data["hpc"],
+        )
+        result = details_repo.get_details(updated_data["exp_id"])
+        assert result == updated_data
+
+        # Delete data
+        details_repo.delete_details(updated_data["exp_id"])
+        result = details_repo.get_details(updated_data["exp_id"])
+        assert result is None


### PR DESCRIPTION
PR related to #2089

It makes `autosubmit expid` and `autosubmit delete` update the `details` table, which is used in the API.

This change, plus the one done in https://github.com/BSC-ES/autosubmit-api/issues/168 will keep the experiment detail data consistent.