### PR TITLE
Cosmetic change: Fix really ugly log from the deletion of expid

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1195,14 +1195,15 @@ class Autosubmit:
         :rtype: str
         """
         message_parts = [
-            f"The {expid_delete} experiment was removed from the local disk and from the database.\n",
-            "Note that this action does not delete any data written by the experiment.\n",
-            "Complete list of files/directories deleted:\n"
+            f"The {expid_delete} experiment was removed from the local disk and from the database.",
+            "Note that this action does not delete any data written by the experiment.",
+            "Complete list of files/directories deleted:",
+            ""
         ]
-        message_parts.extend(f"{path}\n" for path in experiment_path.rglob('*'))
-        message_parts.append(f"{structure_db_path}\n")
-        message_parts.append(f"{job_data_db_path}.db\n")
-        message_parts.append(f"{job_data_db_path}.sql\n")
+        message_parts.extend(f"{path}" for path in experiment_path.rglob('*'))
+        message_parts.append(f"{structure_db_path}")
+        message_parts.append(f"{job_data_db_path}.db")
+        message_parts.append(f"{job_data_db_path}.sql")
         message = '\n'.join(message_parts)
         return message
 


### PR DESCRIPTION
process:

Every line was printed into the log with double newlines, since every line in the list ended with a newline, and the '\n'.join(message_parts) then added a second. This used to be fine but got broken in late 2024.

Example logfile (:20260119_135008_delete_t0ef.log) 
`2026-01-19 13:50:10,007 Autosubmit is running with 4.1.14
2026-01-19 13:50:14,145 Enter Autosubmit._delete_expid t0ef
2026-01-19 13:50:14,150 Autosubmit admin user: eadmin is not set
2026-01-19 13:50:14,286 Deleting experiment from database...
2026-01-19 13:50:14,294 The experiment t0ef has been deleted!!!
2026-01-19 13:50:14,298 Experiment t0ef deleted
2026-01-19 13:50:14,298 Removing experiment directory...
2026-01-19 13:50:18,169 Removing Structure db...
2026-01-19 13:50:18,169 Removing job_data db...
2026-01-19 13:50:18,170 The t0ef experiment was removed from the local disk and from the database.

Note that this action does not delete any data written by the experiment.

Complete list of files/directories deleted:

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf

/appl/AS/AUTOSUBMIT_DATA/t0ef/pkl

/appl/AS/AUTOSUBMIT_DATA/t0ef/tmp

/appl/AS/AUTOSUBMIT_DATA/t0ef/plot

/appl/AS/AUTOSUBMIT_DATA/t0ef/status

/appl/AS/AUTOSUBMIT_DATA/t0ef/proj

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf/as_misc.yml

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf/version.yml

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf/main.yml

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf/minimal.yml

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf/metadata

/appl/AS/AUTOSUBMIT_DATA/t0ef/conf/metadata/experiment_data.yml
`
Fix by removing the extra newlines.
No new tests needed.

**Check List**

- [x] I have read `CONTRIBUTING.md`. It was confusing
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed). 
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
