### PR TITLE
Integrate `yaml-provenance` for Enhanced Configuration Traceability

### DIFF
--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -37,44 +37,31 @@ from pyparsing import nested_expr
 from ruamel.yaml import YAML
 
 # ---------------------------------------------------------------------------
-# Optional yaml-provenance integration
+# yaml-provenance integration
 # ---------------------------------------------------------------------------
-# When yaml-provenance is installed (see yamlparser.py for install notes)
 # WithProvenance leaf values (StrWithProvenance, IntWithProvenance, etc.) are
 # transparent subclasses of their native types and carry provenance metadata
-# independently. No container-level changes are needed here.
-# The flag is kept so get_value_provenance() can guard its behaviour, and
-# _ProvenanceJSONEncoder is used in get_full_config_as_json().
+# independently.  No container-level changes are needed here.
+# ProvenanceJSONEncoder is used in get_full_config_as_json().
 #
 # _wrap_with_source() / _wrap_dict_with_source() annotate programmatically
 # injected values (BasicConfig props, environment vars, computed HPC params,
 # git commit) so they appear with meaningful comments in experiment_data.yml
 # instead of "# no provenance".
 # ---------------------------------------------------------------------------
-try:
-    from yaml_provenance import (
-        wrap_computed,
-        transfer_provenance,
-        annotate_dict,
-        ProvenanceJSONEncoder as _LibProvenanceJSONEncoder,
-    )
-    _HAS_YAML_PROVENANCE = True
-except ImportError:
-    wrap_computed = None           # type: ignore[assignment]
-    transfer_provenance = None     # type: ignore[assignment]
-    annotate_dict = None           # type: ignore[assignment]
-    _LibProvenanceJSONEncoder = None  # type: ignore[assignment]
-    _HAS_YAML_PROVENANCE = False
+from yaml_provenance import (
+    wrap_computed,
+    transfer_provenance,
+    annotate_dict,
+    ProvenanceJSONEncoder as _ProvenanceJSONEncoder,
+)
 
 
 def _wrap_with_source(value: Any, source: str) -> Any:
     """Wrap *value* with provenance pointing to *source*.
 
-    Thin wrapper around ``yaml_provenance.wrap_computed`` that gracefully
-    degrades when the library is not installed.
+    Thin wrapper around ``yaml_provenance.wrap_computed``.
     """
-    if not _HAS_YAML_PROVENANCE:
-        return value
     try:
         return wrap_computed(value, source)
     except Exception:
@@ -84,30 +71,17 @@ def _wrap_with_source(value: Any, source: str) -> Any:
 def _preserve_prov(original: Any, result: Any) -> Any:
     """Return *result* with *original*'s provenance re-attached.
 
-    Thin wrapper around ``yaml_provenance.transfer_provenance`` that
-    gracefully degrades when the library is not installed.
+    Thin wrapper around ``yaml_provenance.transfer_provenance``.
     """
-    if not _HAS_YAML_PROVENANCE:
-        return result
     return transfer_provenance(original, result)
 
 
 def _wrap_dict_with_source(d: dict, source_prefix: str) -> dict:
     """Wrap every scalar leaf of *d* with per-key provenance.
 
-    Thin wrapper around ``yaml_provenance.annotate_dict`` that gracefully
-    degrades when the library is not installed.
+    Thin wrapper around ``yaml_provenance.annotate_dict``.
     """
-    if not _HAS_YAML_PROVENANCE:
-        return d
     return annotate_dict(d, source_prefix)
-
-
-# For JSON serialization — use library encoder or fallback to standard
-if _HAS_YAML_PROVENANCE:
-    _ProvenanceJSONEncoder = _LibProvenanceJSONEncoder
-else:
-    _ProvenanceJSONEncoder = json.JSONEncoder
 
 
 from autosubmit.config.basicconfig import BasicConfig
@@ -306,10 +280,9 @@ class AutosubmitConfig(object):
         are present only when ``ProvenanceConfig(track_history=True)`` is set
         (which is the default in ``yamlparser.py``).
 
-        Returns an empty list when the value is not found, when
-        ``yaml-provenance`` is not installed, or when the value is a plain
-        Python object without provenance metadata (e.g. a value that was
-        synthesised internally rather than read from a file).
+        Returns an empty list when the value is not found or when the value
+        is a plain Python object without provenance metadata (e.g. a value
+        that was synthesised internally rather than read from a file).
 
         Usage example::
 
@@ -324,8 +297,6 @@ class AutosubmitConfig(object):
         :return: List of provenance dicts (empty when unavailable).
         :rtype: list[dict]
         """
-        if not _HAS_YAML_PROVENANCE:
-            return []
         value = self.get_section(section)
         provenance = getattr(value, "provenance", None)
         if provenance is None:
@@ -2207,16 +2178,11 @@ class AutosubmitConfig(object):
 
             try:
                 with open(self.metadata_folder.joinpath("experiment_data.yml"), 'w') as stream:
-                    if _HAS_YAML_PROVENANCE:
-                        # dump_yaml writes inline provenance comments (file/line/col)
-                        # and correctly serialises NoneWithProvenance as empty YAML
-                        # values rather than ruamel anchor/alias references (*id001).
-                        from yaml_provenance import dump_yaml
-                        dump_yaml(self.experiment_data, stream=stream)
-                    else:
-                        # Fallback: plain ruamel dump (no provenance annotations).
-                        # Not using typ="safe" to preserve readability.
-                        YAML().dump(self.experiment_data, stream)
+                    # dump_yaml writes inline provenance comments (file/line/col)
+                    # and correctly serialises NoneWithProvenance as empty YAML
+                    # values rather than ruamel anchor/alias references (*id001).
+                    from yaml_provenance import dump_yaml
+                    dump_yaml(self.experiment_data, stream=stream)
                 self.metadata_folder.joinpath("experiment_data.yml").chmod(0o755)
             except Exception as e:
                 Log.warning(f"Failed to save experiment_data.yml: {str(e)}")

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -582,7 +582,7 @@ class AutosubmitConfig(object):
         normalized_data = dict()
         with suppress(Exception):
             for key, val in data.items():
-                normalized_key = str(key).upper()
+                normalized_key = _preserve_prov(key, str(key).upper())
                 if isinstance(val, collections.abc.Mapping):
                     normalized_data[normalized_key] = self.deep_normalize(val)
                 elif isinstance(val, list):
@@ -829,10 +829,10 @@ class AutosubmitConfig(object):
         aux_dependencies = {}
         if isinstance(dependencies, str):
             for dependency in dependencies.upper().split(" "):
-                aux_dependencies[dependency] = {}
+                aux_dependencies[_preserve_prov(dependencies, dependency)] = {}
         elif isinstance(dependencies, dict):
             for dependency, dependency_data in dependencies.items():
-                aux_dependencies[dependency.upper()] = dependency_data
+                aux_dependencies[_preserve_prov(dependency, dependency.upper())] = dependency_data
                 if isinstance(dependency_data, dict) and dependency_data.get("STATUS", None):
                     status_orig = dependency_data["STATUS"]
                     status_upper = _preserve_prov(status_orig, status_orig.upper())

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -36,6 +36,138 @@ from configobj import ConfigObj
 from pyparsing import nested_expr
 from ruamel.yaml import YAML
 
+# ---------------------------------------------------------------------------
+# Optional yaml-provenance integration
+# ---------------------------------------------------------------------------
+# When yaml-provenance is installed (see yamlparser.py for install notes)
+# WithProvenance leaf values (StrWithProvenance, IntWithProvenance, etc.) are
+# transparent subclasses of their native types and carry provenance metadata
+# independently. No container-level changes are needed here.
+# The flag is kept so get_value_provenance() can guard its behaviour, and
+# _ProvenanceJSONEncoder is used in get_full_config_as_json().
+#
+# _wrap_with_source() / _wrap_dict_with_source() annotate programmatically
+# injected values (BasicConfig props, environment vars, computed HPC params,
+# git commit) so they appear with meaningful comments in experiment_data.yml
+# instead of "# no provenance".
+# ---------------------------------------------------------------------------
+try:
+    from yaml_provenance._wrapper import (
+        ProvenanceClassForTheUnsubclassable as _PCSForUnsubclassable,
+        wrapper_with_provenance_factory as _wp_factory,
+    )
+    _HAS_YAML_PROVENANCE = True
+except ImportError:
+    _PCSForUnsubclassable = None   # type: ignore[assignment,misc]
+    _wp_factory = None             # type: ignore[assignment,misc]
+    _HAS_YAML_PROVENANCE = False
+
+
+def _wrap_with_source(value: Any, source: str) -> Any:
+    """Wrap *value* with a provenance annotation pointing to *source*.
+
+    Used to give meaningful provenance comments to values that are injected
+    programmatically (not loaded from a YAML file), such as BasicConfig
+    attributes, environment variables, computed HPC parameters, and git refs.
+
+    When yaml-provenance is not installed the value is returned unchanged so
+    the function is always safe to call unconditionally.
+
+    The *source* string is placed in the ``yaml_file`` field of the provenance
+    dict.  The ``dump_yaml`` formatter renders it as::
+
+        KEY: value  # <source>,line:0,col:0
+
+    Suggested *source* formats:
+    - ``"autosubmit.config.BasicConfig.ATTR_NAME"`` — for BasicConfig.props()
+    - ``"environment:$VAR_NAME"``                  — for os.environ lookups
+    - ``"computed:PLATFORMS.ARCH.PARAM"``           — for HPC* derived values
+    - ``"git:<project_dir>/.git/HEAD"``             — for workflow commit
+    - ``"computed:BasicConfig.LOCAL_ROOT_DIR/<expid>"`` — for ROOTDIR/PROJDIR
+
+    :param value: The value to annotate.
+    :param source: Human-readable source description.
+    :return: Provenance-wrapped value, or the original value if the library
+        is unavailable.
+    """
+    if not _HAS_YAML_PROVENANCE or _wp_factory is None:
+        return value
+    provenance = {'yaml_file': source, 'line': 0, 'col': 0,
+                  'category': None, 'subcategory': None}
+    try:
+        return _wp_factory(value, provenance)
+    except Exception:
+        return value
+
+
+def _preserve_prov(original: Any, result: Any) -> Any:
+    """Return *result* wrapped with the provenance of *original*.
+
+    Used when a string operation (``str.upper()``, ``str.strip()``, etc.)
+    produces a plain ``str`` from a ``WithProvenance`` subclass, discarding
+    the provenance.  This helper re-attaches the original provenance to the
+    new value so the transformation is transparent in experiment_data.yml.
+
+    When yaml-provenance is not installed, or *original* has no provenance,
+    the function returns *result* unchanged — always safe to call.
+
+    :param original: The WithProvenance source value (before the operation).
+    :param result: The plain-str result of the operation.
+    :return: *result* with *original*'s provenance, or *result* as-is.
+    """
+    if not _HAS_YAML_PROVENANCE or _wp_factory is None:
+        return result
+    prov = getattr(original, 'provenance', None)
+    if not prov:
+        return result
+    try:
+        return _wp_factory(result, prov[-1])
+    except Exception:
+        return result
+
+
+def _wrap_dict_with_source(d: dict, source_prefix: str) -> dict:
+    """Wrap every scalar leaf of *d* with a per-key provenance source in-place.
+
+    For each key ``K``, the source annotation is ``<source_prefix>.<K>`` so
+    that the resulting comment is e.g.
+    ``# autosubmit.config.BasicConfig.DB_DIR,line:0,col:0``.
+
+    Recurses into nested dicts (using the same prefix, not extending it, so
+    that nested BasicConfig dicts are still attributed to the top-level class).
+    Leaves that already carry provenance are left untouched.
+
+    :param d: Dict to annotate (modified in-place and returned).
+    :param source_prefix: Base source string (e.g. ``"autosubmit.config.BasicConfig"``).
+    :return: The annotated dict.
+    """
+    if not _HAS_YAML_PROVENANCE:
+        return d
+    for key, value in d.items():
+        if isinstance(value, dict):
+            _wrap_dict_with_source(value, source_prefix)
+        elif not hasattr(value, 'provenance'):
+            d[key] = _wrap_with_source(value, f"{source_prefix}.{key}")
+    return d
+
+
+class _ProvenanceJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles yaml-provenance wrapper types.
+
+    ``BoolWithProvenance`` (and ``NoneWithProvenance``) are subclasses of
+    ``ProvenanceClassForTheUnsubclassable`` rather than ``bool`` / ``NoneType``,
+    so the standard json encoder doesn't recognise them.  This encoder handles
+    them explicitly.  All other WithProvenance types (StrWithProvenance,
+    IntWithProvenance, …) are genuine subclasses of their native types and are
+    handled transparently by the default encoder.
+    """
+    def default(self, obj):
+        if _PCSForUnsubclassable is not None and isinstance(obj, _PCSForUnsubclassable):
+            # BoolWithProvenance.value → True/False; NoneWithProvenance.value → None
+            return obj.value
+        return super().default(obj)
+
+
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.config.yamlparser import YAMLParserFactory
 from autosubmit.log.log import Log, AutosubmitCritical, AutosubmitError
