### PR TITLE
Reduce the total running time of test_expid (~10s)

### DIFF
--- a/test/unit/test_expid.py
+++ b/test/unit/test_expid.py
@@ -23,6 +23,7 @@ from contextlib import contextmanager
 import pytest
 
 from autosubmit.autosubmit import Autosubmit
+from autosubmit.database import db_common
 from log.log import AutosubmitCritical
 
 
@@ -58,8 +59,9 @@ def test_expid(mocker, copy_id, expected, tmp_path, autosubmit_config, monkeypat
     """
     current_experiment_id = "empty"
 
+    monkeypatch.setattr(db_common, 'TIMEOUT', 1)
+
     db_common_mock = mocker.patch('autosubmit.experiment.experiment_common.db_common')
-    monkeypatch.setattr(db_common_mock, 'TIMEOUT', 2)
     build_db_mock(current_experiment_id, db_common_mock, mocker)
 
     basic_config = autosubmit_config('a000').basic_config

--- a/test/unit/test_expid.py
+++ b/test/unit/test_expid.py
@@ -48,7 +48,7 @@ def build_db_mock(current_experiment_id, mock_db_common, mocker):
     ('', does_not_raise()),
     ('test', pytest.raises(AutosubmitCritical))
 ], ids=['success', 'fail'])
-def test_expid(mocker, copy_id, expected, tmp_path, autosubmit_config) -> None:
+def test_expid(mocker, copy_id, expected, tmp_path, autosubmit_config, monkeypatch) -> None:
     """
     Function to test if the autosubmit().expid generates the paths and expid properly
 
@@ -57,8 +57,11 @@ def test_expid(mocker, copy_id, expected, tmp_path, autosubmit_config) -> None:
     :return: None
     """
     current_experiment_id = "empty"
+
     db_common_mock = mocker.patch('autosubmit.experiment.experiment_common.db_common')
+    monkeypatch.setattr(db_common_mock, 'TIMEOUT', 2)
     build_db_mock(current_experiment_id, db_common_mock, mocker)
+
     basic_config = autosubmit_config('a000').basic_config
     basic_config.STRUCTURES_DIR = basic_config.LOCAL_ROOT_DIR = str(tmp_path)
     basic_config.JOBDATA_DIR = str(tmp_path)


### PR DESCRIPTION
closes #2355

Test has a problem in which due to an expected failure it is taking 10+ seconds to be finished looking for a way to mitigate this time to reasonable execution time