### PR TITLE
[config] Delete function set_git_project_commit as we already have that info in WORKFLOW_COMMIT (was: Fix bytes and str issue in autosubmit clean command)

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2967,8 +2967,6 @@ class Autosubmit:
 
                 project_type = autosubmit_config.get_project_type()
                 if project_type == "git":
-                    Log.info("Registering commit SHA...")
-                    autosubmit_config.set_git_project_commit(autosubmit_config)
                     Log.info("Cleaning GIT directory...")
                     if not clean_git(autosubmit_config):
                         return False

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -2054,25 +2054,6 @@ class AutosubmitConfig(object):
                                section_param] = job_list_by_section[section][0].parameters[section_param]
         return parameters
 
-    def set_expid(self, exp_id) -> None:
-        """Set experiment identifier in autosubmit and experiment config files
-
-        :param exp_id: experiment identifier to store
-        :type exp_id: str
-        """
-        # Experiment conf
-        content = open(self._exp_parser_file).read()
-        if re.search('EXPID:.*', content):
-            content = content.replace(
-                re.search('EXPID:.*', content).group(0), "EXPID: " + exp_id)
-        open(self._exp_parser_file, 'w').write(content)
-
-        content = open(self._conf_parser_file).read()
-        if re.search('EXPID:.*', content):
-            content = content.replace(
-                re.search('EXPID:.*', content).group(0), "EXPID: " + exp_id)
-        open(self._conf_parser_file, 'w').write(content)
-
     def get_project_type(self) -> str:
         """Returns project type from experiment config file.
 
@@ -2198,42 +2179,6 @@ class AutosubmitConfig(object):
             Log.debug(str(exp))
             Log.debug(traceback.format_exc())
         return "project_files"
-
-    def set_git_project_commit(self, as_conf):
-        """Function to register in the configuration the commit SHA of the git project version.
-        :param as_conf: Configuration class for experiment
-        :type as_conf: AutosubmitConfig
-        """
-        full_project_path = as_conf.get_project_dir()
-        try:
-            project_branch = subprocess.check_output(
-                "cd {0}; git rev-parse --abbrev-ref HEAD".format(full_project_path),
-                shell=True
-            )
-        except subprocess.CalledProcessError as e:
-            raise AutosubmitCritical(
-                "Failed to retrieve project branch...", 7014, str(e))
-
-        Log.debug("Project branch is: " + project_branch)
-        try:
-            project_sha = subprocess.check_output(
-                "cd {0}; git rev-parse HEAD".format(full_project_path), shell=True)
-        except subprocess.CalledProcessError as e:
-            raise AutosubmitCritical(
-                "Failed to retrieve project commit SHA...", 7014, str(e))
-        Log.debug("Project commit SHA is: " + project_sha)
-
-        # register changes
-        content = open(self._exp_parser_file).read()
-        if re.search('PROJECT_BRANCH:.*', content):
-            content = content.replace(re.search('PROJECT_BRANCH:.*', content).group(0),
-                                      "PROJECT_BRANCH: " + project_branch)
-        if re.search('PROJECT_COMMIT:.*', content):
-            content = content.replace(re.search('PROJECT_COMMIT:.*', content).group(0),
-                                      "PROJECT_COMMIT: " + project_sha)
-        open(self._exp_parser_file, 'wb').write(content)
-        Log.debug("Project commit SHA successfully registered to the configuration file.")
-        return True
 
     def get_svn_project_url(self):
         """Gets subversion project url
@@ -2406,18 +2351,6 @@ class AutosubmitConfig(object):
             raise AutosubmitCritical(
                 f"Error while reading HPCARCH from the configuration file: {exc}", 7014
             )