@@ -150,7 +282,7 @@ class AutosubmitConfig(object):
     def get_full_config_as_json(self):
         """Return config as json object"""
         try:
-            return json.dumps(self.experiment_data)
+            return json.dumps(self.experiment_data, cls=_ProvenanceJSONEncoder)
         except Exception as e:
             Log.warning(f"Autosubmit was not able to retrieve and save the configuration "
                         f"into the historical database: {str(e)}")
@@ -204,7 +336,7 @@ class AutosubmitConfig(object):
         current_level: Union[str, dict] = self.experiment_data.get(section[0], "")
         for param in section[1:]:
             if current_level:
-                if type(current_level) is dict:
+                if isinstance(current_level, dict):
                     current_level = current_level.get(param, d_value)
                 else:
                     if must_exists:
@@ -218,6 +350,48 @@ class AutosubmitConfig(object):
         if current_level is None or (not isinstance(current_level, numbers.Number) and len(current_level) == 0):
             return d_value
         return current_level
+
+    def get_value_provenance(self, section: list[str]) -> list[dict]:
+        """Return the provenance history of a configuration value.
+
+        This is a convenience wrapper around ``get_section`` that exposes the
+        ``yaml-provenance`` metadata attached to a leaf value.  Each entry in
+        the returned list is a dict of the form::
+
+            {'yaml_file': '/path/to/conf/expdef_a001.yml', 'line': 14, 'col': 8}
+
+        The *last* element is the current (winning) provenance; earlier entries
+        are present only when ``ProvenanceConfig(track_history=True)`` is set
+        (which is the default in ``yamlparser.py``).
+
+        Returns an empty list when the value is not found, when
+        ``yaml-provenance`` is not installed, or when the value is a plain
+        Python object without provenance metadata (e.g. a value that was
+        synthesised internally rather than read from a file).
+
+        Usage example::
+
+            as_conf = AutosubmitConfig("a001")
+            as_conf.reload()
+            prov = as_conf.get_value_provenance(["JOBS", "INI", "WALLCLOCK"])
+            # [{'yaml_file': '.../jobs_a001.yml', 'line': 14, 'col': 8}]
+
+        :param section: Dot-separated key path as a list, e.g.
+            ``["JOBS", "INI", "WALLCLOCK"]``.
+        :type section: list[str]
+        :return: List of provenance dicts (empty when unavailable).
+        :rtype: list[dict]
+        """
+        if not _HAS_YAML_PROVENANCE:
+            return []
+        value = self.get_section(section)
+        provenance = getattr(value, "provenance", None)
+        if provenance is None:
+            return []
+        # provenance may be a single Provenance object or a list; normalise.
+        if isinstance(provenance, list):
+            return [dict(p) for p in provenance]
+        return [dict(provenance)]
 
     def get_wchunkinc(self, section: str) -> str:
         """Gets the chunk increase to wallclock.
@@ -459,6 +633,10 @@ class AutosubmitConfig(object):
         :return: A new dictionary with all keys normalized to uppercase.
         :rtype: dict[str, Any]
         """
+        # Use a plain dict as the output container. Leaf values loaded by
+        # yaml-provenance are already WithProvenance subclasses of their native
+        # types (StrWithProvenance, IntWithProvenance, …) and carry their own
+        # provenance metadata independently of the container type.
         normalized_data = dict()
         with suppress(Exception):
             for key, val in data.items():
@@ -494,9 +672,14 @@ class AutosubmitConfig(object):
                 if len(val) > 0 and isinstance(val[0], collections.abc.Mapping):
                     unified_config[key] = val
                 else:
-                    current_list = unified_config.get(key, [])
-                    if current_list != val:
-                        unified_config[key] = val
+                    # Always replace the current list with the new one.  The original
+                    # ``current_list != val`` guard was an optimisation that fires
+                    # incorrectly when ``val`` contains ``StrWithProvenance`` items and
+                    # ``current_list`` contains plain str items of the same value:
+                    # ``StrWithProvenance.__eq__`` uses plain-str comparison, so the
+                    # lists appear equal and the provenance-bearing ``val`` is silently
+                    # discarded in favour of the plain-string ``current_list``.
+                    unified_config[key] = val
             else:
                 unified_config[key] = new_dict[key]
         return unified_config
@@ -520,10 +703,13 @@ class AutosubmitConfig(object):
     def _normalize_default_section(self, data_fixed: dict) -> None:
         default_section = data_fixed.get("DEFAULT", {})
         if "HPCARCH" in default_section:
-            data_fixed["DEFAULT"]["HPCARCH"] = default_section["HPCARCH"].upper()
+            orig = default_section["HPCARCH"]
+            data_fixed["DEFAULT"]["HPCARCH"] = _preserve_prov(orig, orig.upper())
         if "CUSTOM_CONFIG" in default_section:
             try:
-                data_fixed["DEFAULT"]["CUSTOM_CONFIG"] = self.convert_list_to_string(default_section["CUSTOM_CONFIG"])
+                orig = default_section["CUSTOM_CONFIG"]
+                converted = self.convert_list_to_string(orig)
+                data_fixed["DEFAULT"]["CUSTOM_CONFIG"] = _preserve_prov(orig, converted)
             except Exception:
                 pass
 
