### PR TITLE
[Refactoring] Removing the ENABLE_WRAPPER_THREADS

### DIFF
--- a/docs/source/userguide/configure/develop_a_project.rst
+++ b/docs/source/userguide/configure/develop_a_project.rst
@@ -134,8 +134,6 @@ Autosubmit configuration
         # DELAY_RETRY_TIME:*11 # will wait 11,110,1110,11110...
         # Default output type for CREATE, MONITOR, SET STATUS, RECOVERY. Available options: pdf, svg, png, ps, txt
         # Default:pdf
-        # This parameter is used to enable the use of threads in autosubmit for the wrappers. # Default False
-        ENABLE_WRAPPER_THREADS: False
         OUTPUT:pdf
         WRAPPERS_WALLCLOCK: 48:00  # Default max_wallclock for wrappers before getting killed
         JOB_WALLCLOCK: 24:00  # Default max_wallclock for jobs before getting killed


### PR DESCRIPTION
Closes #2691

When forced to enter the thread creation it would create the thread but since each job run in isolation it would never execute with the exception of when mocked.
So the deleting the best approach would be delete the inactive piece of code 

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
