### PR TITLE
#2524 add missing changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes:**
 
 - Fixed issue with the verification of dirty Git local repositories in operational experiments #2446
+- Fixed error when cleaning projects that use Git #2524
 
 **Enhancements:**
 


### PR DESCRIPTION
Adding changelog for https://github.com/BSC-ES/autosubmit/pull/2524.

Noticed that after @ainagaya reported [this issue](https://github.com/BSC-ES/autosubmit/issues/2616), and I couldn't confirm with the changelog alone if we had already fixed it.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
