### PR TITLE
[Documentation] Mapping docs (no tilde expansion)

### DIFF
--- a/docs/source/userguide/user_mapping.rst
+++ b/docs/source/userguide/user_mapping.rst
@@ -56,9 +56,12 @@ Defaults to: None
 
 * (OPTIONAL) ssh_config file that contains the ssh config for each platform
 
-(Personal user action): The user must set the environment variable "AS_ENV_SSH_CONFIG_PATH" to point to a file that contains the personal ~/.ssh/config file.
+(Personal user action): The user must set the environment variable "AS_ENV_SSH_CONFIG_PATH" to point to a file that contains the personal $HOME/.ssh/config file.
 
-Defaults to: "~/.ssh/config" or "~/.ssh/config_${SUDO_USER}" if the env variable: "AS_ENV_SSH_CONFIG_PATH" is set.
+Defaults to: "$HOME/.ssh/config" or "$HOME/.ssh/config_${SUDO_USER}" if the env variable: "AS_ENV_SSH_CONFIG_PATH" is set.
+
+.. warning::
+    It must be used ``$HOME`` instead of ``~/`` since it wouldn't be red as expected with our configurations
 
 
 How to activate it with examples
@@ -87,7 +90,7 @@ How to activate it with examples
 
 .. code-block:: bash
 
-    export AS_ENV_PLATFORMS_PATH="~/platforms/platform_${SUDO_USER}.yml"
+    export AS_ENV_PLATFORMS_PATH="$HOME/platforms/platform_${SUDO_USER}.yml"
 
 Tip: Add it to the shared account .bashrc file.
 
@@ -95,7 +98,7 @@ Tip: Add it to the shared account .bashrc file.
 
 .. code-block:: bash
 
-    export AS_ENV_SSH_CONFIG_PATH="~/ssh/config_${SUDO_USER}.yml"
+    export AS_ENV_SSH_CONFIG_PATH="$HOME/ssh/config_${SUDO_USER}.yml"
 
 Tip: Add it to the shared account .bashrc file.
 


### PR DESCRIPTION
Closes #2343 

Due to how our YAML extension is handled today there's no support for the use of the PATH auxiliary '~'

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
