### PR TITLE
[Refactoring] Redundant functions

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1435,7 +1435,7 @@ class Autosubmit:
             exp_folder.mkdir(mode=dir_mode)
             required_dirs = ["conf", "pkl", "tmp", "tmp/ASLOGS", f"tmp/LOG_{exp_id}", "plot", "status"]
             for required_dir in required_dirs:
-                Path(exp_folder / required_dir).mkdir(mode=dir_mode)
+                Path(exp_folder / required_dir).mkdir(parents=True, mode=dir_mode)
             Log.info(f"Experiment folder: {exp_folder}")
         except OSError as e:
             try:
@@ -3505,7 +3505,7 @@ class Autosubmit:
                     Log.error("Not a valid path. You must include '~/' at the beginning.")
             database_path = Path(database_path).expanduser().resolve()
             # if not os.path.exists(database_path):
-            HUtils.create_path_if_not_exists(database_path)
+            Path(database_path).mkdir(parents=True, exist_ok=True)
             # Log.error("Database path does not exist.")
             # return False
             while database_filename is None:
@@ -3519,7 +3519,7 @@ class Autosubmit:
             local_root_path = Path(local_root_path).expanduser().resolve()
 
             # if not os.path.exists(local_root_path):
-            HUtils.create_path_if_not_exists(local_root_path)
+            Path(local_root_path).mkdir(parents=True, exist_ok=True)
             # Log.error("Local Root path does not exist.")
             # return False
             # else:
@@ -3576,11 +3576,11 @@ class Autosubmit:
                     # parser.set("hosts", "whitelist", " localhost # Add your machine names")
                     parser.write(config_file)
                     Log.result(f"Configuration file written successfully: \n\t{rc_path}")
-                    HUtils.create_path_if_not_exists(local_root_path)
-                    HUtils.create_path_if_not_exists(global_logs_path)
-                    HUtils.create_path_if_not_exists(structures_path)
-                    HUtils.create_path_if_not_exists(historicdb_path)
-                    HUtils.create_path_if_not_exists(historiclog_path)
+                    Path(local_root_path).mkdir(parents=True, exist_ok=True)
+                    Path(global_logs_path).mkdir(parents=True, exist_ok=True)
+                    Path(structures_path).mkdir(parents=True, exist_ok=True)
+                    Path(historicdb_path).mkdir(parents=True, exist_ok=True)
+                    Path(historiclog_path).mkdir(parents=True, exist_ok=True)
                     Log.result(f"Directories configured successfully: \n\t{str(database_path)} \n\t{str(local_root_path)}"
                                f" \n\t{str(global_logs_path)} \n\t{str(structures_path)} \n\t{str(historicdb_path)}"
                                f" \n\t{str(historiclog_path)}")

--- a/autosubmit/history/utils.py
+++ b/autosubmit/history/utils.py
@@ -59,21 +59,6 @@ def create_file_with_full_permissions(path):
   os.umask(0)
   os.open(path, os.O_WRONLY | os.O_CREAT, 0o777)
 
-def create_path_if_not_exists(path):
-  # type : (str) -> bool
-  if not os.path.exists(path):
-    os.makedirs(path)
-    return True
-  return False
-
-def create_path_if_not_exists_group_permission(path):
-  # type : (str) -> bool
-  if not os.path.exists(path):
-    os.umask(0)
-    os.makedirs(path, mode=0o774)
-    return True
-  return False
-
 class SupportedStatus:
   COMPLETED = "COMPLETED"
   FAILED = "FAILED"

--- a/autosubmit/monitor/monitor.py
+++ b/autosubmit/monitor/monitor.py
@@ -29,7 +29,6 @@ from typing import Any, Callable, Optional, Tuple, Union
 import py3dotplus as pydotplus
 
 from autosubmit.helpers.utils import NaturalSort, check_experiment_ownership
-from autosubmit.history.utils import create_path_if_not_exists_group_permission
 from autosubmit.job.job import Job
 from autosubmit.job.job_common import Status
 from autosubmit.monitor.diagram import create_stats_report
@@ -39,6 +38,12 @@ from log.log import Log, AutosubmitCritical
 _GENERAL_STATS_OPTION_MAX_LENGTH = 1000
 """Maximum length used in the stats plot."""
 
+_DEFAULT_MKDIR_GROUP_PERMISSION = 0o744
+"""Default mkdir mode constant.
+
+This permission mode was previously defined in (now removed)
+``autosubmit.history.utils.create_path_if_not_exists_group_permission``
+"""
 
 _MONITOR_STATUS_TO_COLOR: dict[int, str] = {
     Status.UNKNOWN: 'white',
@@ -625,7 +630,7 @@ class Monitor:
         output_complete_path_stats = os.path.join(BasicConfig.DEFAULT_OUTPUT_DIR, output_filename)
         is_default_path = True
         if is_owner or is_eadmin:
-            create_path_if_not_exists_group_permission(os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "stats"))
+            Path(BasicConfig.LOCAL_ROOT_DIR, expid, "stats").mkdir(mode=_DEFAULT_MKDIR_GROUP_PERMISSION, parents=True, exist_ok=True)
             output_complete_path_stats = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid, "stats", output_filename)
             is_default_path = False
         else:
@@ -638,7 +643,8 @@ class Monitor:
                 is_default_path = False
         if is_default_path:
             Log.info("You don't have enough permissions to the experiment's ({}) folder. The output file will be created in the default location: {}".format(expid, BasicConfig.DEFAULT_OUTPUT_DIR))
-            create_path_if_not_exists_group_permission(BasicConfig.DEFAULT_OUTPUT_DIR)
+
+            Path(BasicConfig.DEFAULT_OUTPUT_DIR).mkdir(mode=_DEFAULT_MKDIR_GROUP_PERMISSION, parents=True, exist_ok=True)
 
         report_created = create_stats_report(
             expid, joblist, str(output_complete_path_stats), section_summary, jobs_summary,


### PR DESCRIPTION
Closes #2364 

Two redundant functions were removed from the utils class
- create_path_if_not_exists
- create_path_if_not_exists_group_permission
Both function had as purpose to create the folder and add the proper permission, which could be done using Path()


**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
