### PR TITLE
Remove wheel from our build-system requires in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Closes #2318 

See also: https://old.reddit.com/r/Python/comments/1jwbymm/psa_you_should_remove_wheel_from_your/ & https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend