### PR TITLE
[Documentation] NUMTHREAD wrong use

### DIFF
--- a/docs/source/userguide/variables.rst
+++ b/docs/source/userguide/variables.rst
@@ -64,8 +64,8 @@ Custom directives
 -----------------
 
 There are job variables that Autosubmit automatically converts into
-directives for your batch server. For example, ``NUMTHREADS`` will
-be set in a Slurm platform as ``--SBATCH --cpus-per-task=$NUMTHREADS``.
+directives for your batch server. For example, ``THREADS`` will
+be set in a Slurm platform as ``--SBATCH --cpus-per-task=$THREADS``.
 
 However, the variables in Autosubmit do not contain all the directives
 available in each platform like Slurm. For values that do not have a


### PR DESCRIPTION
Closes #2123 

Numthreads was being referenced wrongly in the documentation, this is a fix to indicate to the user which one would be the correct directive to use

**Check List**

- [ ] I have read `CONTRIBUTING.md`.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
