### PR TITLE
Update EDITO demo container to install API in different environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Made the details database more consistent and reliable. [PR](https://github.com/BSC-ES/autosubmit/pull/2296)
 - Enhanced the flexibility of workflows, allowing for more adaptable configurations. [#2276](https://github.com/BSC-ES/autosubmit/issues/2276)
 - Improved the log recovery logs. [PR](https://github.com/BSC-ES/autosubmit/pull/2341)
+- EDITO Autosubmit-Demo container updated to install API in different environment [#2398](https://github.com/BSC-ES/autosubmit/issues/2398)
 
 **New features:**
 - Added support for `%^%` variables to improve template customization. [PR](https://github.com/BSC-ES/autosubmit/pull/2288), [Docs](https://autosubmit.readthedocs.io/en/latest/userguide/templates.html#sustitute-placeholders-after-all-files-have-been-loaded)

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -10,26 +10,26 @@ RUN  sudo ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime &&\
 
 # Install Autosubmit
 ARG AUTOSUBMIT_VERSION=4.1.14
-ARG AUTOSUBMIT_API_VERSION=4.1.0b1
+ARG AUTOSUBMIT_GIT_REF
+ARG AUTOSUBMIT_API_VERSION=4.1.0
+ARG AUTOSUBMIT_API_GIT_REF
 
-RUN pip3 install \
-    autosubmit==${AUTOSUBMIT_VERSION} \
-    jupyterlab
+RUN pip3 install --upgrade pip &&\
+    pip3 install jupyterlab \
+    $( [ -n "${AUTOSUBMIT_GIT_REF}" ] && echo "git+https://github.com/BSC-ES/autosubmit.git@${AUTOSUBMIT_GIT_REF}" || echo "autosubmit==${AUTOSUBMIT_VERSION}" )
+
 
 WORKDIR /apps
 
 # Create virtual environment for the Autosubmit API
 RUN python3 -m venv /apps/autosubmit-api &&\
     /apps/autosubmit-api/bin/pip install --upgrade pip &&\
-    /apps/autosubmit-api/bin/pip install autosubmit-api==${AUTOSUBMIT_API_VERSION}
+    /apps/autosubmit-api/bin/pip install \
+    $( [ -n "${AUTOSUBMIT_API_GIT_REF}" ] && echo "git+https://github.com/BSC-ES/autosubmit-api.git@${AUTOSUBMIT_API_GIT_REF}" || echo "autosubmit-api==${AUTOSUBMIT_API_VERSION}" )
 
 # Set the environment variables
 ENV PROTECTION_LEVEL=NONE
 ENV JUPYTER_TOKEN=""
-
-# Install Autosubmit
-RUN autosubmit configure &&\
-    autosubmit install
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -9,13 +9,19 @@ RUN  sudo ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime &&\
      sudo rm -rf /var/lib/apt/lists/*
 
 # Install Autosubmit
-ARG AUTOSUBMIT_VERSION=4.1.10
-ARG AUTOSUBMIT_API_VERSION=4.0.0
+ARG AUTOSUBMIT_VERSION=4.1.14
+ARG AUTOSUBMIT_API_VERSION=4.1.0b1
 
 RUN pip3 install \
     autosubmit==${AUTOSUBMIT_VERSION} \
-    autosubmit-api==${AUTOSUBMIT_API_VERSION} \
     jupyterlab
+
+WORKDIR /apps
+
+# Create virtual environment for the Autosubmit API
+RUN python3 -m venv /apps/autosubmit-api &&\
+    /apps/autosubmit-api/bin/pip install --upgrade pip &&\
+    /apps/autosubmit-api/bin/pip install autosubmit-api==${AUTOSUBMIT_API_VERSION}
 
 # Set the environment variables
 ENV PROTECTION_LEVEL=NONE

--- a/docker/demo/entrypoint.sh
+++ b/docker/demo/entrypoint.sh
@@ -11,4 +11,4 @@ else
 fi
 
 # Run the command passed by docker run
-autosubmit_api start -b 0.0.0.0:8000
+/apps/autosubmit-api/bin/autosubmit_api start -b 0.0.0.0:8000

--- a/docker/demo/entrypoint.sh
+++ b/docker/demo/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Prepare Autosubmit
+autosubmit configure
+autosubmit install
+
 # Execute /load_ssh_private_key.sh
 /load_ssh_private_key.sh
 


### PR DESCRIPTION
@kinow here is a tiny PR to install the API in a different environment than Autosubmit to prevent version conflicts because of the hard dependency the API now has with Autosubmit version 4.1.11

This should be enough to update our container with the latest version of both packages.

Note: I'm planning to release version 4.1.0 of the API, which will be a version before introducing Postgres. So, maybe I'll replace the default `AUTOSUBMIT_API_VERSION` later.