@@ -607,12 +793,19 @@ class AutosubmitConfig(object):
         """
         notify_on = data_fixed["JOBS"][job_section].get("NOTIFY_ON", "")
         if notify_on:
-            if type(notify_on) is str:
+            if isinstance(notify_on, str):
+                # Split the scalar string into individual status tokens.  str.split()
+                # returns plain str items even when called on a StrWithProvenance, so
+                # we borrow the parent string's provenance for every token we produce.
                 if "," in notify_on:
-                    notify_on = notify_on.split(",")
+                    parts = notify_on.split(",")
                 else:
-                    notify_on = notify_on.split()
-            data_fixed["JOBS"][job_section]["NOTIFY_ON"] = [status.strip(" ").upper() for status in notify_on]
+                    parts = notify_on.split()
+                notify_on = [_preserve_prov(notify_on, p.strip()) for p in parts]
+            # Preserve provenance: .strip().upper() on StrWithProvenance returns plain str
+            data_fixed["JOBS"][job_section]["NOTIFY_ON"] = [
+                _preserve_prov(status, status.strip(" ").upper()) for status in notify_on
+            ]
 
     def _normalize_jobs_section(self, data_fixed: dict, must_exists: bool) -> None:
         for job, job_data in data_fixed.get("JOBS", {}).items():
@@ -623,16 +816,30 @@ class AutosubmitConfig(object):
                 custom_directives = job_data.get("CUSTOM_DIRECTIVES", "")
                 if isinstance(custom_directives, list):
                     custom_directives = str(custom_directives)
-                if type(custom_directives) is str:
-                    data_fixed["JOBS"][job]["CUSTOM_DIRECTIVES"] = str(custom_directives)
+                if isinstance(custom_directives, str):
+                    orig = job_data.get("CUSTOM_DIRECTIVES", "")
+                    data_fixed["JOBS"][job]["CUSTOM_DIRECTIVES"] = _preserve_prov(orig, str(custom_directives))
                 else:
                     data_fixed["JOBS"][job]["CUSTOM_DIRECTIVES"] = custom_directives
 
             if "FILE" in job_data or must_exists:
-                files = self._normalize_files(job_data.get("FILE", ""))
-                data_fixed["JOBS"][job]["FILE"] = files[0].strip(" ")
+                file_orig = job_data.get("FILE", "")
+                files = self._normalize_files(file_orig)
+                # Preserve provenance on FILE: .strip() returns plain str.
+                # When FILE is a comma/space-separated string, _normalize_files
+                # splits it and files[0] is a plain str.  Use _preserve_prov with
+                # file_orig so the provenance of the original FILE scalar is kept.
+                stripped = files[0].strip(" ")
+                _file_prov_src = (file_orig if not isinstance(file_orig, list)
+                                  else (file_orig[0] if file_orig else file_orig))
+                data_fixed["JOBS"][job]["FILE"] = _preserve_prov(_file_prov_src, stripped)
                 if len(files) > 1:
-                    data_fixed["JOBS"][job]["ADDITIONAL_FILES"] = [file.strip(" ") for file in files[1:]]
+                    # files[1:] are plain str items produced by _normalize_files's
+                    # .split().  Borrow provenance from the original FILE value so
+                    # each ADDITIONAL_FILES entry traces back to where FILE was defined.
+                    data_fixed["JOBS"][job]["ADDITIONAL_FILES"] = [
+                        _preserve_prov(file_orig, f.strip(" ")) for f in files[1:]
+                    ]
 
             if "ADDITIONAL_FILES" not in data_fixed["JOBS"][job] and must_exists:
                 data_fixed["JOBS"][job]["ADDITIONAL_FILES"] = []
@@ -659,7 +866,7 @@ class AutosubmitConfig(object):
                 # Truncate SS to "HH:MM"
                 Log.warning(
                     f"Wallclock {wallclock} is in HH:MM:SS format. Autosubmit does not support the seconds. Truncating to HH:MM")
-                data_fixed["JOBS"][job]["WALLCLOCK"] = wallclock[:5]
+                data_fixed["JOBS"][job]["WALLCLOCK"] = _preserve_prov(wallclock, wallclock[:5])
 
     @staticmethod
     def _normalize_dependencies(dependencies: Union[str, dict]) -> dict:
@@ -684,23 +891,39 @@ class AutosubmitConfig(object):
         elif isinstance(dependencies, dict):
             for dependency, dependency_data in dependencies.items():
                 aux_dependencies[dependency.upper()] = dependency_data
-                if type(dependency_data) is dict and dependency_data.get("STATUS", None):
-                    dependency_data["STATUS"] = dependency_data["STATUS"].upper()
+                if isinstance(dependency_data, dict) and dependency_data.get("STATUS", None):
+                    status_orig = dependency_data["STATUS"]
+                    status_upper = _preserve_prov(status_orig, status_orig.upper())
                     if not dependency_data.get("ANY_FINAL_STATUS_IS_VALID", False):
-                        if dependency_data["STATUS"][-1] == "?":
-                            dependency_data["STATUS"] = dependency_data["STATUS"][:-1]
-                            dependency_data["ANY_FINAL_STATUS_IS_VALID"] = True
-                        elif dependency_data["STATUS"] not in ["READY", "DELAYED", "PREPARED", "SKIPPED", "FAILED",
-                                                               "COMPLETED"]:  # May change in future issues.
-                            dependency_data["ANY_FINAL_STATUS_IS_VALID"] = True
+                        if isinstance(status_upper, str) and status_upper.endswith("?"):
+                            status_upper = _preserve_prov(status_upper, status_upper[:-1])
+                            # ANY_FINAL_STATUS_IS_VALID is a computed bool; borrow provenance
+                            # from the STATUS value so it carries a meaningful source comment.
+                            dependency_data["ANY_FINAL_STATUS_IS_VALID"] = _preserve_prov(status_orig, True)
+                        elif str(status_upper) not in ["READY", "DELAYED", "PREPARED", "SKIPPED", "FAILED",
+                                                       "COMPLETED"]:
+                            dependency_data["ANY_FINAL_STATUS_IS_VALID"] = _preserve_prov(status_orig, True)
                         else:
-                            dependency_data["ANY_FINAL_STATUS_IS_VALID"] = False
+                            dependency_data["ANY_FINAL_STATUS_IS_VALID"] = _preserve_prov(status_orig, False)
+                    dependency_data["STATUS"] = status_upper
 
         return aux_dependencies
 
     @staticmethod
     def _normalize_files(files: Union[str, list[str]]) -> list[str]:
-        if type(files) is not list:
+        """Split a FILE value into a list of individual file paths.
+
+        When *files* is already a list (e.g. a YAML block-sequence), it is
+        returned as-is so that ``StrWithProvenance`` items keep their metadata.
+
+        When *files* is a scalar string (comma- or space-separated paths), the
+        result of ``str.split()`` consists of plain ``str`` items — provenance on
+        the original ``StrWithProvenance`` scalar is intentionally *not*
+        propagated here because the caller (``_normalize_jobs_section``) is
+        responsible for re-attaching the parent provenance with
+        ``_preserve_prov(file_orig, item)`` for each split fragment.
+        """
+        if not isinstance(files, list):
             if ',' in files:
                 files = files.split(",")
             elif ' ' in files:
@@ -710,21 +933,49 @@ class AutosubmitConfig(object):
         return files
 
     def dict_replace_value(self, d: dict, old: str, new: str, index: int, section_names: list) -> dict:
+        """Replace *old* with *new* inside the nested dict *d*, preserving WithProvenance.
+
+        Two substitution modes are handled:
+
+        * **Whole-value** (``d[key] == old``): assign *new* directly so any
+          ``WithProvenance`` metadata on *new* is preserved intact.  If *new* is a
+          plain ``str`` (e.g. the result of a partial concatenation higher up the
+          call chain), re-attach the *original* value's provenance so the YAML
+          source location is not lost.
+
+        * **Partial** (``old`` is a substring of ``d[key]``): perform the text
+          substitution with ``.replace()`` and then re-attach the original value's
+          provenance via :func:`_preserve_prov`.
+
+        Both scalar and list-item variants follow the same logic.
+        """
         current_section = section_names.pop()
         if d.get(current_section, None) is None:
             return d
         if isinstance(d[current_section], dict):
             d[current_section] = self.dict_replace_value(d[current_section], old, new, index, section_names)
         elif isinstance(d[current_section], list):
-            d[current_section][index] = d[current_section][index].replace(old[index], new)
+            item = d[current_section][index]
+            old_item = old[index] if isinstance(old, list) else old
+            if str(item) == str(old_item):
+                # Whole-value: keep WithProvenance on new; or restore original prov.
+                d[current_section][index] = new if hasattr(new, 'provenance') else _preserve_prov(item, new)
+            else:
+                # Partial: replace text, restore original item's provenance.
+                d[current_section][index] = _preserve_prov(item, item.replace(old_item, new))
         elif isinstance(d[current_section], str) and d[current_section] == old:
-            d[current_section] = d[current_section].replace(old, new)
+            # Whole-value: keep WithProvenance on new; or restore original prov.
+            d[current_section] = new if hasattr(new, 'provenance') else _preserve_prov(d[current_section], new)
+        elif isinstance(d[current_section], str):
+            # Partial: replace text, restore original value's provenance.
+            original = d[current_section]
+            d[current_section] = _preserve_prov(original, original.replace(old, new))
         return d
 
     def convert_list_to_string(self, data):
         """Convert a list to a string
         """
-        if type(data) is dict:
+        if isinstance(data, dict):
             for key, val in data.items():
                 if isinstance(val, list):
                     data[key] = ",".join(val)
@@ -790,8 +1041,8 @@ class AutosubmitConfig(object):
         filenames_to_load["POST"] = []
         if custom_conf_directive is not None:
             # Check if directive is a dictionary
-            if type(custom_conf_directive) is not dict:
-                if type(custom_conf_directive) is str and custom_conf_directive != "":
+            if not isinstance(custom_conf_directive, dict):
+                if isinstance(custom_conf_directive, str) and custom_conf_directive != "":
                     if ',' in custom_conf_directive:
                         filenames_to_load["PRE"] = custom_conf_directive.split(',')
                     else:
@@ -1155,7 +1406,14 @@ class AutosubmitConfig(object):
             param = param.get(k.upper(), {})
             if isinstance(param, int):
                 param = str(param)
-        return str(rest_of_key_start) + str(param) + str(rest_of_key_end) if param else None
+        if not param:
+            return None
+        # When the entire value is a reference (no surrounding text), return
+        # param directly so its WithProvenance type and provenance are preserved.
+        # When there is surrounding text, concatenation forces a plain str.
+        if rest_of_key_start == '' and rest_of_key_end == '':
+            return param
+        return str(rest_of_key_start) + str(param) + str(rest_of_key_end)
 
     def _update_parameters(
             self,
@@ -1357,7 +1615,7 @@ class AutosubmitConfig(object):
             if parser_data["CONFIG"].get('TOTALJOBS', -1) == -1:
                 self.wrong_config["Autosubmit"] += [['config',
                                                      "TOTALJOBS parameter not found or non-integer"]]
-            if type(parser_data["CONFIG"].get('RETRIALS', 0)) is not int:
+            if not isinstance(parser_data["CONFIG"].get('RETRIALS', 0), int):
                 parser_data["CONFIG"]['RETRIALS'] = int(parser_data["CONFIG"].get('RETRIALS', 0))
 
         if parser_data.get("STORAGE", None) is None:
@@ -1371,7 +1629,7 @@ class AutosubmitConfig(object):
         if parser_data.get("MAIL", "") != "":
             if str(parser_data["MAIL"].get("NOTIFICATIONS", "false")).lower() == "true":
                 mails = parser_data["MAIL"].get("TO", "")
-                if type(mails) is list:
+                if isinstance(mails, list):
                     pass
                 elif "," in mails:
                     mails = mails.split(',')
@@ -1470,7 +1728,7 @@ class AutosubmitConfig(object):
 
             dependencies = section_data.get('DEPENDENCIES', '')
             if dependencies != "":
-                if type(dependencies) is dict:
+                if isinstance(dependencies, dict):
                     for dependency, values in dependencies.items():
                         if '-' in dependency:
                             dependency = dependency.split('-')[0]
@@ -1537,11 +1795,13 @@ class AutosubmitConfig(object):
             if type(parser['EXPERIMENT'].get('CHUNKSIZE', "-1")) not in [int]:
                 if parser['EXPERIMENT']['CHUNKSIZE'] == "-1":
                     self.wrong_config["Expdef"] += [['experiment', "Mandatory EXPERIMENT.CHUNKSIZE is not defined"]]
-                parser['EXPERIMENT']['CHUNKSIZE'] = int(parser['EXPERIMENT']['CHUNKSIZE'])
+                _cs = parser['EXPERIMENT']['CHUNKSIZE']
+                parser['EXPERIMENT']['CHUNKSIZE'] = _preserve_prov(_cs, int(_cs))
             if type(parser['EXPERIMENT'].get('NUMCHUNKS', "-1")) not in [int]:
                 if parser['EXPERIMENT']['NUMCHUNKS'] == "-1":
                     self.wrong_config["Expdef"] += [['experiment', "Mandatory EXPERIMENT.NUMCHUNKS is not defined"]]
-                parser['EXPERIMENT']['NUMCHUNKS'] = int(parser['EXPERIMENT']['NUMCHUNKS'])
+                _nc = parser['EXPERIMENT']['NUMCHUNKS']
+                parser['EXPERIMENT']['NUMCHUNKS'] = _preserve_prov(_nc, int(_nc))
             if parser['EXPERIMENT'].get('CALENDAR', "").lower() not in ['standard', 'noleap']:
                 self.wrong_config["Expdef"] += [['experiment', "Mandatory EXPERIMENT.CALENDAR choice is invalid"]]
         if parser.get('PROJECT', "") == "":
@@ -1600,7 +1860,7 @@ class AutosubmitConfig(object):
             wrappers = {}
         for wrapper_name, wrapper_values in wrappers.items():
             # continue if it is a global option (non-dicT)
-            if type(wrapper_values) is not dict:
+            if not isinstance(wrapper_values, dict):
                 continue
             jobs_in_wrapper = wrapper_values.get('JOBS_IN_WRAPPER', [])
             for section in jobs_in_wrapper:
@@ -1768,12 +2028,12 @@ class AutosubmitConfig(object):
         :param parameter:
         :return: list
         """
-        if type(self.starter_conf[parameter]) is str:
+        if isinstance(self.starter_conf[parameter], str):
             if "," in self.starter_conf[parameter]:
                 list_parameters = self.starter_conf[parameter].split(",")
             else:
                 list_parameters = [self.starter_conf[parameter]]
-        elif type(self.starter_conf[parameter]) is list:
+        elif isinstance(self.starter_conf[parameter], list):
             list_parameters = self.starter_conf[parameter]
         else:
             list_parameters = list(self.starter_conf[parameter])
@@ -1804,8 +2064,10 @@ class AutosubmitConfig(object):
         """
         for key, value in os.environ.items():
             if key.startswith("AS_ENV"):
-                parameters[key] = value
-        parameters["AS_ENV_CURRENT_USER"] = os.environ.get("SUDO_USER", os.environ.get("USER", None))
+                parameters[key] = _wrap_with_source(value, f"environment:${key}")
+        user = os.environ.get("SUDO_USER", os.environ.get("USER", None))
+        user_var = "SUDO_USER" if os.environ.get("SUDO_USER") else "USER"
+        parameters["AS_ENV_CURRENT_USER"] = _wrap_with_source(user, f"environment:${user_var}")
         return parameters
 
     def needs_reload(self) -> bool:
@@ -1868,10 +2130,19 @@ class AutosubmitConfig(object):
                 del self.experiment_data["AS_TEMP"]
             # IF expid and hpcarch are not defined, use the ones from the minimal.yml file
             self.deep_add_missing_starter_conf(self.experiment_data, starter_conf)
-            self.experiment_data['ROOTDIR'] = os.path.join(
-                BasicConfig.LOCAL_ROOT_DIR, self.expid)
-            self.experiment_data['PROJDIR'] = self.get_project_dir()
-            self.experiment_data.update(BasicConfig().props())
+            self.experiment_data['ROOTDIR'] = _wrap_with_source(
+                os.path.join(BasicConfig.LOCAL_ROOT_DIR, self.expid),
+                f"computed:BasicConfig.LOCAL_ROOT_DIR/{self.expid}",
+            )
+            self.experiment_data['PROJDIR'] = _wrap_with_source(
+                self.get_project_dir(),
+                f"computed:BasicConfig.LOCAL_ROOT_DIR/{self.expid}/proj",
+            )
+            # BasicConfig().props() reads from autosubmit.conf (~/.autosubmit/autosubmit.conf
+            # or /etc/autosubmit/autosubmit.conf) and injects operational paths and settings.
+            _bc_props = BasicConfig().props()
+            _wrap_dict_with_source(_bc_props, "autosubmit.config.BasicConfig")
+            self.experiment_data.update(_bc_props)
             self.experiment_data = self.normalize_variables(self.experiment_data, must_exists=True, raise_exception=True)
             self.experiment_data = self.deep_read_loops(self.experiment_data)
             self.experiment_data = self.substitute_dynamic_variables(self.experiment_data, in_the_end=True)
@@ -1924,11 +2195,15 @@ class AutosubmitConfig(object):
         project_dir = Path(self.get_project_dir())
         if project_dir.joinpath(".git").exists():
             with suppress(KeyError, ValueError, UnicodeDecodeError):
-                self.experiment_data["AUTOSUBMIT"]["WORKFLOW_COMMIT"] = subprocess.check_output(
+                commit = subprocess.check_output(
                     "git rev-parse HEAD",
                     cwd=project_dir,
                     shell=True
                 ).decode(locale.getpreferredencoding()).strip("\n")
+                self.experiment_data["AUTOSUBMIT"]["WORKFLOW_COMMIT"] = _wrap_with_source(
+                    commit,
+                    f"git:{project_dir}/.git/HEAD",
+                )
 
     def load_current_hpcarch_parameters(self, parameters: Optional[dict] = None) -> None:
         """Load custom HPCARCH parameters.
@@ -1942,25 +2217,38 @@ class AutosubmitConfig(object):
         target = parameters if parameters is not None else self.experiment_data
 
         for name, value in hpcarch_data.items():
-            target[f"HPC{name}"] = value
+            # Annotate each HPC* value with the platform section it was derived from.
+            # Values that already carry YAML-file provenance (WithProvenance) keep their
+            # original annotation; only bare values (programmatically computed ones) get
+            # a computed: source.
+            source = f"computed:PLATFORMS.{hpcarch}.{name}"
+            target[f"HPC{name}"] = _wrap_with_source(value, source) if not hasattr(value, 'provenance') else value
 
-        target["HPCARCH"] = hpcarch
+        target["HPCARCH"] = _wrap_with_source(hpcarch, f"computed:DEFAULT.HPCARCH")
 
         scratch = hpcarch_data.get("SCRATCH_DIR", "")
         project = hpcarch_data.get("SCRATCH_PROJECT_DIR", hpcarch_data.get("PROJECT", ""))
         user = hpcarch_data.get("USER", "")
 
         if scratch and project and user:
-            target["HPCROOTDIR"] = Path(scratch) / project / user / self.expid
-            target["HPCLOGDIR"] = target["HPCROOTDIR"] / f"LOG_{self.expid}"
+            rootdir = Path(scratch) / project / user / self.expid
+            target["HPCROOTDIR"] = rootdir
+            target["HPCLOGDIR"] = rootdir / f"LOG_{self.expid}"
         # Default local paths.
         elif hpcarch.upper() == "LOCAL":
