### PR TITLE
Shared user fix and enable logs for log_process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improved validation for the `expid` flag. [PR](https://github.com/BSC-ES/autosubmit/pull/2309)
 - Made the details database more consistent and reliable. [PR](https://github.com/BSC-ES/autosubmit/pull/2296)
 - Enhanced the flexibility of workflows, allowing for more adaptable configurations. [#2276](https://github.com/BSC-ES/autosubmit/issues/2276)
+- Improved the log recovery logs. [PR](https://github.com/BSC-ES/autosubmit/pull/2341)
 
 **New features:**
 - Added support for `%^%` variables to improve template customization. [PR](https://github.com/BSC-ES/autosubmit/pull/2288), [Docs](https://autosubmit.readthedocs.io/en/latest/userguide/templates.html#sustitute-placeholders-after-all-files-have-been-loaded)

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -23,9 +23,9 @@ if TYPE_CHECKING:
 
 
 def _init_logs_log_process(as_conf, platform_name):
-    Log.set_console_level("INFO")
+    Log.set_console_level(as_conf.experiment_data["LOG_RECOVERY_CONSOLE_LEVEL"])
     aslogs_path = Path(as_conf.experiment_data["ROOTDIR"], "tmp/ASLOGS")
-    Log.set_file(aslogs_path.joinpath(f'{platform_name.lower()}_log_recovery.log'), "out", "EVERYTHING")
+    Log.set_file(aslogs_path.joinpath(f'{platform_name.lower()}_log_recovery.log'), "out", as_conf.experiment_data["LOG_RECOVERY_FILE_LEVEL"])
     Log.set_file(aslogs_path.joinpath(f'{platform_name.lower()}_log_recovery_err.log'), "err")
 
 
@@ -60,8 +60,9 @@ def recover_platform_job_logs_wrapper(
         "AS_ENV_SSH_CONFIG_PATH": as_conf.experiment_data.get("AS_ENV_SSH_CONFIG_PATH", None),
         "AS_ENV_CURRENT_USER": as_conf.experiment_data.get("AS_ENV_CURRENT_USER", None),
         "ROOTDIR": as_conf.experiment_data.get("ROOTDIR", None),
+        "LOG_RECOVERY_CONSOLE_LEVEL": as_conf.experiment_data.get("LOG_RECOVERY_CONSOLE_LEVEL", "DEBUG"),
+        "LOG_RECOVERY_FILE_LEVEL": as_conf.experiment_data.get("LOG_RECOVERY_FILE_LEVEL", "EVERYTHING"),
     }
-    _init_logs_log_process(as_conf, platform.name)
     platform.recover_platform_job_logs(as_conf)
     _exit(0)  # Exit userspace after manually closing ssh sockets, recommended for child processes, the queue() and shared signals should be in charge of the main process.
 
@@ -1115,6 +1116,7 @@ class Platform(object):
         Recovers the logs of the jobs that have been submitted.
         When this is executed as a process, the exit is controlled by the work_event and cleanup_events of the main process.
         """
+        _init_logs_log_process(as_conf, self.name)
         setproctitle.setproctitle(f"autosubmit log {self.expid} recovery {self.name.lower()}")
         identifier = f"{self.name.lower()}(log_recovery):"
         try:

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -1,11 +1,15 @@
 import atexit
 import multiprocessing
 import queue  # only for the exception
+from contextlib import suppress
 from os import _exit
 import setproctitle
 import locale
 import os
 import traceback
+
+from pathlib import Path
+
 from autosubmit.job.job_common import Status
 from typing import List, Union, Set, Any, TYPE_CHECKING
 from autosubmit.helpers.parameters import autosubmit_parameter
@@ -16,6 +20,13 @@ import time
 
 if TYPE_CHECKING:
     from autosubmitconfigparser.config.configcommon import AutosubmitConfig
+
+
+def _init_logs_log_process(as_conf, platform_name):
+    Log.set_console_level("INFO")
+    aslogs_path = Path(as_conf.experiment_data["ROOTDIR"], "tmp/ASLOGS")
+    Log.set_file(aslogs_path.joinpath(f'{platform_name.lower()}_log_recovery.log'), "out", "EVERYTHING")
+    Log.set_file(aslogs_path.joinpath(f'{platform_name.lower()}_log_recovery_err.log'), "err")
 
 
 def recover_platform_job_logs_wrapper(
@@ -47,10 +58,15 @@ def recover_platform_job_logs_wrapper(
     as_conf.experiment_data = {
         "AS_ENV_PLATFORMS_PATH": as_conf.experiment_data.get("AS_ENV_PLATFORMS_PATH", None),
         "AS_ENV_SSH_CONFIG_PATH": as_conf.experiment_data.get("AS_ENV_SSH_CONFIG_PATH", None),
+        "AS_ENV_CURRENT_USER": as_conf.experiment_data.get("AS_ENV_CURRENT_USER", None),
         "ROOTDIR": as_conf.experiment_data.get("ROOTDIR", None),
     }
+    _init_logs_log_process(as_conf, platform.name)
     platform.recover_platform_job_logs(as_conf)
     _exit(0)  # Exit userspace after manually closing ssh sockets, recommended for child processes, the queue() and shared signals should be in charge of the main process.
+
+
+
 
 class CopyQueue(Queue):
     """
@@ -1099,7 +1115,6 @@ class Platform(object):
         Recovers the logs of the jobs that have been submitted.
         When this is executed as a process, the exit is controlled by the work_event and cleanup_events of the main process.
         """
-        Log.get_logger("Autosubmit")  # Log needs to be initialised in the new process
         setproctitle.setproctitle(f"autosubmit log {self.expid} recovery {self.name.lower()}")
         identifier = f"{self.name.lower()}(log_recovery):"
         try:
@@ -1120,7 +1135,9 @@ class Platform(object):
             Log.error(f"{identifier} {e}")
             Log.debug(traceback.format_exc())
 
-        self.closeConnection()
+        with suppress(Exception):
+            self.closeConnection()
+
         Log.info(f"{identifier} Exiting.")
         _exit(0)  # Exit userspace after manually closing ssh sockets, recommended for child processes, the queue() and shared signals should be in charge of the main process.
 

--- a/docs/source/userguide/configure/develop_a_project.rst
+++ b/docs/source/userguide/configure/develop_a_project.rst
@@ -139,6 +139,8 @@ Autosubmit configuration
         OUTPUT:pdf
         WRAPPERS_WALLCLOCK: 48:00  # Default max_wallclock for wrappers before getting killed
         JOB_WALLCLOCK: 24:00  # Default max_wallclock for jobs before getting killed
+        LOG_RECOVERY_CONSOLE_LEVEL: "DEBUG"  # Default log level for console output for the log recovery process.
+        LOG_RECOVERY_FILE_LEVEL: "EVERYTHING"  # Default log level for file output for the log recovery process.
     # wrapper definition
     wrappers:
         wrapper_1_v_example:

--- a/docs/source/userguide/configure/index.rst
+++ b/docs/source/userguide/configure/index.rst
@@ -344,7 +344,7 @@ There are some other parameters that you may need to specify:
     :widths: 25 75
     :header-rows: 1
 
-    * - Paramter
+    * - Parameter
       - Description
     * - ``BUDGET``
       - Budget account for the machine scheduler. If omitted, takes the value defined in ``PROJECT``


### PR DESCRIPTION
**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).

Adds a log, and the other issue was a missing variable. 

- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).

This solves:

* a bug in the auth, derived from wrongly removing a as_conf parameter needed for the connect ( it doesn't send the full as_conf.experiment_data to save memory) 
* Now the log process is visible in the logs

```
-rwxrwxr-x 1 dbeltran dbeltran    0 May  5 10:21 20250505_102058_lumi_log_recovery_err.log*
drwxr-xr-x 2 dbeltran dbeltran 4.0K May  5 10:21 ./
-rwxrwxr-x 1 dbeltran dbeltran  200 May  5 10:21 20250505_102058_lumi_log_recovery.log*
```

