### PR TITLE
add extra yaml files to be copyied by pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include VERSION
 include CHANGES
 include README
 include docs/autosubmit.pdf
-global-include *.conf *.sql
+include autosubmit/config/files/*
+global-include *.conf *.sql *.yml


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

Hi @kinow, I created this PR because I think that during the installation the necessary yaml files that were being copied before the merge of the config parser are no longer present.

This was not noticeable in development environments, but, if you try to install as a library (as RtD was doing with @VindeeR ), it failed.

This was causing an issue with the `expid` command that was failing do to the lack of these files. I altered the `MANIFEST.in` file to include this folder. 

I tested with the immediate commit before the merge of the autosubmit config parser (1bed69), and it worked.

**Check List**

- [x ] I have read `CONTRIBUTING.md`.
- [x ] Contains logically grouped changes (else tidy your branch by rebase).
- [x ] Does not contain off-topic changes (use other PRs for other changes).
- [x ] Applied any dependency changes to `pyproject.toml`.
- [x ] Tests are included (or explain why tests are not needed).
- [x ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x ] Documentation updated.
- [x ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
