### PR TITLE
Refactor(log): Delete unused function `set_error_level`

### DIFF
--- a/log/log.py
+++ b/log/log.py
@@ -287,19 +287,6 @@ class Log:
         Log.console_handler.level = level
 
     @staticmethod
-    def set_error_level(level):
-        """
-        Sets log level for logging to console. Every output of level equal or higher to parameter level will be
-        printed on console
-
-        :param level: new level for console
-        :return: None
-        """
-        if type(level) is str:
-            level = getattr(Log, level)
-        Log.error.level = level
-
-    @staticmethod
     def _verify_args_message(msg: str, *args):
         """
         Verify if the message has arguments to format


### PR DESCRIPTION
Closes #2514

## Summary
This PR deletes the unused function, `set_error_level`, in the `Log` class.

The function is not being used anywhere other than PR #2475, and  `set_console_level` already performs the same task.

PS: Tests were not added as this function is unused.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
