### PR TITLE
Fix brittle test_details_updater (from Postgres branch)

### DIFF
--- a/test/unit/test_detail_updater.py
+++ b/test/unit/test_detail_updater.py
@@ -5,7 +5,10 @@ from autosubmit.experiment.detail_updater import (
 )
 
 
-def test_details_properties():
+def test_details_properties(mocker):
+    # TODO: mocked create_experiment_details_repository as it fails intermittently with
+    #       sqlite3.OperationalError: unable to open database file
+    mocker.patch('autosubmit.experiment.detail_updater.ExperimentDetailsRepository')
     exp_details = ExperimentDetails("a000", init_reload=False)
 
     exp_details.exp_id = 0


### PR DESCRIPTION
From https://github.com/BSC-ES/autosubmit/pull/2187/files#r2079053784

We have seen this test failing intermittently in the past few days. Saw this in the postgres branch too but wasn't sure if that was happening everytime/where.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
