### PR TITLE
Fix parser mutually exclusive actions for operational and evaluation experiments

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1384,7 +1384,7 @@ class Autosubmit:
                 raise AutosubmitCritical(f"Experiment {copy_id} doesn't exists", 7011)
             if minimal_configuration:
                 conf_dir = Path(copy_id_folder) / "conf"
-                if Path(conf_dir, 'minimal.yml').exists() or Path(conf_dir, 'minimal.yaml').exists():
+                if not Path(conf_dir / 'minimal.yml').is_file() and not Path(conf_dir / 'minimal.yaml').is_file():
                     raise AutosubmitCritical(
                             "Cannot copy an experiment that does not have a minimal.yml file", 7011)
             exp_id = copy_experiment(copy_id, description, Autosubmit.autosubmit_version, testcase, operational,

--- a/test/integration/test_expid.py
+++ b/test/integration/test_expid.py
@@ -90,7 +90,6 @@ def test_copy_minimal(has_min_yaml, autosubmit_exp, autosubmit):
     )
     
     minimal_file = Path(BasicConfig.LOCAL_ROOT_DIR) / expid / "conf" / "minimal.yml"
-
     if has_min_yaml:
         minimal_file.write_text("test")
         expid2 = autosubmit.expid(


### PR DESCRIPTION
Operational (op) and evaluation (ev) experiments cannot be created with `--copy` or `--minimal` arguments. This PR addresses this and redefines the mutual exclusion relationships between some `expid` command arguments
Closes #2280 