### PR TITLE
Safe delete

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1034,21 +1034,22 @@ class Autosubmit:
         """
 
         if not expid_delete:
-            raise AutosubmitCritical("Experiment identifier is required for deletion.", 7012)
+            raise AutosubmitCritical("Experiment identifier is required for deletion.", 7011)
         experiment_path = Path(f"{BasicConfig.LOCAL_ROOT_DIR}/{expid_delete}")
         structure_db_path = Path(f"{BasicConfig.STRUCTURES_DIR}/structure_{expid_delete}.db")
         job_data_db_path = Path(f"{BasicConfig.JOBDATA_DIR}/job_data_{expid_delete}")
+        experiment_path = experiment_path.resolve()
+        structure_db_path = structure_db_path.resolve()
+        job_data_db_path = job_data_db_path.resolve()
         if Path(BasicConfig.LOCAL_ROOT_DIR) == experiment_path or \
                 Path(BasicConfig.STRUCTURES_DIR) == structure_db_path or \
                 Path(BasicConfig.JOBDATA_DIR) == job_data_db_path:
             raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
-                                     "Paths must not be the root directories.", 7012)
+                                     "Paths must not be the root directories.", 7011)
 
-        if not (experiment_path.is_relative_to(BasicConfig.LOCAL_ROOT_DIR) and
-                structure_db_path.is_relative_to(BasicConfig.STRUCTURES_DIR) and
-                job_data_db_path.is_relative_to(BasicConfig.JOBDATA_DIR)):
+        if not experiment_path.is_relative_to(BasicConfig.LOCAL_ROOT_DIR):
             raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
-                                     "Paths must be within the configured directories.", 7012)
+                                     "Paths must be within the configured directories.", 7011)
 
         if not experiment_path.exists():
             Log.printlog("Experiment directory does not exist.", Log.WARNING)

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1032,9 +1032,23 @@ class Autosubmit:
 
         :raises AutosubmitCritical: If the experiment does not exist or if there are insufficient permissions.
         """
+
+        if not expid_delete:
+            raise AutosubmitCritical("Experiment identifier is required for deletion.", 7012)
         experiment_path = Path(f"{BasicConfig.LOCAL_ROOT_DIR}/{expid_delete}")
         structure_db_path = Path(f"{BasicConfig.STRUCTURES_DIR}/structure_{expid_delete}.db")
         job_data_db_path = Path(f"{BasicConfig.JOBDATA_DIR}/job_data_{expid_delete}")
+        if Path(BasicConfig.LOCAL_ROOT_DIR) == experiment_path or \
+                Path(BasicConfig.STRUCTURES_DIR) == structure_db_path or \
+                Path(BasicConfig.JOBDATA_DIR) == job_data_db_path:
+            raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
+                                     "Paths must not be the root directories.", 7012)
+
+        if not (experiment_path.is_relative_to(BasicConfig.LOCAL_ROOT_DIR) and
+                structure_db_path.is_relative_to(BasicConfig.STRUCTURES_DIR) and
+                job_data_db_path.is_relative_to(BasicConfig.JOBDATA_DIR)):
+            raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
+                                     "Paths must be within the configured directories.", 7012)
 
         if not experiment_path.exists():
             Log.printlog("Experiment directory does not exist.", Log.WARNING)

--- a/autosubmit/config/files/expdef-dummy.yml
+++ b/autosubmit/config/files/expdef-dummy.yml
@@ -1,6 +1,6 @@
 DEFAULT:
   EXPID: ''
-  HPCARCH: 'local'
+  HPCARCH: ''
 EXPERIMENT:
   DATELIST: "20000101"
   MEMBERS: "fc0"


### PR DESCRIPTION
Derived from #2187, I found that the delete was not safe and could result in the deletion of anything if it was directly called (without the command) 

This fixes it

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
