### PR TITLE
fixes finish time offset if there is an extended_tailer

### DIFF
--- a/autosubmit/job/template/bash.py
+++ b/autosubmit/job/template/bash.py
@@ -53,7 +53,6 @@ function as_exit_handler {
     local exit_code=$?
     
     if [ "$exit_code" -eq 0 ]; then
-        %EXTENDED_TAILER%
         touch "${job_name_ptrn}_COMPLETED"
         # If the user-provided script failed, we exit here with the same exit code;
         # otherwise, we let the execution of the tailer happen, where the _COMPLETED
@@ -87,6 +86,7 @@ _AS_BASH_TAILER = dedent("""\
 ###################
 # Autosubmit tailer
 ###################
+%EXTENDED_TAILER%
 # Job completed successfully
 # The exit trap will handle the tailer
 """)


### PR DESCRIPTION

While checking the trap signal code, I notice that we write the failed time before the extended_tailer code

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
