### PR TITLE
Remove double brackets that create invalid json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - The autosubmit-config-parser GitHub project has been archived and its code moved
   to Autosubmit repository, merging the projects again #2052
 - Documentation about `FOR.NAME` with values that are not strings #2515
-- Improvement of the error message for YAML files #2488
+- Improvement of the error messages for YAML files #2488 and for RO-CRATE #2572
 
 ### 4.1.15: Bug fixes, enhancements, and new features
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4242,7 +4242,7 @@ class Autosubmit:
                         ...
                       ]
                     }
-                ''').replace('{', '{{').replace('}', '}}'))
+                '''))
             raise AutosubmitCritical("You must provide an ROCRATE configuration key when using RO-Crate...", 7014)
 
         # Read job list (from pickles) to retrieve start and end time.


### PR DESCRIPTION
Hi, @kinow ! 

Last week I bumped into this tiny error while trying to create an ro-crate.

The very helpful message with the placeholder ro-crate.yml file contained brackets, which, me as a user, I copied and pasted only to have a json error. (Actually, it was a bit more cryptic, but it does not matter).

After try-testing, I found that it was the double brackets. So I removed them.

Let me know if I am missing something.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