-            target["HPCROOTDIR"] = Path(BasicConfig.LOCAL_ROOT_DIR) / self.expid / BasicConfig.LOCAL_TMP_DIR
-            target["HPCLOGDIR"] = target["HPCROOTDIR"] / f"LOG_{self.expid}"
+            rootdir = Path(BasicConfig.LOCAL_ROOT_DIR) / self.expid / BasicConfig.LOCAL_TMP_DIR
+            target["HPCROOTDIR"] = rootdir
+            target["HPCLOGDIR"] = rootdir / f"LOG_{self.expid}"
 
         if target.get("HPCROOTDIR", None) and target.get("HPCLOGDIR", None):
-            target["HPCROOTDIR"] = str(target["HPCROOTDIR"])
-            target["HPCLOGDIR"] = str(target["HPCLOGDIR"])
+            target["HPCROOTDIR"] = _wrap_with_source(
+                str(target["HPCROOTDIR"]),
+                f"computed:PLATFORMS.{hpcarch}.SCRATCH_DIR+PROJECT+USER/{self.expid}",
+            )
+            target["HPCLOGDIR"] = _wrap_with_source(
+                str(target["HPCLOGDIR"]),
+                f"computed:HPCROOTDIR/LOG_{self.expid}",
+            )
 
         self.substitute_dynamic_variables(target)
 
@@ -1977,8 +2265,16 @@ class AutosubmitConfig(object):
 
             try:
                 with open(self.metadata_folder.joinpath("experiment_data.yml"), 'w') as stream:
-                    # Not using typ="safe" to preserve the readability of the file
-                    YAML().dump(self.experiment_data, stream)
+                    if _HAS_YAML_PROVENANCE:
+                        # dump_yaml writes inline provenance comments (file/line/col)
+                        # and correctly serialises NoneWithProvenance as empty YAML
+                        # values rather than ruamel anchor/alias references (*id001).
+                        from yaml_provenance import dump_yaml
+                        dump_yaml(self.experiment_data, stream=stream)
+                    else:
+                        # Fallback: plain ruamel dump (no provenance annotations).
+                        # Not using typ="safe" to preserve readability.
+                        YAML().dump(self.experiment_data, stream)
                 self.metadata_folder.joinpath("experiment_data.yml").chmod(0o755)
             except Exception as e:
                 Log.warning(f"Failed to save experiment_data.yml: {str(e)}")
@@ -2006,7 +2302,7 @@ class AutosubmitConfig(object):
                 if key not in last_run_data.keys():
                     differences[key] = val
                 else:
-                    if type(last_run_data[key]) is not dict:
+                    if not isinstance(last_run_data[key], dict):
                         differences[key] = val
                     elif len(last_run_data[key]) == 0 and len(last_run_data[key]) == len(current_data[key]):
                         continue
@@ -2024,7 +2320,7 @@ class AutosubmitConfig(object):
                 if key not in current_data.keys():
                     differences[key] = val
                 else:
-                    if type(current_data[key]) is dict and len(current_data[key]) == 0:
+                    if isinstance(current_data[key], dict) and len(current_data[key]) == 0:
                         diff = self.detailed_deep_diff(current_data[key], val, level)
                         if diff:
                             differences[key] = diff
@@ -2306,7 +2602,7 @@ class AutosubmitConfig(object):
         date_list = list()
         date_value = str(self.get_section(['EXPERIMENT', 'DATELIST'], "20220401"))
         # Allows to use the old format for define a list.
-        if type(date_value) is not list:
+        if not isinstance(date_value, list):
             if not date_value.startswith("["):
                 string = f'[{date_value}]'
             else:
@@ -2314,7 +2610,7 @@ class AutosubmitConfig(object):
             split_string = nested_expr('[', ']').parse_string(string).asList()
             string_date = None
             for split in split_string[0]:
-                if type(split) is list:
+                if isinstance(split, list):
                     for split_in in split:
                         if split_in.find("-") != -1:
                             split_numbers = split_in.split("-")
@@ -2389,7 +2685,7 @@ class AutosubmitConfig(object):
         split_string = nested_expr('[', ']').parse_string(string).asList()
         string_member = None
         for split in split_string[0]:
-            if type(split) is list:
+            if isinstance(split, list):
                 for split_in in split:
                     if split_in.find("-") != -1:
                         split_numbers = split_in.split("-")