-
-    def set_platform(self, hpc):
-        """Sets main platforms in experiment's config file
-
-        :param hpc: main platforms
-        :type: str
-        """
-        content = open(self._exp_parser_file).read()
-        if re.search('HPCARCH:.*', content):
-            content = content.replace(
-                re.search('HPCARCH:.*', content).group(0), "HPCARCH: " + hpc)
-        open(self._exp_parser_file, 'w').write(content)
 
     def set_last_as_command(self, command):
         """Set the last autosubmit command used in the experiment's config file

--- a/autosubmit/git/autosubmit_git.py
+++ b/autosubmit/git/autosubmit_git.py
@@ -142,10 +142,6 @@ def clean_git(as_conf: AutosubmitConfig) -> bool:
         Log.info("Changes not pushed detected... SKIPPING!")
         raise AutosubmitCritical("Synchronization needed!", 7064)
 
-    if not as_conf.set_git_project_commit(as_conf):
-        Log.info("Failed to set Git project commit... SKIPPING!")
-        return False
-
     proj_dir = Path(BasicConfig.LOCAL_ROOT_DIR, as_conf.expid, BasicConfig.LOCAL_PROJ_DIR)
     Log.debug(f"Removing project directory {str(proj_dir)}")
     rmtree(proj_dir)

--- a/test/integration/git/test_autosubmit_git.py
+++ b/test/integration/git/test_autosubmit_git.py
@@ -382,36 +382,6 @@ def test_clean_git_not_pushed(
     assert str(cm.value.code) == '7064'
 
 
-def test_clean_git_set_git_project_commit_fails(
-        tmp_path,
-        autosubmit_exp,
-        mocker,
-        git_server: Generator[Tuple[DockerContainer, Path, str], None, None]
-):
-    """Test that cleaning Git fails when the project commit cannot be recorded."""
-    _, git_repos_path, git_url = git_server  # type: DockerContainer, Path, str
-
-    mocked_log = mocker.patch('autosubmit.git.autosubmit_git.Log')
-
-    git_repo = git_repos_path / test_clean_git_not_pushed.__name__
-    create_git_repository(git_repo, bare=True)
-
-    git_repo_url = f'{git_url}/{git_repo.name}'
-
-    experiment_data = _get_experiment_data(tmp_path)
-    experiment_data['PROJECT']['PROJECT_TYPE'] = 'git'
-    experiment_data['GIT']['PROJECT_ORIGIN'] = git_repo_url
-
-    as_exp = autosubmit_exp(_EXPID, experiment_data)
-    as_conf = as_exp.as_conf
-
-    mocker.patch.object(as_conf, 'set_git_project_commit', return_value=False)
-
-    assert not clean_git(as_conf)
-
-    assert mocked_log.info.call_args_list[1][0][0] == 'Failed to set Git project commit... SKIPPING!'
-
-
 def test_clean_git(
         tmp_path,
         autosubmit_exp,
@@ -432,9 +402,6 @@ def test_clean_git(
 
     as_exp = autosubmit_exp(_EXPID, experiment_data)
     as_conf = as_exp.as_conf
-
-    # TODO: remove when bug in config parser is fixed!
-    mocker.patch.object(as_conf, 'set_git_project_commit', return_value=True)
 
     proj_dir = Path(as_conf.get_project_dir())
     Path(proj_dir / 'not_committed.txt').touch()

--- a/test/integration/scripts/test_clean.py
+++ b/test/integration/scripts/test_clean.py
@@ -161,11 +161,6 @@ def test_clean_git_project(
     """
     mocked_log = mocker.patch('autosubmit.autosubmit.Log')
 
-    # TODO: Bug in AutosubmitConfigParser, can be deleted once it's fixed,
-    #       https://github.com/BSC-ES/autosubmit-config-parser/issues/87.
-    mocked_autosubmit_config = mocker.patch('autosubmit.autosubmit.AutosubmitConfig.set_git_project_commit')
-    mocked_autosubmit_config.return_value = True
-
     mocker.patch('autosubmit.autosubmit.clean_git', return_value=clean_git_return)
 
     git_project = Path(tmp_path / 'tmp_git_project')


### PR DESCRIPTION
From https://github.com/BSC-ES/autosubmit-config-parser/pull/33

Closes #1075 (duplicate #2489 )

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
