### PR TITLE
Allow users to delete multiple expids, and cleanup Autosubmit class (…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install mypy
-      - run: python3 -m pip install types-requests
+      - run: |
+          python3 -m pip install types-mock
+          python3 -m pip install types-requests
+          mypy --install-types
       - name: Get Python changed files
         id: changed-py-files
         uses: tj-actions/changed-files@v47
@@ -49,4 +52,8 @@ jobs:
             **/*.py
       - name: Run if any of the listed files above is changed
         if: steps.changed-py-files.outputs.any_changed == 'true'
-        run: mypy --follow-imports=skip ${{ steps.changed-py-files.outputs.all_changed_files }} --ignore-missing-imports
+        run: |
+          mypy \
+            --follow-imports=skip ${{ steps.changed-py-files.outputs.all_changed_files }} \
+            --ignore-missing-imports \
+            --check-untyped-defs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@
   `HPC*` variables (e.g. `%HPC_DN_SERVER%` of a user platform) #2574
 - Used a Shell trap-function to detect when an Autosubmit job is signalled to stop
   and to handle non-zero exit codes writing the `_STAT` files (for GUI/metrics) #2788 #2807
+- Do not print warning if an experiment has been successfully deleted #2334 #2793
 
 **Enhancements:**
 
 - Fix intermittent failures of unit tests, and enable print of AS exceptions.
   Changes and improvements to fixtures and pytest organisation and setup #2745
 - Removed broken migrate command #2617
+- Allow users to delete multiple experiments #1216 #2793
 
 ### 4.1.16: Unreleased
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -38,7 +38,7 @@ from importlib.metadata import version
 from importlib.resources import files as read_files
 from pathlib import Path
 from time import sleep
-from typing import Generator, Optional, Union
+from typing import cast, Generator, Optional, Union
 
 from bscearth.utils.date import date2str
 from portalocker import Lock
@@ -52,16 +52,17 @@ from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.config.configcommon import AutosubmitConfig
 from autosubmit.config.yamlparser import YAMLParserFactory
 from autosubmit.database.db_common import (
-    create_db, delete_experiment, get_experiment_description, get_autosubmit_version, check_experiment_exists,
+    create_db, get_experiment_description, get_autosubmit_version, check_experiment_exists,
     update_experiment_description_version
 )
 from autosubmit.database.db_structure import get_structure
 from autosubmit.experiment.detail_updater import ExperimentDetails
-from autosubmit.experiment.experiment_common import copy_experiment, new_experiment, create_required_folders
+from autosubmit.experiment.experiment_common import (
+    check_ownership, copy_experiment, create_required_folders, delete_experiment, new_experiment
+)
 from autosubmit.git.autosubmit_git import AutosubmitGit
 from autosubmit.git.autosubmit_git import check_unpushed_changes, clean_git
-from autosubmit.helpers.processes import process_id
-from autosubmit.helpers.utils import check_jobs_file_exists, get_rc_path, strtobool
+from autosubmit.helpers.utils import check_jobs_file_exists, get_rc_path, user_yes_no_query
 from autosubmit.history.experiment_history import ExperimentHistory
 from autosubmit.history.experiment_status import ExperimentStatus
 from autosubmit.job.job import Job
@@ -85,9 +86,6 @@ dialog = None
 """Main module for autosubmit. Only contains an interface class to all functionality implemented on autosubmit."""
 
 sys.path.insert(0, os.path.abspath('.'))
-
-
-# noinspection PyUnusedLocal
 
 
 def signal_handler(signal_received, frame):  # noqa: F841
@@ -246,7 +244,8 @@ class Autosubmit:
             # Delete
             subparser = subparsers.add_parser(
                 'delete', description="delete specified experiment")
-            subparser.add_argument('expid', help='experiment identifier')
+            subparser.add_argument('expid', help='experiment identifiers separated by commas',
+                               nargs='?')
             subparser.add_argument(
                 '-f', '--force', action='store_true', help='deletes experiment without confirmation')
             subparser.add_argument('-v', '--update_version', action='store_true',
@@ -712,7 +711,7 @@ class Autosubmit:
             subparser = subparsers.add_parser(
                 'stop', description='Completely stops an autosubmit run process')
             group = subparser.add_mutually_exclusive_group(required=True)
-            group.add_argument('expid', help='experiment identifier, stops each of the listed expid separated by ","',
+            group.add_argument('expid', help='experiment identifiers separated by commas',
                                nargs='?')
             subparser.add_argument('-f', '--force', default=False, action='store_true',
                                    help='Forces to stop autosubmit process, equivalent to kill -9')
@@ -766,7 +765,7 @@ class Autosubmit:
                                     args.git_repo, args.git_branch, args.git_as_conf, args.operational, args.testcase,
                                     args.evaluation, args.use_local_minimal) != ''
         elif args.command == 'delete':
-            return Autosubmit.delete(args.expid, args.force)
+            return delete_experiment(args.expid, args.force)
         elif args.command == 'monitor':
             return Autosubmit.monitor(args.expid, args.output, args.list, args.filter_chunks, args.filter_status,
                                       args.filter_type, args.hide, args.text, args.group_by, args.expand,
@@ -902,7 +901,7 @@ class Autosubmit:
         if args.command == "stop":
             if args.all or args.force_all:
                 expid_less.append("stop")
-        global_log_command = ["delete", "archive", "upgrade"]
+        global_log_command = ["archive", "upgrade"]
         import platform
         fullhost = platform.node()
         if "." in fullhost:
@@ -931,7 +930,9 @@ class Autosubmit:
                 args.command]):
                 raise AutosubmitCritical(message, 7071)
         if (expid != 'None' and expid) and args.command not in expid_less and args.command not in global_log_command:
-            if "," in expid:
+            if isinstance(expid, list):
+                expids = cast(list[str], expid)
+            elif "," in expid:
                 expids = expid.split(",")
             else:
                 expids = expid.split(" ")
@@ -966,12 +967,12 @@ class Autosubmit:
                 os.mkdir(tmp_path)
             if not os.path.exists(aslogs_path):
                 os.mkdir(aslogs_path)
-            if args.command == "stop":
+            if args.command in ['stop', 'delete']:
                 exp_id = "_".join(expids)
                 Log.set_file(os.path.join(BasicConfig.GLOBAL_LOG_DIR,
-                                          args.command + exp_id + '.log'), "out", log_level)
+                                          args.command + '_' + exp_id + '.log'), "out", log_level)
                 Log.set_file(os.path.join(BasicConfig.GLOBAL_LOG_DIR,
-                                          args.command + exp_id + '_err.log'), "err")
+                                          args.command + '_' + exp_id + '_err.log'), "err")
             else:
                 if owner:
                     os.chmod(tmp_path, 0o775)
@@ -1026,7 +1027,9 @@ class Autosubmit:
                                                      f"\nOr with the -v parameter: autosubmit {args.command} {expid} "
                                                      f"-v ", 7014)
         else:
-            if expid == 'None' or not expid:
+            if isinstance(expid, list):
+                exp_id = '_'.join(expid)
+            elif expid == 'None' or not expid:
                 exp_id = ""
             else:
                 exp_id = "_" + expid
@@ -1062,199 +1065,12 @@ class Autosubmit:
     @staticmethod
     def _check_ownership_and_set_last_command(as_conf, expid, command):
         if command not in ["monitor", "describe", "delete", "report", "stats", "dbfix"]:
-            owner, eadmin, current_owner = Autosubmit._check_ownership(expid, raise_error=True)
+            owner, eadmin, current_owner = check_ownership(expid, raise_error=True)
         else:
-            owner, eadmin, current_owner = Autosubmit._check_ownership(expid, raise_error=False)
+            owner, eadmin, current_owner = check_ownership(expid, raise_error=False)
         if owner:
             as_conf.set_last_as_command(command)
         return owner, eadmin, current_owner
-
-    @staticmethod
-    def _check_ownership(expid, raise_error=False):
-        """Check if the user owns and if it is eadmin.
-
-        :return: the owner, eadmin and current_owner
-        :rtype: boolean, boolean, str
-        """
-        current_owner = None
-        eadmin = False
-        owner = False
-        current_user_id = os.getuid()
-        admin_user = "eadmin"  # to be improved in #944
-        try:
-            eadmin = current_user_id == pwd.getpwnam(admin_user).pw_uid
-        except Exception:
-            Log.info(f"Autosubmit admin user: {admin_user} is not set")
-        current_owner_id = Path(BasicConfig.LOCAL_ROOT_DIR, expid).stat().st_uid
-        try:
-            current_owner = pwd.getpwuid(current_owner_id).pw_name
-        except (TypeError, KeyError):
-            Log.warning(f"Current owner of experiment {expid} could not be retrieved. The owner is no longer in the "
-                        f"system database.")
-        if current_owner_id == current_user_id:
-            owner = True
-        elif raise_error:
-            raise AutosubmitCritical(f"You don't own the experiment {expid}.", 7012)
-        return owner, eadmin, current_owner
-
-    @staticmethod
-    def _delete_expid(expid_delete: str, force: bool = False) -> bool:
-        """Removes an experiment from the path and database.
-        If the current user is eadmin and the -f flag has been sent, it deletes regardless of experiment owner.
-
-        :param expid_delete: Identifier of the experiment to delete.
-        :type expid_delete: str
-        :param force: If True, does not ask for confirmation.
-        :type force: bool
-
-        :returns: True if successfully deleted, False otherwise.
-        :rtype: bool
-
-        :raises AutosubmitCritical: If the experiment does not exist or if there are insufficient permissions.
-        """
-
-        if not expid_delete:
-            raise AutosubmitCritical("Experiment identifier is required for deletion.", 7011)
-        experiment_path = Path(f"{BasicConfig.LOCAL_ROOT_DIR}/{expid_delete}")
-        structure_db_path = Path(f"{BasicConfig.STRUCTURES_DIR}/structure_{expid_delete}.db")
-        job_data_db_path = Path(f"{BasicConfig.JOBDATA_DIR}/job_data_{expid_delete}")
-        experiment_path = experiment_path.resolve()
-        structure_db_path = structure_db_path.resolve()
-        job_data_db_path = job_data_db_path.resolve()
-        if Path(BasicConfig.LOCAL_ROOT_DIR) == experiment_path or \
-                Path(BasicConfig.STRUCTURES_DIR) == structure_db_path or \
-                Path(BasicConfig.JOBDATA_DIR) == job_data_db_path:
-            raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
-                                     "Paths must not be the root directories.", 7011)
-
-        if not experiment_path.is_relative_to(BasicConfig.LOCAL_ROOT_DIR):
-            raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
-                                     "Paths must be within the configured directories.", 7011)
-
-        if not experiment_path.exists():
-            Log.printlog("Experiment directory does not exist.", Log.WARNING)
-            return False
-
-        owner, eadmin, _ = Autosubmit._check_ownership(expid_delete)
-        if not (owner or (force and eadmin)):
-            Autosubmit._raise_permission_error(eadmin, expid_delete)
-
-        message = Autosubmit._generate_deletion_message(expid_delete, experiment_path, structure_db_path,
-                                                        job_data_db_path)
-        error_message = Autosubmit._perform_deletion(experiment_path, structure_db_path, job_data_db_path, expid_delete)
-
-        if not error_message:
-            Log.printlog(message, Log.RESULT)
-        else:
-            Log.printlog(error_message, Log.ERROR)
-            raise AutosubmitError(
-                "Some experiment files weren't correctly deleted\nPlease if the trace shows DATABASE IS LOCKED, report it to git\nIf there are I/O issues, wait until they're solved and then use this command again.\n",
-                error_message, 6004
-            )
-
-        return not bool(error_message)  # if there is a non-empty error, return False
-
-    @staticmethod
-    def _raise_permission_error(eadmin: bool, expid_delete: str) -> None:
-        """Raise a permission error if the current user is not allowed to delete the experiment.
-
-        :param eadmin: Indicates if the current user is an eadmin.
-        :type eadmin: bool
-        :param expid_delete: Identifier of the experiment to delete.
-        :type expid_delete: str
-
-        :raises AutosubmitCritical: If the user does not have permission to delete the experiment.
-        """
-        if not eadmin:
-            raise AutosubmitCritical(
-                f"Detected Eadmin user however, -f flag is not found. {expid_delete} cannot be deleted!", 7012)
-        else:
-            raise AutosubmitCritical(
-                f"Current user is not the owner of the experiment. {expid_delete} cannot be deleted!", 7012)
-
-    @staticmethod
-    def _generate_deletion_message(expid_delete: str, experiment_path: Path, structure_db_path: Path,
-                                   job_data_db_path: Path) -> str:
-        """Generate a message detailing what is being deleted from an experiment.
-
-        :param expid_delete: Identifier of the experiment to delete.
-        :type expid_delete: str
-        :param experiment_path: Path to the experiment directory.
-        :type experiment_path: Path
-        :param structure_db_path: Path to the structure database file.
-        :type structure_db_path: Path
-        :param job_data_db_path: Path to the job data database file.
-        :type job_data_db_path: Path
-
-        :return: A message detailing the deletion of the experiment.
-        :rtype: str
-        """
-        message_parts = [
-            f"The {expid_delete} experiment was removed from the local disk and from the database.",
-            "Note that this action does not delete any data written by the experiment.",
-            "Complete list of files/directories deleted:",
-            ""
-        ]
-        message_parts.extend(f"{path}" for path in experiment_path.rglob('*'))
-        message_parts.append(f"{structure_db_path}")
-        message_parts.append(f"{job_data_db_path}.db")
-        message_parts.append(f"{job_data_db_path}.sql")
-        message = '\n'.join(message_parts)
-        return message
-
-    @staticmethod
-    def _perform_deletion(experiment_path: Path, structure_db_path: Path, job_data_db_path: Path,
-                          expid_delete: str) -> str:
-        """Perform the deletion of an experiment, including its directory, structure database, and job data database.
-
-        :param experiment_path: Path to the experiment directory.
-        :type experiment_path: Path
-        :param structure_db_path: Path to the structure database file.
-        :type structure_db_path: Path
-        :param job_data_db_path: Path to the job data database file.
-        :type job_data_db_path: Path
-        :param expid_delete: Identifier of the experiment to delete.
-        :type expid_delete: str
-        :return: An error message if any errors occurred during deletion, otherwise an empty string.
-        :rtype: str
-        """
-        error_message = ""
-
-        is_sqlite = BasicConfig.DATABASE_BACKEND == 'sqlite'
-
-        Log.info(f"Deleting experiment from {BasicConfig.DATABASE_BACKEND} database...")
-        try:
-            ret = delete_experiment(expid_delete)
-            if ret:
-                Log.result(f"Experiment {expid_delete} deleted")
-        except BaseException as e:
-            error_message += f"Cannot delete experiment entry: {e}\n"
-
-        Log.info("Removing experiment directory...")
-        try:
-            shutil.rmtree(experiment_path)
-        except BaseException as e:
-            error_message += f"Cannot delete directory: {e}\n"
-
-        if is_sqlite:
-            Log.info("Removing Structure db...")
-            try:
-                os.remove(structure_db_path)
-            except BaseException as e:
-                error_message += f"Cannot delete structure: {e}\n"
-
-            Log.info("Removing job_data db...")
-            try:
-                db_path = job_data_db_path.with_suffix(".db")
-                sql_path = job_data_db_path.with_suffix(".sql")
-                if db_path.exists():
-                    os.remove(db_path)
-                if sql_path.exists():
-                    os.remove(sql_path)
-            except BaseException as e:
-                error_message += f"Cannot delete job_data: {e}\n"
-
-        return error_message
 
     @staticmethod
     def copy_as_config(exp_id, copy_id):
@@ -1486,47 +1302,6 @@ class Autosubmit:
         return exp_id
 
     @staticmethod
-    def delete(expid: str, force: bool) -> bool:
-        """Deletes an experiment from the database,
-        the experiment's folder database entry and all the related metadata files.
-
-        :param expid: Identifier of the experiment to delete.
-        :type expid: str
-        :param force: If True, does not ask for confirmation.
-        :type force: bool
-
-        :returns: True if successful, False otherwise.
-        :rtype: bool
-
-        :raises AutosubmitCritical: If the experiment does not exist or if there are insufficient permissions.
-        """
-        if process_id(expid) is not None:
-            raise AutosubmitCritical("Ensure no processes are running in the experiment directory", 7076)
-
-        experiment_path = Path(f"{BasicConfig.LOCAL_ROOT_DIR}/{expid}")
-
-        if experiment_path.exists():
-            if force or Autosubmit._user_yes_no_query(f"Do you want to delete {expid} ?"):
-                Log.debug(f'Enter Autosubmit._delete_expid {expid}')
-
-                # Try to delete the experiment details
-                try:
-                    ExperimentDetails(expid).delete_details()
-                except Exception:
-                    pass
-
-                try:
-                    return Autosubmit._delete_expid(expid, force)
-                except AutosubmitCritical:
-                    raise
-                except BaseException as e:
-                    raise AutosubmitCritical("Seems that something went wrong, please check the trace", 7012, str(e))
-            else:
-                raise AutosubmitCritical("Insufficient permissions", 7012)
-        else:
-            raise AutosubmitCritical("Experiment does not exist", 7012)
-
-    @staticmethod
     def _load_parameters(as_conf, job_list, platforms):
         """Add parameters from configuration files into platform objects, and into the job_list object.
 
@@ -1568,7 +1343,7 @@ class Autosubmit:
          """
         try:
             Log.info(f"Inspecting experiment {expid}")
-            Autosubmit._check_ownership(expid, raise_error=True)
+            check_ownership(expid, raise_error=True)
             exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
             tmp_path = os.path.join(exp_path, BasicConfig.LOCAL_TMP_DIR)
             if os.path.exists(os.path.join(tmp_path, 'autosubmit.lock')):
@@ -3015,7 +2790,7 @@ class Autosubmit:
         if not save:
             Log.warning("Changes will be NOT saved to the jobList. Use -s option to save")
 
-        Autosubmit._check_ownership(expid, raise_error=True)
+        check_ownership(expid, raise_error=True)
         exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
         as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
         as_conf.check_conf_files(True)
@@ -3796,7 +3571,7 @@ class Autosubmit:
         :type expid: str
         """
         try:
-            Autosubmit._check_ownership(expid, raise_error=True)
+            check_ownership(expid, raise_error=True)
             as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
             as_conf.reload(force_load=True)
             # as_conf.check_conf_files(False)
@@ -3825,7 +3600,7 @@ class Autosubmit:
         :param expid: experiment identifier
         :type expid: str
         """
-        Autosubmit._check_ownership(expid, raise_error=True)
+        check_ownership(expid, raise_error=True)
 
         as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
         as_conf.reload(force_load=True)
@@ -3915,7 +3690,7 @@ class Autosubmit:
         Log.info("Checking if experiment exists...")
         try:
             # Check that the user is the owner and the configuration is well configured
-            Autosubmit._check_ownership(expid, raise_error=True)
+            check_ownership(expid, raise_error=True)
             folder = Path(BasicConfig.LOCAL_ROOT_DIR) / expid / "conf"
             factory = YAMLParserFactory()
             # update scripts to yml format
@@ -4035,7 +3810,7 @@ class Autosubmit:
                         _stat = os.stat(current_pkl_path)
                         if _stat.st_size > 6:
                             # Greater than 6 bytes -> Not empty
-                            if not force and not Autosubmit._user_yes_no_query(
+                            if not force and not user_yes_no_query(
                                     f"The current pkl file {current_pkl_path} is not empty. Do you want to continue?"
                             ):
                                 # The user chooses not to continue. Operation stopped.
@@ -4453,7 +4228,7 @@ class Autosubmit:
 
         # checking if there is a lock file to avoid multiple running on the same expid
         try:
-            Autosubmit._check_ownership(expid, raise_error=True)
+            check_ownership(expid, raise_error=True)
             exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
             tmp_path = os.path.join(exp_path, BasicConfig.LOCAL_TMP_DIR)
             with Lock(os.path.join(tmp_path, 'autosubmit.lock'), timeout=1) as fh:
@@ -5238,7 +5013,7 @@ class Autosubmit:
         for f in [filter_chunks, filter_type_chunk, filter_type_chunk_split]:
             filter_chunk_section_split = f if f else filter_chunk_section_split
 
-        Autosubmit._check_ownership(expid, raise_error=True)
+        check_ownership(expid, raise_error=True)
         exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
         tmp_path = os.path.join(exp_path, BasicConfig.LOCAL_TMP_DIR)
         try:
@@ -5441,29 +5216,6 @@ class Autosubmit:
                 return True
         except Exception:
             raise
-
-    @staticmethod
-    def _user_yes_no_query(question):
-        """Utility function to ask user a yes/no question.
-
-        :param question: question to ask
-        :type question: str
-        :return: True if answer is yes, False if it is no
-        :rtype: bool
-        """
-        sys.stdout.write(f'{question} [y/n]\n')
-        while True:
-            try:
-                if sys.version_info[0] == 3:
-                    answer = input()
-                else:
-                    # noinspection PyCompatibility
-                    answer = input()
-                return strtobool(answer.lower())
-            except EOFError as e:
-                raise AutosubmitCritical("No input detected, the experiment won't be erased.", 7011, str(e))
-            except ValueError:
-                sys.stdout.write('Please respond with \'y\' or \'n\'.\n')
 
     @staticmethod
     def _get_status(s):

--- a/autosubmit/database/db_common.py
+++ b/autosubmit/database/db_common.py
@@ -286,7 +286,7 @@ def last_name_used(test=False, operational=False, evaluation=False):
 
 def delete_experiment(experiment_id):
     """
-    Removes experiment from database. Anti-lock version.  
+    Removes experiment from database. Anti-lock version.
 
     :param experiment_id: experiment identifier
     :type experiment_id: str

--- a/autosubmit/experiment/experiment_common.py
+++ b/autosubmit/experiment/experiment_common.py
@@ -17,11 +17,31 @@
 
 """Module containing functions to manage autosubmit's experiments."""
 
+import os
+import pwd
 import string
 from pathlib import Path
+from shutil import rmtree
+from typing import Optional
 
+from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database import db_common
-from autosubmit.log.log import Log, AutosubmitCritical
+from autosubmit.experiment.detail_updater import ExperimentDetails
+from autosubmit.helpers.processes import process_id
+from autosubmit.helpers.utils import user_yes_no_query
+from autosubmit.log.log import Log, AutosubmitCritical, AutosubmitError
+
+__all__ = [
+    'base36encode',
+    'base36decode',
+    'check_ownership',
+    'copy_experiment',
+    'create_required_folders',
+    'delete_experiment',
+    'is_valid_experiment_id',
+    'new_experiment',
+    'next_experiment_id'
+]
 
 Log.get_logger("Autosubmit")
 
@@ -31,15 +51,11 @@ def new_experiment(description, version, test=False, operational=False, evaluati
     Stores a new experiment on the database and generates its identifier
 
     :param description: description of the experiment
-    :type description: str
     :param version: version of the experiment
-    :type version: str
     :param test: if True, the experiment is a test experiment
-    :type test: bool
     :param operational: if True, the experiment is an operational experiment
-    :type operational: bool
-    :return: experiment id for the new experiment
-    :rtype: str
+    :param evaluation: if True, the experiment is an evaluation experiment
+    :return: the experiment id for the new experiment
     """
     try:
         if test:
@@ -79,6 +95,183 @@ def new_experiment(description, version, test=False, operational=False, evaluati
     except Exception as e:
         raise AutosubmitCritical(f'Error while generating a new experiment in the db: {e}',
                                  7011) from e
+
+
+def delete_experiment(expids: str, force: bool) -> bool:
+    """Deletes an experiment from the database,
+    the experiment's folder database entry and all the related metadata files.
+
+    :param expids: List of experiment IDs to delete.
+    :param force: Ask for confirmation if ``False``.
+    :returns: ``True`` if successful, ``False`` otherwise.
+    :raises AutosubmitCritical: If the experiment does not exist or if there are insufficient permissions.
+    """
+    # expid will come from argparse, which provides nix-style comma-separated values,
+    # so here we parse the comma-separated values. ``.fromkeys`` keeps order and removes
+    # duplicates.
+    expid_list = expids.replace(',', ' ').split(' ')
+    expid_list = [expid.lower() for expid in filter(lambda x: x, expid_list)]
+
+    failed: list[str] = []
+
+    for expid in expid_list:
+        try:
+            _delete_experiment(expid, force)
+        except Exception as e:
+            Log.error(f'Failed to delete experiment {expid}: {str(e)}')
+            failed.append(expid)
+
+    if failed:
+        Log.error(f"Deletion failed for experiments: {', '.join(failed)}")
+        return False
+
+    return True
+
+
+def _delete_experiment(expid: str, force: bool) -> None:
+    if process_id(expid) is not None:
+        raise AutosubmitCritical("Ensure no processes are running in the experiment directory", 7076)
+
+    experiment_path = Path(f"{BasicConfig.LOCAL_ROOT_DIR}/{expid}")
+    if not experiment_path.exists():
+        raise AutosubmitCritical("Experiment does not exist", 7012)
+
+    confirm_removal = force or user_yes_no_query(f"Do you want to delete {expid} ?")
+
+    if not confirm_removal:
+        Log.info(f'Experiment {expid} deletion cancelled by user')
+        return
+
+    Log.info(f'Deleting experiment {expid}')
+
+    # Try to delete the experiment details
+    try:
+        ExperimentDetails(expid).delete_details()
+    except Exception as e:
+        Log.warning(f'Failed to delete DB details for experiment {expid}: {str(e)}')
+        raise
+
+    try:
+        _delete_expid(expid, force)
+        Log.info(f'Experiment {expid} has been deleted')
+    except Exception as e:
+        raise AutosubmitCritical("Seems that something went wrong, please check the trace", 7012, str(e))
+
+
+def _delete_expid(expid_delete: str, force: bool = False) -> None:
+    """Removes an experiment from the path and database.
+    If the current user is eadmin and the -f flag has been sent, it deletes regardless of experiment owner.
+
+    :param expid_delete: Identifier of the experiment to delete.
+    :type expid_delete: str
+    :param force: If True, does not ask for confirmation.
+    :type force: bool
+
+    :returns: True if successfully deleted, False otherwise.
+    :rtype: bool
+
+    :raises AutosubmitCritical: If the experiment does not exist or if there are insufficient permissions.
+    """
+
+    if not expid_delete:
+        raise AutosubmitCritical("Experiment identifier is required for deletion.", 7011)
+    experiment_path = Path(f"{BasicConfig.LOCAL_ROOT_DIR}/{expid_delete}")
+    structure_db_path = Path(f"{BasicConfig.STRUCTURES_DIR}/structure_{expid_delete}.db")
+    job_data_db_path = Path(f"{BasicConfig.JOBDATA_DIR}/job_data_{expid_delete}")
+    experiment_path = experiment_path.resolve()
+    structure_db_path = structure_db_path.resolve()
+    job_data_db_path = job_data_db_path.resolve()
+    if Path(BasicConfig.LOCAL_ROOT_DIR) == experiment_path or \
+            Path(BasicConfig.STRUCTURES_DIR) == structure_db_path or \
+            Path(BasicConfig.JOBDATA_DIR) == job_data_db_path:
+        raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
+                                 "Paths must not be the root directories.", 7011)
+
+    if not experiment_path.is_relative_to(BasicConfig.LOCAL_ROOT_DIR):
+        raise AutosubmitCritical(f"Invalid paths for experiment deletion: {expid_delete}. "
+                                 "Paths must be within the configured directories.", 7011)
+
+    if not experiment_path.exists():
+        Log.printlog("Experiment directory does not exist.", Log.WARNING)
+        return
+
+    owner, eadmin, _ = check_ownership(expid_delete)
+    if not (owner or (force and eadmin)):
+        if not eadmin:
+            raise AutosubmitCritical(
+                f"Detected Eadmin user however, -f flag is not found. {expid_delete} cannot be deleted!", 7012)
+        else:
+            raise AutosubmitCritical(
+                f"Current user is not the owner of the experiment. {expid_delete} cannot be deleted!", 7012)
+
+    message_parts = [
+        f"The {expid_delete} experiment was removed from the local disk and from the database.",
+        "Note that this action does not delete any data written by the experiment.",
+        "Complete list of files/directories deleted:",
+        ""
+    ]
+    message_parts.extend(f"{path}" for path in experiment_path.rglob('*'))
+    message_parts.append(f"{structure_db_path}")
+    message_parts.append(f"{job_data_db_path}.db")
+    message_parts.append(f"{job_data_db_path}.sql")
+    message = '\n'.join(message_parts)
+
+    error_message = _perform_deletion(experiment_path, structure_db_path, job_data_db_path, expid_delete)
+
+    if not error_message:
+        Log.printlog(message, Log.RESULT)
+    else:
+        Log.printlog(error_message, Log.ERROR)
+        raise AutosubmitError(
+            "Some experiment files weren't correctly deleted\n"
+            "Please if the trace shows DATABASE IS LOCKED, report it to git\n"
+            "If there are I/O issues, wait until they're solved and then use this command again.\n",
+            6004, error_message
+        )
+
+
+def _perform_deletion(experiment_path: Path, structure_db_path: Path, job_data_db_path: Path,
+                      expid_delete: str) -> str:
+    """Perform the deletion of an experiment, including its directory, structure database, and job data database.
+
+    :param experiment_path: Path to the experiment directory.
+    :param structure_db_path: Path to the structure database file.
+    :param job_data_db_path: Path to the job data database file.
+    :param expid_delete: Identifier of the experiment to delete.
+    :return: An error message if any errors occurred during deletion, otherwise an empty string.
+    """
+    error_message = []
+
+    is_sqlite = BasicConfig.DATABASE_BACKEND == 'sqlite'
+
+    Log.info(f"Deleting experiment from {BasicConfig.DATABASE_BACKEND} database...")
+    try:
+        db_common.delete_experiment(expid_delete)
+        Log.result(f"Experiment {expid_delete} deleted from database")
+    except Exception as e:
+        error_message.append(f"Cannot delete experiment entry: {e}")
+
+    Log.info("Removing experiment directory...")
+    try:
+        rmtree(experiment_path)
+        Log.result(f"Experiment directory {experiment_path} deleted from disk")
+    except Exception as e:
+        error_message.append(f"Cannot delete directory: {e}")
+
+    if is_sqlite:
+        Log.info("Removing structure db...")
+
+        structure_db_path.unlink(missing_ok=True)
+        Log.info(f"Experiment {expid_delete} structure db deleted")
+
+        Log.info("Removing job_data db...")
+        db_path = job_data_db_path.with_suffix(".db")
+        sql_path = job_data_db_path.with_suffix(".sql")
+        db_path.unlink(missing_ok=True)
+        sql_path.unlink(missing_ok=True)
+        Log.info(f"Experiment {expid_delete} job_data db deleted")
+
+    return "\n".join(error_message)
 
 
 def copy_experiment(experiment_id, description, version, test=False, operational=False, evaluation=False):
@@ -205,3 +398,31 @@ def create_required_folders(exp_id: str, exp_folder: Path) -> None:
     required_dirs = ["conf", "pkl", "tmp", "tmp/ASLOGS", f"tmp/LOG_{exp_id}", "plot", "status"]
     for required_dir in required_dirs:
         Path(exp_folder / required_dir).mkdir(mode=dir_mode)
+
+
+def check_ownership(expid: str, raise_error=False) -> tuple[bool, bool, Optional[str]]:
+    """Check if the user owns and if it is eadmin.
+
+    :return: the owner, eadmin and current_owner
+    """
+    current_owner = None
+    eadmin = False
+    owner = False
+    current_user_id = os.getuid()
+    # TODO: to be improved in #944
+    admin_user = "eadmin"
+    try:
+        eadmin = current_user_id == pwd.getpwnam(admin_user).pw_uid
+    except Exception as e:
+        Log.info(f"Autosubmit admin user: {admin_user} is not set: {str(e)}")
+    current_owner_id = Path(BasicConfig.LOCAL_ROOT_DIR, expid).stat().st_uid
+    try:
+        current_owner = pwd.getpwuid(current_owner_id).pw_name
+    except (TypeError, KeyError) as e:
+        Log.warning(f"Current owner of experiment {expid} could not be retrieved. "
+                    f"The owner is no longer in the system database: {str(e)}")
+    if current_owner_id == current_user_id:
+        owner = True
+    elif raise_error:
+        raise AutosubmitCritical(f"You do not own the experiment {expid}.", 7012)
+    return owner, eadmin, current_owner

--- a/autosubmit/log/utils.py
+++ b/autosubmit/log/utils.py
@@ -27,7 +27,7 @@ GZIP_MAGIC = "1F 8B"
 
 def compress_xz(
     input_path: Union[Path, str],
-    output_path: Union[Path, str] = None,
+    output_path: Optional[Union[Path, str]] = None,
     preset: int = 6,
     extreme: bool = False,
     keep_input: bool = True,
@@ -60,7 +60,7 @@ def compress_xz(
 
 def compress_gzip(
     input_path: str,
-    output_path: str = None,
+    output_path: Optional[str] = None,
     compression_level: int = 9,
     keep_input: bool = True,
 ):

--- a/test/integration/commands/run/test_run_local_scenarios.py
+++ b/test/integration/commands/run/test_run_local_scenarios.py
@@ -1,3 +1,20 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
 from multiprocessing import Process
 from pathlib import Path
 from textwrap import dedent
@@ -6,10 +23,8 @@ import pytest
 from ruamel.yaml import YAML
 
 from autosubmit.config.basicconfig import BasicConfig
-from test.integration.commands.run.conftest import (
-    _check_db_fields, _assert_exit_code, _check_files_recovered,
+from test.integration.commands.run.conftest import _check_db_fields, _assert_exit_code, _check_files_recovered, \
     _assert_db_fields, _assert_files_recovered
-)
 from test.integration.test_utils.misc import wait_locker
 
 

--- a/test/integration/experiment/test_experiment_common.py
+++ b/test/integration/experiment/test_experiment_common.py
@@ -1,0 +1,57 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Integration tests for ``experiment_common.py``."""
+
+from autosubmit.experiment.experiment_common import delete_experiment
+
+
+def test_delete_experiment_cancelled(autosubmit_exp, mocker):
+    """Test that a user cancellation results in no experiment deleted."""
+    exp1 = autosubmit_exp(experiment_data={})
+    exp2 = autosubmit_exp(experiment_data={})
+
+    mocker.patch('autosubmit.experiment.experiment_common.user_yes_no_query', side_effect=[False, True])
+    mocked_log = mocker.patch('autosubmit.experiment.experiment_common.Log')
+    delete_experiment(f'{exp1.expid},{exp2.expid}', force=False)
+
+    assert exp1.exp_path.exists()
+    assert mocked_log.info.call_count > 0
+    assert mocked_log.info.call_args_list[0][:-1][0][0] == f'Experiment {exp1.expid} deletion cancelled by user'
+
+    assert not exp2.exp_path.exists()
+
+
+def test_delete_experiment_failed(autosubmit_exp, mocker):
+    exp = autosubmit_exp(experiment_data={})
+    mocker.patch('autosubmit.experiment.experiment_common._delete_experiment', side_effect=ValueError)
+
+    assert not delete_experiment(exp.expid, force=True)
+
+
+def test_delete_experiment_that_is_running(autosubmit_exp, mocker):
+    exp = autosubmit_exp(experiment_data={})
+    mocker.patch('autosubmit.experiment.experiment_common.process_id', return_value=True)
+
+    assert not delete_experiment(exp.expid, force=True)
+
+
+def test_delete_experiment_fails_db_details(autosubmit_exp, mocker):
+    exp = autosubmit_exp(experiment_data={})
+    mocker.patch('autosubmit.experiment.experiment_common.ExperimentDetails', side_effect=ValueError)
+
+    assert not delete_experiment(exp.expid, force=True)

--- a/test/integration/scripts/test_pklfix.py
+++ b/test/integration/scripts/test_pklfix.py
@@ -50,7 +50,7 @@ def test_pklfix_bypass_prompt_confirmation(autosubmit_exp, mocker: 'MockerFixtur
     passed_args = ["autosubmit", "pklfix"] + (["-f"] if force else []) + [exp.expid]
     mocker.patch("sys.argv", passed_args)
 
-    mock_user_yes_no_query = mocker.patch("autosubmit.autosubmit.Autosubmit._user_yes_no_query")
+    mock_user_yes_no_query = mocker.patch("autosubmit.autosubmit.user_yes_no_query")
     mock_user_yes_no_query.return_value = False
 
     assert main() == 0

--- a/test/integration/test_autosubmit.py
+++ b/test/integration/test_autosubmit.py
@@ -324,7 +324,7 @@ def test_autosubmit_pklfix_restores_backup(autosubmit_exp, mocker):
 
     mocked_log = mocker.patch('autosubmit.autosubmit.Log')
 
-    mocker.patch('autosubmit.autosubmit.Autosubmit._user_yes_no_query', return_value=True)
+    mocker.patch('autosubmit.autosubmit.user_yes_no_query', return_value=True)
 
     assert 0 == main()
 

--- a/test/integration/test_expid.py
+++ b/test/integration/test_expid.py
@@ -19,17 +19,23 @@
 import sqlite3
 import tempfile
 from collections.abc import Callable
+from contextlib import nullcontext as does_not_raise
 from getpass import getuser
 from itertools import permutations, product
 from pathlib import Path
 from textwrap import dedent
+from typing import cast, Any, Iterable
 
 import pytest
 from ruamel.yaml import YAML
 
 from autosubmit.autosubmit import Autosubmit
 from autosubmit.config.basicconfig import BasicConfig
-from autosubmit.experiment.experiment_common import new_experiment, copy_experiment
+# noinspection PyProtectedMember
+from autosubmit.experiment.experiment_common import (
+    check_ownership, copy_experiment, delete_experiment,
+    _delete_expid, new_experiment, _perform_deletion
+)
 from autosubmit.log.log import AutosubmitCritical, AutosubmitError
 from autosubmit.utils import as_conf_default_values
 
@@ -384,7 +390,6 @@ def test_copy_expid_with_flag_hpc(tmp_path: Path, autosubmit: Autosubmit, experi
         autosubmit expid -H ithaca -d "experiment"
         autosubmit expid -H "" -d "experiment"
 
-    :param fake_hpc: The value for the -H flag (hpc value).
     :param expected_hpc: The value it is expected for the variable hpc.
     :param autosubmit: Autosubmit interface that instantiate with no experiment.
     """
@@ -552,7 +557,7 @@ def test_autosubmit_generate_config(mocker, autosubmit: Autosubmit, tmp_path, ge
                 'CONFIG.TEST': '42'
             }
         }
-        autosubmit.generate_as_config(exp_id=expid, parameters=parameters)
+        autosubmit.generate_as_config(exp_id=expid, parameters=parameters)  # type: ignore
 
         source_text = Path(source_yaml.name).read_text()
         source_name = Path(source_yaml.name)
@@ -595,7 +600,7 @@ def test_autosubmit_generate_config_resource_listdir_order(autosubmit, mocker):
     keys = ['resources', 'dummy', 'local', 'minimal_configuration']
 
     for test_case in test_cases:
-        test = dict(zip(keys, test_case))
+        test: dict[str, Iterable[Any]] = cast(dict[str, Iterable], dict(zip(keys, test_case)))
         expid = 'ff99'
         original_local_root_dir = BasicConfig.LOCAL_ROOT_DIR
 
@@ -622,9 +627,9 @@ def test_autosubmit_generate_config_resource_listdir_order(autosubmit, mocker):
 
             autosubmit.generate_as_config(
                 exp_id=expid,
-                dummy=test['dummy'],
-                minimal_configuration=test['minimal_configuration'],
-                local=test['local'])
+                dummy=cast(bool, test['dummy']),
+                minimal_configuration=cast(bool, test['minimal_configuration']),
+                local=cast(bool, test['local']))
 
             msg = (f'Incorrect call count for resources={",".join(resources_return)}, dummy={test["dummy"]},'
                    f' minimal_configuration={test["minimal_configuration"]}, local={test["local"]}')
@@ -640,10 +645,11 @@ def test_expid_generated_correctly(tmp_path, autosubmit_exp, autosubmit):
     autosubmit.install()
     as_exp = autosubmit_exp(experiment_data=_get_experiment_data(tmp_path))
     run_dir = as_exp.as_conf.basic_config.LOCAL_ROOT_DIR
-    autosubmit.inspect(expid=f'{as_exp.expid}', check_wrapper=True, force=True, lst=None, filter_chunks=None,
-                       filter_status=None, filter_section=None)
-    assert f"{as_exp.expid}_DEBUG.cmd" in [Path(f).name for f in
-                                     Path(f"{run_dir}/{as_exp.expid}/tmp").iterdir()]
+    autosubmit.inspect(expid=f'{as_exp.expid}', check_wrapper=True, force=True, lst=None,  # type: ignore
+                       filter_chunks=None, filter_status=None, filter_section=None)  # type: ignore
+    assert f"{as_exp.expid}_DEBUG.cmd" in [
+        Path(f).name for f in Path(f"{run_dir}/{as_exp.expid}/tmp").iterdir()
+    ]
     # Consult if the expid is in the database
     db_path = Path(f"{run_dir}/tests.db")
     with sqlite3.connect(db_path) as conn:
@@ -657,8 +663,12 @@ def test_delete_experiment(mocker, tmp_path, autosubmit_exp, autosubmit: Autosub
     autosubmit.install()
     as_exp = autosubmit_exp(experiment_data=_get_experiment_data(tmp_path))
     run_dir = as_exp.as_conf.basic_config.LOCAL_ROOT_DIR
-    mocker.patch("autosubmit.autosubmit.process_id", return_value=None)
-    autosubmit.delete(expid=f'{as_exp.expid}', force=True)
+    mocker.patch("autosubmit.experiment.experiment_common.process_id", return_value=None)
+    mocked_log = mocker.patch("autosubmit.experiment.experiment_common.Log")
+
+    assert delete_experiment(expids=f'{as_exp.expid}', force=True)
+    assert mocked_log.error.call_count == 0
+
     assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}").iterdir())
     assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/data").iterdir())
     assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/logs").iterdir())
@@ -671,32 +681,40 @@ def test_delete_experiment(mocker, tmp_path, autosubmit_exp, autosubmit: Autosub
     assert cursor.fetchone() is None
     cursor.close()
     # Test doesn't exist
-    with pytest.raises(AutosubmitCritical):
-        autosubmit.delete(expid=f'{as_exp.expid}', force=True)
+
+    delete_experiment(expids=f'{as_exp.expid}', force=True)
+    assert mocked_log.error.call_count > 0
+    assert 'Experiment does not exist' in mocked_log.error.call_args_list[0][0][0]
 
 
 def test_delete_experiment_not_owner(mocker, tmp_path, autosubmit_exp, autosubmit: Autosubmit):
     autosubmit.install()
     as_exp = autosubmit_exp(experiment_data=_get_experiment_data(tmp_path))
     run_dir = as_exp.as_conf.basic_config.LOCAL_ROOT_DIR
-    mocker.patch('autosubmit.autosubmit.Autosubmit._user_yes_no_query', return_value=True)
+    mocker.patch('autosubmit.experiment.experiment_common.user_yes_no_query', return_value=True)
     mocker.patch('pwd.getpwuid', side_effect=TypeError)
-    mocker.patch("autosubmit.autosubmit.process_id", return_value=None)
-    _, _, current_owner = autosubmit._check_ownership(as_exp.expid)
+    mocker.patch("autosubmit.experiment.experiment_common.process_id", return_value=None)
+    mocked_log = mocker.patch("autosubmit.experiment.experiment_common.Log")
+    _, _, current_owner = check_ownership(as_exp.expid)
     assert current_owner is None
     # test not owner not eadmin
     _user = getuser()
-    mocker.patch("autosubmit.autosubmit.Autosubmit._check_ownership",
+    mocker.patch("autosubmit.experiment.experiment_common.check_ownership",
                  return_value=(False, False, _user))
-    with pytest.raises(AutosubmitCritical):
-        autosubmit.delete(expid=f'{as_exp.expid}', force=True)
+
+    delete_experiment(expids=f'{as_exp.expid}', force=True)
+    assert mocked_log.error.call_count > 0
+    assert 'Failed to delete experiment' in mocked_log.error.call_args_list[0][0][0]
+
     # test eadmin
-    mocker.patch("autosubmit.autosubmit.Autosubmit._check_ownership",
+    mocker.patch("autosubmit.experiment.experiment_common.check_ownership",
                  return_value=(False, True, _user))
-    with pytest.raises(AutosubmitCritical):
-        autosubmit.delete(expid=f'{as_exp.expid}', force=False)
+    delete_experiment(expids=f'{as_exp.expid}', force=False)
+    assert mocked_log.error.call_count > 0
+    assert 'Failed to delete experiment' in mocked_log.error.call_args_list[0][0][0]
+
     # test eadmin force
-    autosubmit.delete(expid=f'{as_exp.expid}', force=True)
+    delete_experiment(expids=f'{as_exp.expid}', force=True)
     assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}").iterdir())
     assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/data").iterdir())
     assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/logs").iterdir())
@@ -721,32 +739,30 @@ def test_delete_experiment_not_owner(mocker, tmp_path, autosubmit_exp, autosubmi
 )
 def test_delete_expid(mocker, tmp_path, autosubmit_exp, autosubmit, expid_value):
     as_exp = autosubmit_exp(experiment_data=_get_experiment_data(tmp_path))
-    mocker.patch('autosubmit.autosubmit.Autosubmit._perform_deletion', return_value="error")
+    mocker.patch('autosubmit.experiment.experiment_common._perform_deletion', return_value="error")
     expid_value = as_exp.expid if expid_value == "as_exp.expid" else expid_value
     if expid_value in ["..", "", "."]:
         with pytest.raises(AutosubmitCritical) as exc_info:
-            autosubmit._delete_expid(expid_value, force=True)
+            _delete_expid(expid_value, force=True)
             assert exc_info.value.code == 7001
     else:
         with pytest.raises(AutosubmitError):
-            autosubmit._delete_expid(as_exp.expid, force=True)
+            _delete_expid(as_exp.expid, force=True)
     mocker.stopall()
-    autosubmit._delete_expid(as_exp.expid, force=True)
-    assert not autosubmit._delete_expid(as_exp.expid, force=True)
+    _delete_expid(as_exp.expid, force=True)
+    with does_not_raise():
+        _delete_expid(as_exp.expid, force=True)
 
 
 def test_perform_deletion(mocker, tmp_path, autosubmit_exp, autosubmit):
     as_exp = autosubmit_exp(experiment_data=_get_experiment_data(tmp_path))
-    mocker.patch("shutil.rmtree", side_effect=FileNotFoundError)
-    mocker.patch("os.remove", side_effect=FileNotFoundError)
+    mocker.patch("autosubmit.experiment.experiment_common.rmtree", side_effect=FileNotFoundError)
     basic_config = as_exp.as_conf.basic_config
-    experiment_path = Path(f"{basic_config.LOCAL_ROOT_DIR}/{as_exp.expid}")
-    structure_db_path = Path(f"{basic_config.STRUCTURES_DIR}/structure_{as_exp.expid}.db")
-    job_data_db_path = Path(f"{basic_config.JOBDATA_DIR}/job_data_{as_exp.expid}")
+    experiment_path = Path(basic_config.LOCAL_ROOT_DIR, as_exp.expid)
+    structure_db_path = Path(basic_config.STRUCTURES_DIR, f'structure_{as_exp.expid}.db')
+    job_data_db_path = Path(basic_config.JOBDATA_DIR, f'job_data_{as_exp.expid}')
     if all("tmp" not in path for path in [str(experiment_path), str(structure_db_path), str(job_data_db_path)]):
         raise AutosubmitCritical("tmp not in path")
-    mocker.patch("autosubmit.autosubmit.delete_experiment", side_effect=FileNotFoundError)
-    err_message = autosubmit._perform_deletion(experiment_path, structure_db_path, job_data_db_path, as_exp.expid)
-    assert all(x in err_message for x in
-               ["Cannot delete experiment entry", "Cannot delete directory", "Cannot delete structure",
-                "Cannot delete job_data"])
+    mocker.patch("autosubmit.database.db_common.delete_experiment", side_effect=FileNotFoundError)
+    err_message = _perform_deletion(experiment_path, structure_db_path, job_data_db_path, as_exp.expid)
+    assert all(x in err_message for x in ["Cannot delete experiment entry", "Cannot delete directory"])

--- a/test/integration/test_run_command.py
+++ b/test/integration/test_run_command.py
@@ -50,7 +50,7 @@ def set_up_test(
     )
 
     if 'delete' in command:
-        mocker.patch('autosubmit.autosubmit.Autosubmit._user_yes_no_query', return_value=True)
+        mocker.patch('autosubmit.experiment.experiment_common.user_yes_no_query', return_value=True)
 
     command = [c.format(expid=expid) for c in command]
 

--- a/test/integration/test_utils/misc.py
+++ b/test/integration/test_utils/misc.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     'wait_child',
+    'wait_locker'
 ]
 
 


### PR DESCRIPTION
…deletion code in experiment_common now)

Closes #1216
Closes #2334

Also cleans up `Autosubmit` class. It has over 6000 lines, and the delete logic is all in the `Autosubmit` class, occupying ~600 lines (≈10%). I've moved the deletion logic to `experiment_common`, and now will update the code & tests, then add the logic in argparse to return a list of expids, and call the delete command multiple times.

If an expid fails to be deleted, the command will move on with others and report what worked, and what didn't. cc @Lerriola 

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
