### PR TITLE
Force yes in command prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   to Autosubmit repository, merging the projects again #2052
 - Documentation about `FOR.NAME` with values that are not strings #2515
 - Improvement of the error messages for YAML files #2488 and for RO-CRATE #2572
+- Added `--force` flag to `autosubmit pklfix` command, and `--yes` flag to `autosubmit stop` to
+  automatically answer yes to prompts #2569
 
 ### 4.1.15: Bug fixes, enhancements, and new features
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -694,7 +694,7 @@ class Autosubmit:
             subparser.add_argument('-f', '--force', default=False, action='store_true',
                                    help='Forces to stop autosubmit process, equivalent to kill -9')
             group.add_argument('-a', '--all', default=False, action='store_true',
-                               help='Stop all current running autosubmit processes, will ask for confirmation')
+                               help='Stop all current running autosubmit processes, will ask for confirmation unless -y is used')
             group.add_argument('-fa', '--force_all', default=False, action='store_true',
                                help='Stop all current running autosubmit processes')
             subparser.add_argument(
@@ -4077,6 +4077,8 @@ class Autosubmit:
 
         :param expid: experiment identifier
         :type expid: str
+        :param force: force the operation without confirmation
+        :type force: bool
         :return:
         :rtype: 
         """
@@ -5874,6 +5876,8 @@ class Autosubmit:
         :type current_status: str
         :param status: status to change the active jobs to
         :type status: str
+        :param force_yes: force yes answer to prompts
+        :type force_yes: bool
         """
         from autosubmit.helpers.processes import process_id, retrieve_expids
         from autosubmit.job.job_utils import cancel_jobs

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -591,6 +591,12 @@ class Autosubmit:
             subparser = subparsers.add_parser(
                 'pklfix', description='restore the backup of your pkl')
             subparser.add_argument('expid', help='experiment identifier')
+            subparser.add_argument(
+                "-f",
+                "--force",
+                action="store_true",
+                help="force restore without confirmation",
+            )
 
             # Update Description
             subparser = subparsers.add_parser(
@@ -691,6 +697,13 @@ class Autosubmit:
                                help='Stop all current running autosubmit processes, will ask for confirmation')
             group.add_argument('-fa', '--force_all', default=False, action='store_true',
                                help='Stop all current running autosubmit processes')
+            subparser.add_argument(
+                "-y",
+                "--yes",
+                default=False,
+                action="store_true",
+                help="Automatically answer yes to prompts",
+            )
             subparser.add_argument('-c', '--cancel', action=CancelAction, default=False, nargs=0,
                                 help='Orders to the schedulers to stop active jobs.')
             subparser.add_argument('-fs', '--filter_status', type=str, default="SUBMITTED, QUEUING, RUNNING",
@@ -797,13 +810,13 @@ class Autosubmit:
         elif args.command == 'dbfix':
             return Autosubmit.database_fix(args.expid)
         elif args.command == 'pklfix':
-            return Autosubmit.pkl_fix(args.expid)
+            return Autosubmit.pkl_fix(args.expid, args.force)
         elif args.command == 'updatedescrip':
             return Autosubmit.update_description(args.expid, args.description)
         elif args.command == 'cat-log':
             return Autosubmit.cat_log(args.ID, args.file, args.mode, args.inspect)
         elif args.command == 'stop':
-            return Autosubmit.stop(args.expid, args.force, args.all, args.force_all, args.cancel, args.filter_status, args.target)
+            return Autosubmit.stop(args.expid, args.force, args.all, args.force_all, args.cancel, args.filter_status, args.target, args.yes)
 
     @staticmethod
     def _init_logs(args, console_level='INFO', log_level='DEBUG', expid='None'):
@@ -4058,7 +4071,7 @@ class Autosubmit:
         update_experiment_descrip_version(expid, version=Autosubmit.autosubmit_version)
 
     @staticmethod
-    def pkl_fix(expid):
+    def pkl_fix(expid, force: bool = False):
         """
         Tries to find a backup of the pkl file and restores it. Verifies that autosubmit is not running on this experiment.  
 
@@ -4095,8 +4108,9 @@ class Autosubmit:
                         _stat = os.stat(current_pkl_path)
                         if _stat.st_size > 6:
                             # Greater than 6 bytes -> Not empty
-                            if not Autosubmit._user_yes_no_query(
-                                    f"The current pkl file {current_pkl_path} is not empty. Do you want to continue?"):
+                            if not force and not Autosubmit._user_yes_no_query(
+                                f"The current pkl file {current_pkl_path} is not empty. Do you want to continue?"
+                            ):
                                 # The user chooses not to continue. Operation stopped.
                                 Log.info(
                                     "Pkl restore operation stopped. No changes have been made.")
@@ -5843,7 +5857,7 @@ class Autosubmit:
 
     @staticmethod
     def stop(expids: str, force=False, all_expids=False, force_all=False, cancel=False,
-             current_status="", status="FAILED") -> None:
+             current_status="", status="FAILED", force_yes=False) -> None:
         """The stop command allows users to stop the desired experiments.
 
         :param expids: expids to stop
@@ -5886,7 +5900,7 @@ class Autosubmit:
             expids = [
                 expid
                 for expid in expids
-                if input(f"Confirm stopping the experiment: {expid} (y/n)[enter=y]? ").lower() in truthy_values
+                if force_yes or input(f"Confirm stopping the experiment: {expid} (y/n)[enter=y]? ").lower() in truthy_values
             ]
 
         sig_to_process = signal.SIGKILL if force else signal.SIGINT

--- a/test/integration/scripts/test_pklfix.py
+++ b/test/integration/scripts/test_pklfix.py
@@ -1,0 +1,80 @@
+# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test for the autosubmit pklfix command"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from pytest_mock import MockerFixture
+
+from autosubmit.scripts.autosubmit import main
+
+_EXPID = "t111"
+
+
+def test_autosubmit_pklfix_command_invocation(autosubmit_exp, mocker: MockerFixture):
+    autosubmit_exp(_EXPID, experiment_data={})
+
+    mocker.patch("sys.argv", ["autosubmit", "pklfix", "-f", _EXPID])
+
+    with patch("autosubmit.autosubmit.Autosubmit.pkl_fix") as mock_pklfix:
+        mock_pklfix.return_value = 0
+        assert 0 == main()
+
+        mock_pklfix.assert_called_once()
+
+        passed_args = mock_pklfix.call_args[0]
+        assert passed_args[1] is True
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_pklfix_bypass_prompt_confirmation(
+    autosubmit_exp, mocker: MockerFixture, force: bool
+):
+    exp = autosubmit_exp(_EXPID, experiment_data={})
+
+    as_conf = exp.as_conf
+
+    # Create empty pkl files
+    exp_path = os.path.join(as_conf.basic_config.LOCAL_ROOT_DIR, _EXPID)
+    pkl_folder_path = os.path.join(exp_path, "pkl")
+    current_pkl_path = os.path.join(pkl_folder_path, f"job_list_{_EXPID}.pkl")
+    backup_pkl_path = os.path.join(pkl_folder_path, f"job_list_{_EXPID}_backup.pkl")
+
+    os.makedirs(pkl_folder_path, exist_ok=True)
+    with open(current_pkl_path, "w") as f:
+        f.write("some big content here")
+    with open(backup_pkl_path, "w") as f:
+        f.write("some big content here")
+
+    # Mock command line arguments
+    passed_args = ["autosubmit", "pklfix"] + (["-f"] if force else []) + [_EXPID]
+    mocker.patch("sys.argv", passed_args)
+
+    with patch(
+        "autosubmit.autosubmit.Autosubmit._user_yes_no_query"
+    ) as mock_user_yes_no_query:
+        mock_user_yes_no_query.return_value = False
+
+        assert main() is None
+
+        if force:
+            mock_user_yes_no_query.assert_not_called()
+        else:
+            mock_user_yes_no_query.assert_called_once()

--- a/test/integration/scripts/test_pklfix.py
+++ b/test/integration/scripts/test_pklfix.py
@@ -17,7 +17,7 @@
 
 """Test for the autosubmit pklfix command"""
 
-import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -29,13 +29,15 @@ _EXPID = "t111"
 
 
 def test_autosubmit_pklfix_command_invocation(autosubmit_exp, mocker: MockerFixture):
+    """
+    Test if the pkl_fix function was called by the CLI
+    """
     autosubmit_exp(_EXPID, experiment_data={})
 
     mocker.patch("sys.argv", ["autosubmit", "pklfix", "-f", _EXPID])
 
     with patch("autosubmit.autosubmit.Autosubmit.pkl_fix") as mock_pklfix:
-        mock_pklfix.return_value = 0
-        assert 0 == main()
+        main()
 
         mock_pklfix.assert_called_once()
 
@@ -47,17 +49,19 @@ def test_autosubmit_pklfix_command_invocation(autosubmit_exp, mocker: MockerFixt
 def test_pklfix_bypass_prompt_confirmation(
     autosubmit_exp, mocker: MockerFixture, force: bool
 ):
+    """
+    Test if the --force option bypasses the prompt confirmation
+    """
     exp = autosubmit_exp(_EXPID, experiment_data={})
 
     as_conf = exp.as_conf
 
     # Create empty pkl files
-    exp_path = os.path.join(as_conf.basic_config.LOCAL_ROOT_DIR, _EXPID)
-    pkl_folder_path = os.path.join(exp_path, "pkl")
-    current_pkl_path = os.path.join(pkl_folder_path, f"job_list_{_EXPID}.pkl")
-    backup_pkl_path = os.path.join(pkl_folder_path, f"job_list_{_EXPID}_backup.pkl")
+    exp_path = Path(as_conf.basic_config.LOCAL_ROOT_DIR).joinpath(_EXPID)
+    pkl_folder_path = exp_path.joinpath("pkl")
+    current_pkl_path = pkl_folder_path.joinpath(f"job_list_{_EXPID}.pkl")
+    backup_pkl_path = pkl_folder_path.joinpath(f"job_list_{_EXPID}_backup.pkl")
 
-    os.makedirs(pkl_folder_path, exist_ok=True)
     with open(current_pkl_path, "w") as f:
         f.write("some big content here")
     with open(backup_pkl_path, "w") as f:

--- a/test/integration/scripts/test_stop.py
+++ b/test/integration/scripts/test_stop.py
@@ -17,31 +17,12 @@
 
 """Test for the autosubmit stop command"""
 
-from unittest.mock import patch
-
 import pytest
 from pytest_mock import MockerFixture
 
 from autosubmit.scripts.autosubmit import main
 
 _EXPID = "t111"
-
-
-def test_autosubmit_stop_command_invocation(autosubmit_exp, mocker: MockerFixture):
-    """
-    Test if the stop function was called by the CLI
-    """
-    autosubmit_exp(_EXPID, experiment_data={})
-
-    mocker.patch("sys.argv", ["autosubmit", "stop", "-y", _EXPID])
-
-    with patch("autosubmit.autosubmit.Autosubmit.stop") as mock_stop:
-        main()
-
-        mock_stop.assert_called_once()
-
-        passed_args = mock_stop.call_args[0]
-        assert passed_args[7] is True
 
 
 @pytest.mark.parametrize("force_yes", [True, False])
@@ -57,12 +38,9 @@ def test_stop_bypass_prompt_confirmation(
     passed_args = ["autosubmit", "stop"] + (["-y"] if force_yes else []) + [_EXPID]
     mocker.patch("sys.argv", passed_args)
 
-    with patch("builtins.input") as mock_input:
-        mock_input.return_value = "no"
+    mock_input = mocker.patch("builtins.input")
+    mock_input.return_value = "no"
 
-        assert main() is None
+    assert main() is None
 
-        if force_yes:
-            mock_input.assert_not_called()
-        else:
-            mock_input.assert_called_once()
+    assert mock_input.call_count == (0 if force_yes else 1)

--- a/test/integration/scripts/test_stop.py
+++ b/test/integration/scripts/test_stop.py
@@ -1,0 +1,41 @@
+# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test for the autosubmit stop command"""
+
+from unittest.mock import patch
+
+from pytest_mock import MockerFixture
+
+from autosubmit.scripts.autosubmit import main
+
+_EXPID = "t111"
+
+
+def test_autosubmit_stop_command_invocation(autosubmit_exp, mocker: MockerFixture):
+    autosubmit_exp(_EXPID, experiment_data={})
+
+    mocker.patch("sys.argv", ["autosubmit", "stop", "-y", _EXPID])
+
+    with patch("autosubmit.autosubmit.Autosubmit.stop") as mock_stop:
+        mock_stop.return_value = 0
+        assert 0 == main()
+
+        mock_stop.assert_called_once()
+
+        passed_args = mock_stop.call_args[0]
+        assert passed_args[7] is True

--- a/test/integration/scripts/test_stop.py
+++ b/test/integration/scripts/test_stop.py
@@ -19,6 +19,7 @@
 
 from unittest.mock import patch
 
+import pytest
 from pytest_mock import MockerFixture
 
 from autosubmit.scripts.autosubmit import main
@@ -27,15 +28,41 @@ _EXPID = "t111"
 
 
 def test_autosubmit_stop_command_invocation(autosubmit_exp, mocker: MockerFixture):
+    """
+    Test if the stop function was called by the CLI
+    """
     autosubmit_exp(_EXPID, experiment_data={})
 
     mocker.patch("sys.argv", ["autosubmit", "stop", "-y", _EXPID])
 
     with patch("autosubmit.autosubmit.Autosubmit.stop") as mock_stop:
-        mock_stop.return_value = 0
-        assert 0 == main()
+        main()
 
         mock_stop.assert_called_once()
 
         passed_args = mock_stop.call_args[0]
         assert passed_args[7] is True
+
+
+@pytest.mark.parametrize("force_yes", [True, False])
+def test_stop_bypass_prompt_confirmation(
+    autosubmit_exp, mocker: MockerFixture, force_yes: bool
+):
+    """
+    Test if the -y option bypasses the prompt confirmation
+    """
+    autosubmit_exp(_EXPID, experiment_data={})
+
+    # Mock command line arguments
+    passed_args = ["autosubmit", "stop"] + (["-y"] if force_yes else []) + [_EXPID]
+    mocker.patch("sys.argv", passed_args)
+
+    with patch("builtins.input") as mock_input:
+        mock_input.return_value = "no"
+
+        assert main() is None
+
+        if force_yes:
+            mock_input.assert_not_called()
+        else:
+            mock_input.assert_called_once()


### PR DESCRIPTION
Small PR to bypass confirmation prompts in `stop` and `pklfix` commands. Perfect to make it easier to integrate into users' automation scripts.

Based on what was missing for https://github.com/BSC-ES/autosubmit-api/pull/215