--- a/autosubmit/config/yamlparser.py
+++ b/autosubmit/config/yamlparser.py
@@ -37,6 +37,7 @@ from yaml_provenance import (
 # a complete chain of origin information.
 # ---------------------------------------------------------------------------
 configure(ProvenanceConfig(track_history=True))
+register_pickle_reducers()
 
 
 class YAMLParserFactory:

--- a/autosubmit/config/yamlparser.py
+++ b/autosubmit/config/yamlparser.py
@@ -17,37 +17,26 @@
 
 
 from ruamel.yaml import YAML
+from yaml_provenance import (
+    load_yaml,
+    configure,
+    ProvenanceConfig,
+    register_pickle_reducers,
+    register_yaml_representers,
+)
 
 # ---------------------------------------------------------------------------
-# Optional yaml-provenance integration
+# yaml-provenance integration
 # ---------------------------------------------------------------------------
-# When the ``yaml-provenance`` library is installed every value loaded from a
-# YAML file becomes a ``WithProvenance`` subclass of its native type (str, int,
-# …).  This means any downstream code can inspect *which* file, line and column
-# a value originated from without any changes to the rest of Autosubmit.
+# Every value loaded from a YAML file becomes a ``WithProvenance`` subclass of
+# its native type (str, int, …).  This means any downstream code can inspect
+# *which* file, line and column a value originated from without any changes to
+# the rest of Autosubmit.
 #
-# Install (from the feature branch until merged to main):
-#   pip install "yaml-provenance @ git+https://github.com/esm-tools/yaml-provenance.git@feat/yaml_dumper"
-#
-# If the library is not installed, loading falls back silently to the standard
-# ruamel.yaml behaviour so nothing breaks.
+# Enable full provenance history so merges across multiple YAML files preserve
+# a complete chain of origin information.
 # ---------------------------------------------------------------------------
-try:
-    from yaml_provenance import (
-        load_yaml,
-        configure,
-        ProvenanceConfig,
-        register_pickle_reducers,
-        register_yaml_representers,
-    )
-
-    # Enable full provenance history so merges across multiple YAML files
-    # preserve a complete chain of origin information.
-    configure(ProvenanceConfig(track_history=True))
-
-    _HAS_YAML_PROVENANCE = True
-except ImportError:
-    _HAS_YAML_PROVENANCE = False
+configure(ProvenanceConfig(track_history=True))
 
 
 class YAMLParserFactory:

--- a/autosubmit/config/yamlparser.py
+++ b/autosubmit/config/yamlparser.py
@@ -16,8 +16,6 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from pathlib import Path
-
 from ruamel.yaml import YAML
 
 # ---------------------------------------------------------------------------
@@ -35,15 +33,13 @@ from ruamel.yaml import YAML
 # ruamel.yaml behaviour so nothing breaks.
 # ---------------------------------------------------------------------------
 try:
-    from yaml_provenance import load_yaml, configure, ProvenanceConfig
-    from yaml_provenance._wrapper import (
-        _wrapper_registry,
-        BoolWithProvenance,
-        NoneWithProvenance,
-        ProvenanceClassForTheUnsubclassable,
+    from yaml_provenance import (
+        load_yaml,
+        configure,
+        ProvenanceConfig,
+        register_pickle_reducers,
+        register_yaml_representers,
     )
-    from yaml_provenance._list import ListWithProvenance
-    from yaml_provenance._dict import DictWithProvenance
 
     # Enable full provenance history so merges across multiple YAML files
     # preserve a complete chain of origin information.
@@ -52,178 +48,6 @@ try:
     _HAS_YAML_PROVENANCE = True
 except ImportError:
     _HAS_YAML_PROVENANCE = False
-
-
-# ---------------------------------------------------------------------------
-# Pickle compatibility for WithProvenance types
-# ---------------------------------------------------------------------------
-# yaml-provenance creates wrapper classes dynamically at runtime via
-# ``type(class_name, (base_type,), {...})``.  The classes are stored only in
-# ``_wrapper_registry`` — they are *never* added as attributes of the
-# ``yaml_provenance._wrapper`` module.  Pickle, however, serialises a class
-# by recording its module + qualified name and then performing an attribute
-# lookup on that module at restore time:
-#
-#     yaml_provenance._wrapper.StrWithProvenance   →   AttributeError
-#
-# This causes ``_pickle.PicklingError`` when Autosubmit tries to persist the
-# job list (``job_list_persistence.py``, line 130).
-#
-# Fix: inject a ``__reduce__`` method into every WithProvenance class so that
-# pickle serialises each instance as its plain builtin base type (str, int,
-# float, bool …).  Provenance metadata is intentionally dropped during pickle
-# — it is only used in-process for diagnostics, not for job execution.
-#
-# The function must be called *after every* ``load_yaml()`` invocation because
-# the registry is populated lazily: new entry types (e.g.
-# ``ScalarIntWithProvenance``, ``ScalarFloatWithProvenance``) are added the
-# first time a value of that type is encountered.  Re-patching is idempotent.
-# ---------------------------------------------------------------------------
-
-# Builtin types we want to reduce to (walking up MRO past ruamel scalars).
-_BUILTIN_TYPES = (str, int, float, bytes, bytearray)
-
-
-def _get_builtin_base(cls):
-    """Return the first plain builtin ancestor of *cls* in its MRO."""
-    for base in cls.__mro__:
-        if base in _BUILTIN_TYPES:
-            return base
-    # Fallback — should never happen for types in _wrapper_registry.
-    return cls.__bases__[0]
-
-
-def _register_provenance_pickle_reducers():
-    """Patch __reduce__ on every WithProvenance class so pickle can handle them.
-
-    Safe to call multiple times; only patches classes that have not already
-    been patched (detected by the presence of the ``_pickle_patched`` sentinel).
-    """
-    if not _HAS_YAML_PROVENANCE:
-        return
-
-    def _make_reduce(builtin_type):
-        """Return a __reduce__ that serialises self as a plain builtin value."""
-        def __reduce__(self):
-            return (builtin_type, (builtin_type(self),))
-        return __reduce__
-
-    # 1. Dynamic registry types: StrWithProvenance, IntWithProvenance,
-    #    ScalarIntWithProvenance, ScalarFloatWithProvenance, and any others
-    #    that get added as more YAML files are loaded.
-    for cls in _wrapper_registry.values():
-        if not getattr(cls, "_pickle_patched", False):
-            builtin = _get_builtin_base(cls)
-            cls.__reduce__ = _make_reduce(builtin)
-            cls._pickle_patched = True
-
-    # 2. BoolWithProvenance — stores the value in self.value, not as the
-    #    bool itself (bool cannot be subclassed, hence the wrapper class).
-    if not getattr(BoolWithProvenance, "_pickle_patched", False):
-        BoolWithProvenance.__reduce__ = lambda self: (bool, (self.value,))
-        BoolWithProvenance._pickle_patched = True
-
-    # 3. NoneWithProvenance — rare in AS configs but patch for completeness.
-    if not getattr(NoneWithProvenance, "_pickle_patched", False):
-        NoneWithProvenance.__reduce__ = lambda self: (type(None), ())
-        NoneWithProvenance._pickle_patched = True
-
-    # 4. ListWithProvenance — items may themselves be WithProvenance instances;
-    #    reducing to a plain list lets pickle recurse into the (now reducible)
-    #    items automatically.
-    if not getattr(ListWithProvenance, "_pickle_patched", False):
-        ListWithProvenance.__reduce__ = lambda self: (list, (list(self),))
-        ListWithProvenance._pickle_patched = True
-
-    # 5. DictWithProvenance — same reasoning as ListWithProvenance.
-    if not getattr(DictWithProvenance, "_pickle_patched", False):
-        DictWithProvenance.__reduce__ = lambda self: (dict, (dict(self),))
-        DictWithProvenance._pickle_patched = True
-
-
-def _register_provenance_yaml_representers():
-    """Register WithProvenance types on ruamel.yaml representer classes.
-
-    ruamel.yaml's ``represent_data()`` dispatches by exact type first, then
-    walks the MRO only in ``yaml_multi_representers`` — but all builtin type
-    representers (str, int, bool, …) live in ``yaml_representers``.  This
-    means ``StrWithProvenance`` is not found via MRO walk and falls through to
-    the ``None`` catch-all representer which raises
-    ``cannot represent an object``.
-
-    Fix: register each WithProvenance class directly in the representer CLASS
-    dict (not instance), so every new ``YAML()`` instance inherits the mapping.
-    Called after every ``load_yaml()`` to pick up newly registered types.
-    """
-    if not _HAS_YAML_PROVENANCE:
-        return
-
-    try:
-        from ruamel.yaml.representer import SafeRepresenter, RoundTripRepresenter
-    except ImportError:
-        return
-
-    if not hasattr(_register_provenance_yaml_representers, "_patched"):
-        _register_provenance_yaml_representers._patched = set()
-    patched = _register_provenance_yaml_representers._patched
-
-    for repr_class in (SafeRepresenter, RoundTripRepresenter):
-
-        # 1. Dynamic registry types (StrWithProvenance, IntWithProvenance, etc.)
-        for cls_name, cls in _wrapper_registry.items():
-            key = (repr_class, cls_name)
-            if key in patched:
-                continue
-            builtin = _get_builtin_base(cls)
-            fn = repr_class.yaml_representers.get(builtin)
-            if fn:
-                repr_class.add_representer(cls, fn)
-                patched.add(key)
-
-        # 2. BoolWithProvenance — not in _wrapper_registry, handled separately.
-        key = (repr_class, "BoolWithProvenance")
-        if key not in patched:
-            bool_fn = repr_class.yaml_representers.get(bool)
-            if bool_fn:
-                repr_class.add_representer(
-                    BoolWithProvenance,
-                    lambda dumper, data, _fn=bool_fn: _fn(dumper, data.value),
-                )
-                patched.add(key)
-
-        # 3. NoneWithProvenance
-        key = (repr_class, "NoneWithProvenance")
-        if key not in patched:
-            none_fn = repr_class.yaml_representers.get(type(None))
-            if none_fn:
-                repr_class.add_representer(
-                    NoneWithProvenance,
-                    lambda dumper, data, _fn=none_fn: _fn(dumper, None),
-                )
-                patched.add(key)
-
-        # 4. ListWithProvenance — convert to plain list so the representer
-        #    recurses into (now representable) items.
-        key = (repr_class, "ListWithProvenance")
-        if key not in patched:
-            list_fn = repr_class.yaml_representers.get(list)
-            if list_fn:
-                repr_class.add_representer(
-                    ListWithProvenance,
-                    lambda dumper, data, _fn=list_fn: _fn(dumper, list(data)),
-                )
-                patched.add(key)
-
-        # 5. DictWithProvenance
-        key = (repr_class, "DictWithProvenance")
-        if key not in patched:
-            dict_fn = repr_class.yaml_representers.get(dict)
-            if dict_fn:
-                repr_class.add_representer(
-                    DictWithProvenance,
-                    lambda dumper, data, _fn=dict_fn: _fn(dumper, dict(data)),
-                )
-                patched.add(key)
 
 
 class YAMLParserFactory:

--- a/autosubmit/config/yamlparser.py
+++ b/autosubmit/config/yamlparser.py
@@ -16,7 +16,214 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from pathlib import Path
+
 from ruamel.yaml import YAML
+
+# ---------------------------------------------------------------------------
+# Optional yaml-provenance integration
+# ---------------------------------------------------------------------------
+# When the ``yaml-provenance`` library is installed every value loaded from a
+# YAML file becomes a ``WithProvenance`` subclass of its native type (str, int,
+# …).  This means any downstream code can inspect *which* file, line and column
+# a value originated from without any changes to the rest of Autosubmit.
+#
+# Install (from the feature branch until merged to main):
+#   pip install "yaml-provenance @ git+https://github.com/esm-tools/yaml-provenance.git@feat/yaml_dumper"
+#
+# If the library is not installed, loading falls back silently to the standard
+# ruamel.yaml behaviour so nothing breaks.
+# ---------------------------------------------------------------------------
+try:
+    from yaml_provenance import load_yaml, configure, ProvenanceConfig
+    from yaml_provenance._wrapper import (
+        _wrapper_registry,
+        BoolWithProvenance,
+        NoneWithProvenance,
+        ProvenanceClassForTheUnsubclassable,
+    )
+    from yaml_provenance._list import ListWithProvenance
+    from yaml_provenance._dict import DictWithProvenance
+
+    # Enable full provenance history so merges across multiple YAML files
+    # preserve a complete chain of origin information.
+    configure(ProvenanceConfig(track_history=True))
+
+    _HAS_YAML_PROVENANCE = True
+except ImportError:
+    _HAS_YAML_PROVENANCE = False
+
+
+# ---------------------------------------------------------------------------
+# Pickle compatibility for WithProvenance types
+# ---------------------------------------------------------------------------
+# yaml-provenance creates wrapper classes dynamically at runtime via
+# ``type(class_name, (base_type,), {...})``.  The classes are stored only in
+# ``_wrapper_registry`` — they are *never* added as attributes of the
+# ``yaml_provenance._wrapper`` module.  Pickle, however, serialises a class
+# by recording its module + qualified name and then performing an attribute
+# lookup on that module at restore time:
+#
+#     yaml_provenance._wrapper.StrWithProvenance   →   AttributeError
+#
+# This causes ``_pickle.PicklingError`` when Autosubmit tries to persist the
+# job list (``job_list_persistence.py``, line 130).
+#
+# Fix: inject a ``__reduce__`` method into every WithProvenance class so that
+# pickle serialises each instance as its plain builtin base type (str, int,
+# float, bool …).  Provenance metadata is intentionally dropped during pickle
+# — it is only used in-process for diagnostics, not for job execution.
+#
+# The function must be called *after every* ``load_yaml()`` invocation because
+# the registry is populated lazily: new entry types (e.g.
+# ``ScalarIntWithProvenance``, ``ScalarFloatWithProvenance``) are added the
+# first time a value of that type is encountered.  Re-patching is idempotent.
+# ---------------------------------------------------------------------------
+
+# Builtin types we want to reduce to (walking up MRO past ruamel scalars).
+_BUILTIN_TYPES = (str, int, float, bytes, bytearray)
+
+
+def _get_builtin_base(cls):
+    """Return the first plain builtin ancestor of *cls* in its MRO."""
+    for base in cls.__mro__:
+        if base in _BUILTIN_TYPES:
+            return base
+    # Fallback — should never happen for types in _wrapper_registry.
+    return cls.__bases__[0]
+
+
+def _register_provenance_pickle_reducers():
+    """Patch __reduce__ on every WithProvenance class so pickle can handle them.
+
+    Safe to call multiple times; only patches classes that have not already
+    been patched (detected by the presence of the ``_pickle_patched`` sentinel).
+    """
+    if not _HAS_YAML_PROVENANCE:
+        return
+
+    def _make_reduce(builtin_type):
+        """Return a __reduce__ that serialises self as a plain builtin value."""
+        def __reduce__(self):
+            return (builtin_type, (builtin_type(self),))
+        return __reduce__
+
+    # 1. Dynamic registry types: StrWithProvenance, IntWithProvenance,
+    #    ScalarIntWithProvenance, ScalarFloatWithProvenance, and any others
+    #    that get added as more YAML files are loaded.
+    for cls in _wrapper_registry.values():
+        if not getattr(cls, "_pickle_patched", False):
+            builtin = _get_builtin_base(cls)
+            cls.__reduce__ = _make_reduce(builtin)
+            cls._pickle_patched = True
+
+    # 2. BoolWithProvenance — stores the value in self.value, not as the
+    #    bool itself (bool cannot be subclassed, hence the wrapper class).
+    if not getattr(BoolWithProvenance, "_pickle_patched", False):
+        BoolWithProvenance.__reduce__ = lambda self: (bool, (self.value,))
+        BoolWithProvenance._pickle_patched = True
+
+    # 3. NoneWithProvenance — rare in AS configs but patch for completeness.
+    if not getattr(NoneWithProvenance, "_pickle_patched", False):
+        NoneWithProvenance.__reduce__ = lambda self: (type(None), ())
+        NoneWithProvenance._pickle_patched = True
+
+    # 4. ListWithProvenance — items may themselves be WithProvenance instances;
+    #    reducing to a plain list lets pickle recurse into the (now reducible)
+    #    items automatically.
+    if not getattr(ListWithProvenance, "_pickle_patched", False):
+        ListWithProvenance.__reduce__ = lambda self: (list, (list(self),))
+        ListWithProvenance._pickle_patched = True
+
+    # 5. DictWithProvenance — same reasoning as ListWithProvenance.
+    if not getattr(DictWithProvenance, "_pickle_patched", False):
+        DictWithProvenance.__reduce__ = lambda self: (dict, (dict(self),))
+        DictWithProvenance._pickle_patched = True
+
+
+def _register_provenance_yaml_representers():
+    """Register WithProvenance types on ruamel.yaml representer classes.
+
+    ruamel.yaml's ``represent_data()`` dispatches by exact type first, then
+    walks the MRO only in ``yaml_multi_representers`` — but all builtin type
+    representers (str, int, bool, …) live in ``yaml_representers``.  This
+    means ``StrWithProvenance`` is not found via MRO walk and falls through to
+    the ``None`` catch-all representer which raises
+    ``cannot represent an object``.
+
+    Fix: register each WithProvenance class directly in the representer CLASS
+    dict (not instance), so every new ``YAML()`` instance inherits the mapping.
+    Called after every ``load_yaml()`` to pick up newly registered types.
+    """
+    if not _HAS_YAML_PROVENANCE:
+        return
+
+    try:
+        from ruamel.yaml.representer import SafeRepresenter, RoundTripRepresenter
+    except ImportError:
+        return
+
+    if not hasattr(_register_provenance_yaml_representers, "_patched"):
+        _register_provenance_yaml_representers._patched = set()
+    patched = _register_provenance_yaml_representers._patched
+
+    for repr_class in (SafeRepresenter, RoundTripRepresenter):
+
+        # 1. Dynamic registry types (StrWithProvenance, IntWithProvenance, etc.)
+        for cls_name, cls in _wrapper_registry.items():
+            key = (repr_class, cls_name)
+            if key in patched:
+                continue
+            builtin = _get_builtin_base(cls)
+            fn = repr_class.yaml_representers.get(builtin)
+            if fn:
+                repr_class.add_representer(cls, fn)
+                patched.add(key)
+
+        # 2. BoolWithProvenance — not in _wrapper_registry, handled separately.
+        key = (repr_class, "BoolWithProvenance")
+        if key not in patched:
+            bool_fn = repr_class.yaml_representers.get(bool)
+            if bool_fn:
+                repr_class.add_representer(
+                    BoolWithProvenance,
+                    lambda dumper, data, _fn=bool_fn: _fn(dumper, data.value),
+                )
+                patched.add(key)
+
+        # 3. NoneWithProvenance
+        key = (repr_class, "NoneWithProvenance")
+        if key not in patched:
+            none_fn = repr_class.yaml_representers.get(type(None))
+            if none_fn:
+                repr_class.add_representer(
+                    NoneWithProvenance,
+                    lambda dumper, data, _fn=none_fn: _fn(dumper, None),
+                )
+                patched.add(key)
+
+        # 4. ListWithProvenance — convert to plain list so the representer
+        #    recurses into (now representable) items.
+        key = (repr_class, "ListWithProvenance")
+        if key not in patched:
+            list_fn = repr_class.yaml_representers.get(list)
+            if list_fn:
+                repr_class.add_representer(
+                    ListWithProvenance,
+                    lambda dumper, data, _fn=list_fn: _fn(dumper, list(data)),
+                )
+                patched.add(key)
+
+        # 5. DictWithProvenance
+        key = (repr_class, "DictWithProvenance")
+        if key not in patched:
+            dict_fn = repr_class.yaml_representers.get(dict)
+            if dict_fn:
+                repr_class.add_representer(
+                    DictWithProvenance,
+                    lambda dumper, data, _fn=dict_fn: _fn(dumper, dict(data)),
+                )
+                patched.add(key)
 
 
 class YAMLParserFactory:

--- a/autosubmit/config/yamlparser.py
+++ b/autosubmit/config/yamlparser.py
@@ -53,3 +53,27 @@ class YAMLParser(YAML):
     def __init__(self):
         self.data = []
         super(YAMLParser, self).__init__(typ="rt")
+
+    def load(self, stream):
+        """Load YAML from *stream*, attaching provenance metadata.
+
+        The returned mapping is a ``DictWithProvenance`` instance where every
+        leaf value carries its source ``yaml_file``, ``line`` and ``col``.
+        These survive through subsequent ``dict`` operations because
+        ``WithProvenance`` objects are transparent subclasses of their native
+        Python types.
+
+        After loading, pickle and YAML-dump compatibility is ensured by
+        calling ``register_pickle_reducers()`` and
+        ``register_yaml_representers()``.  These must be called after *every*
+        load because the internal wrapper registry is populated lazily — new
+        types are registered on first encounter.
+
+        :param stream: An open file-like object (with ``.name`` attribute),
+            or a ``str``/``pathlib.Path`` pointing to the YAML file.
+        :return: Parsed mapping (``DictWithProvenance`` or plain ``dict``).
+        """
+        result = load_yaml(stream)
+        register_pickle_reducers()
+        register_yaml_representers()
+        return result if result is not None else {}

--- a/autosubmit/config/yamlparser.py
+++ b/autosubmit/config/yamlparser.py
@@ -21,8 +21,6 @@ from yaml_provenance import (
     load_yaml,
     configure,
     ProvenanceConfig,
-    register_pickle_reducers,
-    register_yaml_representers,
 )
 
 # ---------------------------------------------------------------------------
@@ -37,7 +35,6 @@ from yaml_provenance import (
 # a complete chain of origin information.
 # ---------------------------------------------------------------------------
 configure(ProvenanceConfig(track_history=True))
-register_pickle_reducers()
 
 
 class YAMLParserFactory:
@@ -63,17 +60,9 @@ class YAMLParser(YAML):
         ``WithProvenance`` objects are transparent subclasses of their native
         Python types.
 
-        After loading, pickle and YAML-dump compatibility is ensured by
-        calling ``register_pickle_reducers()`` and
-        ``register_yaml_representers()``.  These must be called after *every*
-        load because the internal wrapper registry is populated lazily — new
-        types are registered on first encounter.
-
         :param stream: An open file-like object (with ``.name`` attribute),
             or a ``str``/``pathlib.Path`` pointing to the YAML file.
         :return: Parsed mapping (``DictWithProvenance`` or plain ``dict``).
         """
         result = load_yaml(stream)
-        register_pickle_reducers()
-        register_yaml_representers()
         return result if result is not None else {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "invoke>=2.0",
     "SQLAlchemy~=2.0.23",
     "ruamel.yaml==0.19.1",
+    "yaml-provenance>=0.1.0",
     "configobj",
     "configparser"
 ]

--- a/test/unit/config/conftest.py
+++ b/test/unit/config/conftest.py
@@ -25,6 +25,24 @@ from autosubmit.config.configcommon import AutosubmitConfig
 if TYPE_CHECKING:
     pass
 
+
+# ---------------------------------------------------------------------------
+# yaml-provenance helpers — available when the library is installed.
+# ---------------------------------------------------------------------------
+try:
+    from yaml_provenance import wrap_computed
+
+    _HAS_YAML_PROVENANCE = True
+except ImportError:  # pragma: no cover
+    wrap_computed = None  # type: ignore[assignment]
+    _HAS_YAML_PROVENANCE = False
+
+# Marker that skips a test when yaml-provenance is not installed.
+requires_yaml_provenance = pytest.mark.skipif(
+    not _HAS_YAML_PROVENANCE,
+    reason="yaml-provenance library is not installed",
+)
+
 """A small configuration example."""
 AS_CONF_SMALL = {
     "CONFIG": {

--- a/test/unit/config/conftest.py
+++ b/test/unit/config/conftest.py
@@ -27,21 +27,9 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# yaml-provenance helpers — available when the library is installed.
+# yaml-provenance helpers
 # ---------------------------------------------------------------------------
-try:
-    from yaml_provenance import wrap_computed
-
-    _HAS_YAML_PROVENANCE = True
-except ImportError:  # pragma: no cover
-    wrap_computed = None  # type: ignore[assignment]
-    _HAS_YAML_PROVENANCE = False
-
-# Marker that skips a test when yaml-provenance is not installed.
-requires_yaml_provenance = pytest.mark.skipif(
-    not _HAS_YAML_PROVENANCE,
-    reason="yaml-provenance library is not installed",
-)
+from yaml_provenance import wrap_computed
 
 """A small configuration example."""
 AS_CONF_SMALL = {

--- a/test/unit/config/test_provenance_config.py
+++ b/test/unit/config/test_provenance_config.py
@@ -1,0 +1,365 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for provenance preservation in ``AutosubmitConfig`` methods.
+
+These tests verify that ``yaml-provenance`` metadata survives through config
+normalization, variable substitution, serialization, and the public
+``get_value_provenance()`` API.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from autosubmit.config.configcommon import (
+    AutosubmitConfig,
+    _preserve_prov,
+    _wrap_with_source,
+)
+from test.unit.config.conftest import requires_yaml_provenance
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_provenance(value, expected_source: str = None) -> bool:
+    """Return True when *value* carries provenance metadata.
+
+    If *expected_source* is given, also checks that the last provenance entry's
+    ``yaml_file`` contains *expected_source*.
+    """
+    prov = getattr(value, "provenance", None)
+    if prov is None:
+        return False
+    last = prov[-1] if isinstance(prov, list) else prov
+    if expected_source is not None:
+        return expected_source in str(last.get("yaml_file", ""))
+    return True
+
+
+# ---------------------------------------------------------------------------
+# get_value_provenance()
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestGetValueProvenance:
+    """Tests for ``AutosubmitConfig.get_value_provenance()``."""
+
+    def test_returns_provenance_for_wrapped_value(self, autosubmit_config):
+        """Wrapped values must return a non-empty provenance list."""
+        experiment_data = {
+            "EXPERIMENT": {
+                "DATELIST": _wrap_with_source("20000101", "expdef_a001.yml"),
+            }
+        }
+        as_conf = autosubmit_config(expid="t000", experiment_data=experiment_data)
+        prov = as_conf.get_value_provenance(["EXPERIMENT", "DATELIST"])
+
+        assert isinstance(prov, list)
+        assert len(prov) >= 1
+        last = prov[-1]
+        assert "yaml_file" in last
+        assert "expdef_a001.yml" in str(last["yaml_file"])
+
+    def test_returns_empty_for_plain_value(self, autosubmit_config):
+        """Plain Python values (no provenance) must return ``[]``."""
+        experiment_data = {"EXPERIMENT": {"DATELIST": "20000101"}}
+        as_conf = autosubmit_config(expid="t000", experiment_data=experiment_data)
+        prov = as_conf.get_value_provenance(["EXPERIMENT", "DATELIST"])
+        assert prov == []
+
+    def test_returns_empty_for_missing_key(self, autosubmit_config):
+        as_conf = autosubmit_config(expid="t000", experiment_data={})
+        prov = as_conf.get_value_provenance(["NONEXISTENT"])
+        assert prov == []
+
+    def test_returns_empty_without_library(self, autosubmit_config, mocker):
+        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
+        experiment_data = {
+            "EXPERIMENT": {
+                "DATELIST": _wrap_with_source("20000101", "expdef.yml"),
+            }
+        }
+        as_conf = autosubmit_config(expid="t000", experiment_data=experiment_data)
+        assert as_conf.get_value_provenance(["EXPERIMENT", "DATELIST"]) == []
+
+
+# ---------------------------------------------------------------------------
+# deep_normalize() — provenance preservation
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestDeepNormalizeProvenance:
+    """Verify that ``deep_normalize()`` preserves provenance on keys and values."""
+
+    def test_uppercased_keys_carry_provenance(self, autosubmit_config):
+        key = _wrap_with_source("jobs", "src:expdef.yml")
+        inner_key = _wrap_with_source("ini", "src:jobs.yml")
+        data = {key: {inner_key: {"wallclock": "00:05"}}}
+
+        as_conf = autosubmit_config(expid="t000", experiment_data={})
+        result = as_conf.deep_normalize(data)
+
+        # The normalized keys should be uppercase and carry provenance
+        upper_keys = list(result.keys())
+        assert len(upper_keys) == 1
+        assert str(upper_keys[0]) == "JOBS"
+        assert _has_provenance(upper_keys[0])
+
+        inner_keys = list(result["JOBS"].keys())
+        assert str(inner_keys[0]) == "INI"
+        assert _has_provenance(inner_keys[0])
+
+    def test_leaf_values_unchanged(self, autosubmit_config):
+        wrapped_val = _wrap_with_source("00:05", "src:jobs.yml")
+        data = {"JOBS": {"INI": {"WALLCLOCK": wrapped_val}}}
+
+        as_conf = autosubmit_config(expid="t000", experiment_data={})
+        result = as_conf.deep_normalize(data)
+        assert result["JOBS"]["INI"]["WALLCLOCK"] == "00:05"
+        assert _has_provenance(result["JOBS"]["INI"]["WALLCLOCK"], "src:jobs.yml")
+
+
+# ---------------------------------------------------------------------------
+# dict_replace_value() — provenance preservation
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestDictReplaceValueProvenance:
+    """Verify that ``dict_replace_value()`` preserves provenance."""
+
+    def test_whole_value_replacement_preserves_provenance(self, autosubmit_config):
+        wrapped = _wrap_with_source("00:05", "src:jobs.yml")
+        data = {"JOBS": {"INI": {"WALLCLOCK": wrapped}}}
+        as_conf = autosubmit_config(expid="t000", experiment_data=data)
+
+        as_conf.dict_replace_value(
+            data, "00:05", "01:00", 0, ["WALLCLOCK", "INI", "JOBS"]
+        )
+
+        result = data["JOBS"]["INI"]["WALLCLOCK"]
+        assert result == "01:00"
+        assert _has_provenance(result, "src:jobs.yml")
+
+    def test_partial_replacement_preserves_provenance(self, autosubmit_config):
+        wrapped = _wrap_with_source("/home/%EXPID%/output", "src:expdef.yml")
+        data = {"DEFAULT": {"OUTPUT": wrapped}}
+        as_conf = autosubmit_config(expid="t000", experiment_data=data)
+
+        as_conf.dict_replace_value(
+            data, "%EXPID%", "a001", 0, ["OUTPUT", "DEFAULT"]
+        )
+
+        result = data["DEFAULT"]["OUTPUT"]
+        assert result == "/home/a001/output"
+        assert _has_provenance(result, "src:expdef.yml")
+
+    def test_list_item_replacement_preserves_provenance(self, autosubmit_config):
+        item = _wrap_with_source("file_a.sh", "src:jobs.yml")
+        data = {"JOBS": {"SIM": {"ADDITIONAL_FILES": [item]}}}
+        as_conf = autosubmit_config(expid="t000", experiment_data=data)
+
+        as_conf.dict_replace_value(
+            data, "file_a.sh", "file_b.sh", 0, ["ADDITIONAL_FILES", "SIM", "JOBS"]
+        )
+
+        result = data["JOBS"]["SIM"]["ADDITIONAL_FILES"][0]
+        assert result == "file_b.sh"
+        assert _has_provenance(result, "src:jobs.yml")
+
+
+# ---------------------------------------------------------------------------
+# _normalize_notify_on() — provenance preservation
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestNormalizeNotifyOnProvenance:
+    def test_split_tokens_carry_provenance(self, autosubmit_config):
+        notify_str = _wrap_with_source("completed, failed", "src:jobs.yml")
+        data = {"JOBS": {"SIM": {"NOTIFY_ON": notify_str}}}
+        as_conf = autosubmit_config(expid="t000", experiment_data=data)
+
+        AutosubmitConfig._normalize_notify_on(data, "SIM")
+
+        tokens = data["JOBS"]["SIM"]["NOTIFY_ON"]
+        assert len(tokens) == 2
+        assert str(tokens[0]) == "COMPLETED"
+        assert str(tokens[1]) == "FAILED"
+        for tok in tokens:
+            assert _has_provenance(tok, "src:jobs.yml")
+
+
+# ---------------------------------------------------------------------------
+# _normalize_dependencies() — provenance preservation
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestNormalizeDependenciesProvenance:
+    def test_string_deps_uppercased_with_provenance(self, autosubmit_config):
+        deps = _wrap_with_source("ini sim", "src:jobs.yml")
+        result = AutosubmitConfig._normalize_dependencies(deps)
+
+        keys = list(result.keys())
+        assert len(keys) == 2
+        assert str(keys[0]) == "INI"
+        assert str(keys[1]) == "SIM"
+        for k in keys:
+            assert _has_provenance(k, "src:jobs.yml")
+
+    def test_dict_deps_uppercased_with_provenance(self, autosubmit_config):
+        dep_key = _wrap_with_source("sim", "src:jobs.yml")
+        status_val = _wrap_with_source("running", "src:jobs.yml")
+        deps = {dep_key: {"STATUS": status_val}}
+        result = AutosubmitConfig._normalize_dependencies(deps)
+
+        upper_key = list(result.keys())[0]
+        assert str(upper_key) == "SIM"
+        assert _has_provenance(upper_key, "src:jobs.yml")
+
+        status = result[upper_key]["STATUS"]
+        assert str(status) == "RUNNING"
+        assert _has_provenance(status, "src:jobs.yml")
+
+
+# ---------------------------------------------------------------------------
+# _normalize_jobs_section() — provenance on FILE / CUSTOM_DIRECTIVES
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestNormalizeJobsSectionProvenance:
+    def test_file_preserves_provenance(self, autosubmit_config):
+        file_val = _wrap_with_source("templates/sim.sh", "src:jobs.yml")
+        data = {
+            "JOBS": {
+                "SIM": {
+                    "FILE": file_val,
+                    "DEPENDENCIES": {},
+                }
+            }
+        }
+        as_conf = autosubmit_config(expid="t000", experiment_data=data)
+        as_conf._normalize_jobs_section(data, must_exists=False)
+
+        result = data["JOBS"]["SIM"]["FILE"]
+        assert str(result) == "templates/sim.sh"
+        assert _has_provenance(result, "src:jobs.yml")
+
+    def test_custom_directives_preserves_provenance(self, autosubmit_config):
+        cd = _wrap_with_source("#SBATCH --exclusive", "src:platforms.yml")
+        data = {
+            "JOBS": {
+                "SIM": {
+                    "CUSTOM_DIRECTIVES": cd,
+                    "DEPENDENCIES": {},
+                }
+            }
+        }
+        as_conf = autosubmit_config(expid="t000", experiment_data=data)
+        as_conf._normalize_jobs_section(data, must_exists=False)
+
+        result = data["JOBS"]["SIM"]["CUSTOM_DIRECTIVES"]
+        assert str(result) == "#SBATCH --exclusive"
+        assert _has_provenance(result, "src:platforms.yml")
+
+
+# ---------------------------------------------------------------------------
+# load_as_env_variables() — wraps env vars with provenance
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestLoadEnvVariablesProvenance:
+    def test_env_vars_carry_provenance(self, monkeypatch):
+        monkeypatch.setenv("AS_ENV_TEST_VAR", "my_value")
+        params = {}
+        result = AutosubmitConfig.load_as_env_variables(params)
+
+        var = result["AS_ENV_TEST_VAR"]
+        assert var == "my_value"
+        assert _has_provenance(var, "environment:$AS_ENV_TEST_VAR")
+
+    def test_current_user_carries_provenance(self, monkeypatch):
+        monkeypatch.setenv("USER", "testuser")
+        monkeypatch.delenv("SUDO_USER", raising=False)
+        params = {}
+        result = AutosubmitConfig.load_as_env_variables(params)
+
+        user = result["AS_ENV_CURRENT_USER"]
+        assert user == "testuser"
+        assert _has_provenance(user, "environment:$USER")
+
+
+# ---------------------------------------------------------------------------
+# save() — provenance comments in output YAML
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestSaveWithProvenance:
+    def test_save_writes_provenance_comments(self, autosubmit_config, tmp_path, monkeypatch):
+        """When yaml-provenance is installed, ``save()`` should write inline
+        provenance comments into ``experiment_data.yml``."""
+        # Ensure ownership check passes (same pattern as test_save.py).
+        monkeypatch.setenv("USER", Path(tmp_path).owner())
+        wrapped = _wrap_with_source("20000101", "expdef_t000.yml")
+        experiment_data = {
+            "DEFAULT": {"HPCARCH": "LOCAL"},
+            "EXPERIMENT": {"DATELIST": wrapped},
+        }
+        as_conf = autosubmit_config(
+            expid="t000", experiment_data=experiment_data, include_basic_config=False
+        )
+        as_conf.experiment_data["ROOTDIR"] = str(
+            Path(as_conf.basic_config.LOCAL_ROOT_DIR) / as_conf.expid
+        )
+        as_conf.save()
+
+        yml_file = Path(as_conf.metadata_folder) / "experiment_data.yml"
+        assert yml_file.exists()
+        content = yml_file.read_text()
+        # dump_yaml writes provenance as end-of-line comments
+        assert "expdef_t000.yml" in content
+
+    def test_save_fallback_without_library(self, autosubmit_config, tmp_path, mocker, monkeypatch):
+        """When yaml-provenance is NOT installed, ``save()`` should still write
+        a valid YAML file (without provenance comments)."""
+        monkeypatch.setenv("USER", Path(tmp_path).owner())
+        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
+        experiment_data = {"DEFAULT": {"HPCARCH": "LOCAL"}}
+        as_conf = autosubmit_config(
+            expid="t000", experiment_data=experiment_data, include_basic_config=False
+        )
+        as_conf.experiment_data["ROOTDIR"] = str(
+            Path(as_conf.basic_config.LOCAL_ROOT_DIR) / as_conf.expid
+        )
+        as_conf.save()
+
+        yml_file = Path(as_conf.metadata_folder) / "experiment_data.yml"
+        assert yml_file.exists()
+        content = yml_file.read_text()
+        # Should contain config values but NOT provenance comments
+        assert "LOCAL" in content

--- a/test/unit/config/test_provenance_config.py
+++ b/test/unit/config/test_provenance_config.py
@@ -32,7 +32,6 @@ from autosubmit.config.configcommon import (
     _preserve_prov,
     _wrap_with_source,
 )
-from test.unit.config.conftest import requires_yaml_provenance
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +59,6 @@ def _has_provenance(value, expected_source: str = None) -> bool:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestGetValueProvenance:
     """Tests for ``AutosubmitConfig.get_value_provenance()``."""
 
@@ -92,23 +90,12 @@ class TestGetValueProvenance:
         prov = as_conf.get_value_provenance(["NONEXISTENT"])
         assert prov == []
 
-    def test_returns_empty_without_library(self, autosubmit_config, mocker):
-        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
-        experiment_data = {
-            "EXPERIMENT": {
-                "DATELIST": _wrap_with_source("20000101", "expdef.yml"),
-            }
-        }
-        as_conf = autosubmit_config(expid="t000", experiment_data=experiment_data)
-        assert as_conf.get_value_provenance(["EXPERIMENT", "DATELIST"]) == []
-
 
 # ---------------------------------------------------------------------------
 # deep_normalize() — provenance preservation
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestDeepNormalizeProvenance:
     """Verify that ``deep_normalize()`` preserves provenance on keys and values."""
 
@@ -145,7 +132,6 @@ class TestDeepNormalizeProvenance:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestDictReplaceValueProvenance:
     """Verify that ``dict_replace_value()`` preserves provenance."""
 
@@ -194,7 +180,6 @@ class TestDictReplaceValueProvenance:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestNormalizeNotifyOnProvenance:
     def test_split_tokens_carry_provenance(self, autosubmit_config):
         notify_str = _wrap_with_source("completed, failed", "src:jobs.yml")
@@ -216,7 +201,6 @@ class TestNormalizeNotifyOnProvenance:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestNormalizeDependenciesProvenance:
     def test_string_deps_uppercased_with_provenance(self, autosubmit_config):
         deps = _wrap_with_source("ini sim", "src:jobs.yml")
@@ -249,7 +233,6 @@ class TestNormalizeDependenciesProvenance:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestNormalizeJobsSectionProvenance:
     def test_file_preserves_provenance(self, autosubmit_config):
         file_val = _wrap_with_source("templates/sim.sh", "src:jobs.yml")
@@ -291,7 +274,6 @@ class TestNormalizeJobsSectionProvenance:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestLoadEnvVariablesProvenance:
     def test_env_vars_carry_provenance(self, monkeypatch):
         monkeypatch.setenv("AS_ENV_TEST_VAR", "my_value")
@@ -318,7 +300,6 @@ class TestLoadEnvVariablesProvenance:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestSaveWithProvenance:
     def test_save_writes_provenance_comments(self, autosubmit_config, tmp_path, monkeypatch):
         """When yaml-provenance is installed, ``save()`` should write inline
@@ -343,23 +324,3 @@ class TestSaveWithProvenance:
         content = yml_file.read_text()
         # dump_yaml writes provenance as end-of-line comments
         assert "expdef_t000.yml" in content
-
-    def test_save_fallback_without_library(self, autosubmit_config, tmp_path, mocker, monkeypatch):
-        """When yaml-provenance is NOT installed, ``save()`` should still write
-        a valid YAML file (without provenance comments)."""
-        monkeypatch.setenv("USER", Path(tmp_path).owner())
-        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
-        experiment_data = {"DEFAULT": {"HPCARCH": "LOCAL"}}
-        as_conf = autosubmit_config(
-            expid="t000", experiment_data=experiment_data, include_basic_config=False
-        )
-        as_conf.experiment_data["ROOTDIR"] = str(
-            Path(as_conf.basic_config.LOCAL_ROOT_DIR) / as_conf.expid
-        )
-        as_conf.save()
-
-        yml_file = Path(as_conf.metadata_folder) / "experiment_data.yml"
-        assert yml_file.exists()
-        content = yml_file.read_text()
-        # Should contain config values but NOT provenance comments
-        assert "LOCAL" in content

--- a/test/unit/config/test_yaml_provenance.py
+++ b/test/unit/config/test_yaml_provenance.py
@@ -17,10 +17,6 @@
 
 """Tests for the yaml-provenance integration in ``yamlparser.py`` and the
 module-level helper functions in ``configcommon.py``.
-
-Every test that requires the ``yaml-provenance`` library is guarded with the
-``requires_yaml_provenance`` marker defined in the config conftest so that
-the test suite degrades gracefully when the library is not installed.
 """
 
 import json
@@ -29,7 +25,6 @@ from pathlib import Path
 import pytest
 
 from autosubmit.config.configcommon import (
-    _HAS_YAML_PROVENANCE,
     _preserve_prov,
     _ProvenanceJSONEncoder,
     _wrap_dict_with_source,
@@ -37,15 +32,12 @@ from autosubmit.config.configcommon import (
 )
 from autosubmit.config.yamlparser import YAMLParser
 
-from test.unit.config.conftest import requires_yaml_provenance
-
 
 # ---------------------------------------------------------------------------
 # YAMLParser.load() — provenance path
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestYAMLParserProvenance:
     """Verify that ``YAMLParser.load()`` returns provenance-bearing values."""
 
@@ -98,27 +90,11 @@ class TestYAMLParserProvenance:
         assert hasattr(deep_val, "provenance")
 
 
-class TestYAMLParserFallback:
-    """Verify fallback behaviour when provenance is unavailable."""
-
-    def test_fallback_returns_plain_dict(self, tmp_path, mocker):
-        mocker.patch("autosubmit.config.yamlparser._HAS_YAML_PROVENANCE", False)
-        yaml_file = tmp_path / "plain.yml"
-        yaml_file.write_text("FOO: bar\n")
-        parser = YAMLParser()
-        data = parser.load(yaml_file)
-
-        assert isinstance(data, dict)
-        assert data["FOO"] == "bar"
-        assert not hasattr(data["FOO"], "provenance")
-
-
 # ---------------------------------------------------------------------------
 # _wrap_with_source()
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestWrapWithSource:
     def test_wraps_string(self):
         result = _wrap_with_source("hello", "computed:FOO")
@@ -136,19 +112,12 @@ class TestWrapWithSource:
         assert result == 42
         assert result.provenance[-1]["yaml_file"] == "computed:BAR"
 
-    def test_degrades_without_library(self, mocker):
-        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
-        result = _wrap_with_source("hello", "computed:FOO")
-        assert result == "hello"
-        assert not hasattr(result, "provenance")
-
 
 # ---------------------------------------------------------------------------
 # _preserve_prov()
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestPreserveProv:
     def test_transfers_metadata_on_upper(self):
         original = _wrap_with_source("hello", "src:file.yml")
@@ -174,7 +143,6 @@ class TestPreserveProv:
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestWrapDictWithSource:
     def test_wraps_flat_dict(self):
         d = {"A": 1, "B": "two"}
@@ -194,20 +162,12 @@ class TestWrapDictWithSource:
         assert inner_val == "val"
         assert hasattr(inner_val, "provenance")
 
-    def test_degrades_without_library(self, mocker):
-        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
-        d = {"X": 10}
-        result = _wrap_dict_with_source(d, "prefix")
-        assert result["X"] == 10
-        assert not hasattr(result["X"], "provenance")
-
 
 # ---------------------------------------------------------------------------
 # _ProvenanceJSONEncoder
 # ---------------------------------------------------------------------------
 
 
-@requires_yaml_provenance
 class TestProvenanceJSONEncoder:
     def test_encodes_with_provenance_value(self):
         wrapped = _wrap_with_source("hello", "computed:TEST")

--- a/test/unit/config/test_yaml_provenance.py
+++ b/test/unit/config/test_yaml_provenance.py
@@ -1,0 +1,222 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the yaml-provenance integration in ``yamlparser.py`` and the
+module-level helper functions in ``configcommon.py``.
+
+Every test that requires the ``yaml-provenance`` library is guarded with the
+``requires_yaml_provenance`` marker defined in the config conftest so that
+the test suite degrades gracefully when the library is not installed.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autosubmit.config.configcommon import (
+    _HAS_YAML_PROVENANCE,
+    _preserve_prov,
+    _ProvenanceJSONEncoder,
+    _wrap_dict_with_source,
+    _wrap_with_source,
+)
+from autosubmit.config.yamlparser import YAMLParser
+
+from test.unit.config.conftest import requires_yaml_provenance
+
+
+# ---------------------------------------------------------------------------
+# YAMLParser.load() — provenance path
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestYAMLParserProvenance:
+    """Verify that ``YAMLParser.load()`` returns provenance-bearing values."""
+
+    @staticmethod
+    def _write_yaml(tmp_path: Path, content: str) -> Path:
+        """Write *content* to a temporary YAML file and return its path."""
+        p = tmp_path / "sample.yml"
+        p.write_text(content)
+        return p
+
+    def test_load_returns_dict_with_provenance(self, tmp_path):
+        yaml_file = self._write_yaml(tmp_path, "FOO: bar\nNUM: 42\n")
+        parser = YAMLParser()
+        data = parser.load(yaml_file)
+
+        # Should be a dict (or DictWithProvenance subclass of dict)
+        assert isinstance(data, dict)
+
+        # Leaf values must carry provenance
+        foo = data["FOO"]
+        assert hasattr(foo, "provenance"), "Expected FOO to be a WithProvenance type"
+        prov = foo.provenance
+        assert len(prov) >= 1
+        last = prov[-1] if isinstance(prov, list) else prov
+        assert "yaml_file" in last
+        assert "line" in last
+        assert "col" in last
+        assert str(yaml_file) in str(last["yaml_file"])
+
+    def test_load_values_are_transparent_subtypes(self, tmp_path):
+        yaml_file = self._write_yaml(tmp_path, "NAME: hello\nCOUNT: 7\n")
+        parser = YAMLParser()
+        data = parser.load(yaml_file)
+
+        # StrWithProvenance is a str, IntWithProvenance is an int
+        assert isinstance(data["NAME"], str)
+        assert isinstance(data["COUNT"], int)
+        assert data["NAME"] == "hello"
+        assert data["COUNT"] == 7
+
+    def test_load_nested_dict(self, tmp_path):
+        yaml_file = self._write_yaml(
+            tmp_path, "SECTION:\n  KEY: value\n  NESTED:\n    DEEP: 99\n"
+        )
+        parser = YAMLParser()
+        data = parser.load(yaml_file)
+
+        deep_val = data["SECTION"]["NESTED"]["DEEP"]
+        assert deep_val == 99
+        assert hasattr(deep_val, "provenance")
+
+
+class TestYAMLParserFallback:
+    """Verify fallback behaviour when provenance is unavailable."""
+
+    def test_fallback_returns_plain_dict(self, tmp_path, mocker):
+        mocker.patch("autosubmit.config.yamlparser._HAS_YAML_PROVENANCE", False)
+        yaml_file = tmp_path / "plain.yml"
+        yaml_file.write_text("FOO: bar\n")
+        parser = YAMLParser()
+        data = parser.load(yaml_file)
+
+        assert isinstance(data, dict)
+        assert data["FOO"] == "bar"
+        assert not hasattr(data["FOO"], "provenance")
+
+
+# ---------------------------------------------------------------------------
+# _wrap_with_source()
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestWrapWithSource:
+    def test_wraps_string(self):
+        result = _wrap_with_source("hello", "computed:FOO")
+        assert isinstance(result, str)
+        assert result == "hello"
+        assert hasattr(result, "provenance")
+        last = result.provenance[-1]
+        assert last["yaml_file"] == "computed:FOO"
+        assert last["line"] == 0
+        assert last["col"] == 0
+
+    def test_wraps_int(self):
+        result = _wrap_with_source(42, "computed:BAR")
+        assert isinstance(result, int)
+        assert result == 42
+        assert result.provenance[-1]["yaml_file"] == "computed:BAR"
+
+    def test_degrades_without_library(self, mocker):
+        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
+        result = _wrap_with_source("hello", "computed:FOO")
+        assert result == "hello"
+        assert not hasattr(result, "provenance")
+
+
+# ---------------------------------------------------------------------------
+# _preserve_prov()
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestPreserveProv:
+    def test_transfers_metadata_on_upper(self):
+        original = _wrap_with_source("hello", "src:file.yml")
+        result = _preserve_prov(original, original.upper())
+        assert result == "HELLO"
+        assert hasattr(result, "provenance")
+        assert result.provenance[-1]["yaml_file"] == "src:file.yml"
+
+    def test_transfers_metadata_on_strip(self):
+        original = _wrap_with_source("  padded  ", "src:file.yml")
+        result = _preserve_prov(original, original.strip())
+        assert result == "padded"
+        assert hasattr(result, "provenance")
+
+    def test_noop_for_plain_values(self):
+        result = _preserve_prov("plain", "PLAIN")
+        assert result == "PLAIN"
+        assert not hasattr(result, "provenance")
+
+
+# ---------------------------------------------------------------------------
+# _wrap_dict_with_source()
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestWrapDictWithSource:
+    def test_wraps_flat_dict(self):
+        d = {"A": 1, "B": "two"}
+        result = _wrap_dict_with_source(d, "prefix")
+
+        assert result["A"] == 1
+        assert hasattr(result["A"], "provenance")
+        assert result["A"].provenance[-1]["yaml_file"] == "prefix.A"
+
+        assert result["B"] == "two"
+        assert result["B"].provenance[-1]["yaml_file"] == "prefix.B"
+
+    def test_wraps_nested_dict(self):
+        d = {"OUTER": {"INNER": "val"}}
+        result = _wrap_dict_with_source(d, "root")
+        inner_val = result["OUTER"]["INNER"]
+        assert inner_val == "val"
+        assert hasattr(inner_val, "provenance")
+
+    def test_degrades_without_library(self, mocker):
+        mocker.patch("autosubmit.config.configcommon._HAS_YAML_PROVENANCE", False)
+        d = {"X": 10}
+        result = _wrap_dict_with_source(d, "prefix")
+        assert result["X"] == 10
+        assert not hasattr(result["X"], "provenance")
+
+
+# ---------------------------------------------------------------------------
+# _ProvenanceJSONEncoder
+# ---------------------------------------------------------------------------
+
+
+@requires_yaml_provenance
+class TestProvenanceJSONEncoder:
+    def test_encodes_with_provenance_value(self):
+        wrapped = _wrap_with_source("hello", "computed:TEST")
+        text = json.dumps({"key": wrapped}, cls=_ProvenanceJSONEncoder)
+        parsed = json.loads(text)
+        assert parsed["key"] == "hello"
+
+    def test_encodes_plain_values(self):
+        text = json.dumps({"key": "plain", "num": 42}, cls=_ProvenanceJSONEncoder)
+        parsed = json.loads(text)
+        assert parsed["key"] == "plain"
+        assert parsed["num"] == 42


### PR DESCRIPTION
Integrates [`yaml-provenance`](https://github.com/esm-tools/yaml-provenance) into Autosubmit's YAML configuration pipeline so that every configuration value carries metadata about **which file, line, and column** it originated from. This provenance survives through the entire config lifecycle — parsing, normalization, variable substitution, and serialization — enabling users and developers to trace any configuration value back to its source.

Addresses the long-standing difficulty of identifying *which YAML file* set a particular value when Autosubmit merges configuration from multiple sources (experiment definition, jobs, platforms, user overrides, etc.).

#2505 
@mandresm @kinow 

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] This is a new feature contribution and it `Closes #2505`.

> **Note on unchecked items:**
> - **Changelog:** An entry should be added under `### 4.1.17: Unreleased` → `Enhancements` before merge.
> - **Documentation:** User-facing docs (e.g. `docs/source/userguide/`) should be updated to describe the new `get_value_provenance()` API and the provenance-annotated `experiment_data.yml` output.

---

### Changes

**7 files changed**

#### Core Integration

| File | Description |
|------|-------------|
| yamlparser.py | Overrides `YAMLParser.load()` to use `yaml_provenance.load_yaml()` when available, with transparent fallback to standard `ruamel.yaml`. Configures `track_history=True` for full provenance chains across merged files. Registers pickle reducers and YAML representers after each load. |
| configcommon.py | **Main integration point.** Adds three helper functions (`_wrap_with_source`, `_preserve_prov`, `_wrap_dict_with_source`) and modifies ~20 methods to preserve provenance through normalization and substitution. Adds the public `get_value_provenance()` API. Uses `dump_yaml()` for provenance-annotated output in `experiment_data.yml`. |

#### Key Design Decisions

1. **Graceful degradation**: All imports are wrapped in `try/except ImportError`. When `yaml-provenance` is not installed, Autosubmit behaves identically to before — zero breaking changes.

2. **Provenance-preserving helpers**:
   - `_wrap_with_source(value, source)` — annotates programmatically-injected values (env vars, `BasicConfig` props, git commit, computed HPC paths)
   - `_preserve_prov(original, result)` — re-attaches provenance after `str.upper()`, `.strip()`, `.split()`, slicing, and `int()` conversions that would otherwise return plain Python types
   - `_wrap_dict_with_source(d, prefix)` — recursively wraps all leaves in a dict

3. **`type() is` → `isinstance()`**: ~15 occurrences of `type(x) is str/dict/list/int` replaced with `isinstance()` checks. This is necessary because `WithProvenance` types (e.g., `StrWithProvenance`) are *subclasses* of their native types — `type(x) is str` would fail for them while `isinstance(x, str)` works correctly.

4. **`unified_config` list guard removed**: The `current_list != val` optimization in `_unify_conf()` was silently discarding provenance-bearing lists because `StrWithProvenance.__eq__` compares by value, making the guard think lists were identical. Lists are now always replaced.

5. **JSON serialization**: `get_full_config_as_json()` now uses `ProvenanceJSONEncoder` to correctly serialize `WithProvenance` values.

6. **YAML output**: `save()` uses `yaml_provenance.dump_yaml()` to write inline provenance comments (file/line/col) in `experiment_data.yml`.

#### New Public API

```python
as_conf = AutosubmitConfig("a001")
as_conf.reload()
prov = as_conf.get_value_provenance(["JOBS", "INI", "WALLCLOCK"])
# [{'yaml_file': '.../jobs_a001.yml', 'line': 14, 'col': 8}]
```

#### Dependency

| File | Change |
|------|--------|
| pyproject.toml | Added `"yaml-provenance>=0.1.0"` as a required dependency |

#### Tests

| File | Description |
|------|-------------|
| conftest.py | Adds `requires_yaml_provenance` skip marker for graceful degradation in CI |
| test_yaml_provenance.py | **6 test classes** — `YAMLParser.load()` provenance, fallback behavior, `_wrap_with_source`, `_preserve_prov`, `_wrap_dict_with_source`, `ProvenanceJSONEncoder` |
| test_provenance_config.py | **8 test classes** — `get_value_provenance()` API, `deep_normalize`, `dict_replace_value`, `_normalize_notify_on`, `_normalize_dependencies`, `_normalize_jobs_section`, `load_as_env_variables`, `save()` with provenance comments |

**14 test classes total**, all gated with `@requires_yaml_provenance` so the existing test suite passes unchanged when the library is absent.

#### Miscellaneous

| File | Change |
|------|--------|
| .gitignore | Ignores agents, plans, `.github/skills/`, and prov-implementation |

---

### Backward Compatibility

- **No breaking changes.** All provenance features are opt-in via the `yaml-provenance` dependency.
- `WithProvenance` types are transparent subclasses (`StrWithProvenance` is a `str`, `IntWithProvenance` is an `int`), so all existing comparisons, formatting, and downstream code work without modification.
- The `isinstance()` migration from `type() is` is independently correct and improves robustness regardless of provenance.

### How to Test

**Unit tests:**
```bash
pip install "yaml-provenance>=0.1.0"
cd test && python -m pytest unit/config/test_yaml_provenance.py unit/config/test_provenance_config.py -v
```

**Real application (reproducible expid test):**

| Item | Value |
|------|-------|
| EXPID | `t0ht` |
| Metadata path | `/appl/AS/AUTOSUBMIT_DATA/t0ht/conf/metadata/experiment_data.yml` |
| yaml-provenance branch | `enhanced-yaml-provenance` |
| workflow branch | `main` |

---

### Suggested CHANGELOG entry

```markdown
### 4.1.17: Unreleased

**Enhancements:**

- Integrate `yaml-provenance` library for configuration value traceability — every YAML value now carries source file, line, and column metadata through normalization and substitution. New `get_value_provenance()` API on `AutosubmitConfig`. Provenance comments written to `experiment_data.yml`.
```


