### PR TITLE
[config] fix runtime error in current_variables when reference variable does n…

### DIFF
--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -1025,6 +1025,8 @@ class AutosubmitConfig(object):
             keys = parameters.get(str(dynamic_var[0][start_long:-1]), None)
             if not keys:
                 keys = parameters.get(str(dynamic_var[0]), None)
+                if type(keys) in [int, float]:
+                    keys = None
         else:
             keys = dynamic_var[1]
         keys = keys if isinstance(keys, list) else [keys]


### PR DESCRIPTION
From https://github.com/BSC-ES/autosubmit-config-parser/pull/79

@dbeltrankyl 's original comment:

This fixes an issue when the key to substitute is an int, float. This only happens on running time. 

I'm not entirely sure why. 

However, it occurs when you have a current variable that autosubmit generates during runtime, which refers to a variable that does not exist.

Example:

```yaml
PLATFORMS:
      BLA:
        type: ps
        BLA_PROCESSORS: 3
   
JOBS:
  JOB:
    PROCESSORS: "%CURRENT_BLA_PROCESSORS%"
    PLATFORM: BLA
```

This works.

But this doesn't


```yaml
PLATFORMS:
      BLA:
         type: ps
         
JOBS:
  JOB:
    PROCESSORS: "%CURRENT_BLA_PROCESSORS%"
    PLATFORM: BLA
```

Here, Autosubmit understands that Processors is 1 ( default value when processors is None )


**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
