### PR TITLE
Fallback when PLATFORMS not defined and HPCARCH is LOCAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes:**
 
--
+- Fixed issue with experiments running on LOCAL platform without a defined LOCAL entry in platforms.yml config file #1131
 
 **Enhancements:**
 

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -95,11 +95,24 @@ class AutosubmitConfig(object):
     @property
     def platforms_data(self) -> dict[str, Any]:
         try:
-            return self.experiment_data["PLATFORMS"]
-        except KeyError:
-            raise AutosubmitCritical(
-                "PLATFORMS section not found in configuration file", 7014
-            )
+            hpcarch = str(
+                self.experiment_data.get("DEFAULT", {}).get("HPCARCH", "")
+            ).upper()
+            platforms = self.experiment_data.get("PLATFORMS")
+            if platforms is None:
+                if hpcarch == "LOCAL":
+                    # DEFAULT.HPCARCH is LOCAL and no defined platform, return empty dict
+                    return {}
+                raise AutosubmitCritical(
+                    "PLATFORMS section not found in configuration file", 7014
+                )
+            if not isinstance(platforms, dict):
+                raise AutosubmitCritical(
+                    "PLATFORMS section is malformed in configuration file", 7014
+                )
+            return platforms
+        except AutosubmitCritical:
+            raise
         except Exception as exc:
             raise AutosubmitCritical(
                 f"Error while reading PLATFORMS section: {exc}", 7014

--- a/test/unit/config/test_configcommon.py
+++ b/test/unit/config/test_configcommon.py
@@ -283,3 +283,69 @@ def test_is_valid_mail_address(email, expected):
             AutosubmitConfig.is_valid_mail_address(email)
     else:
         assert AutosubmitConfig.is_valid_mail_address(email) is expected
+
+
+def test_platforms_missing_hpcarch_local(autosubmit_config: "AutosubmitConfigFactory"):
+    """Test that if PLATFORMS is missing but DEFAULT.HPCARCH is LOCAL, we return an empty dictionary."""
+    as_conf: AutosubmitConfig = autosubmit_config(
+        expid="a000", experiment_data={"DEFAULT": {"HPCARCH": "LOCAL"}}
+    )
+    as_conf.experiment_data.pop("PLATFORMS", None)
+
+    assert as_conf.platforms_data == {}
+
+
+def test_platforms_missing_hpcarch_non_local(
+    autosubmit_config: "AutosubmitConfigFactory",
+):
+    """Test that if PLATFORMS is missing and DEFAULT.HPCARCH is not LOCAL, we raise an AutosubmitCritical."""
+    as_conf: AutosubmitConfig = autosubmit_config(
+        expid="a000", experiment_data={"DEFAULT": {"HPCARCH": "MARENOSTRUM5"}}
+    )
+    as_conf.experiment_data.pop("PLATFORMS", None)
+
+    with pytest.raises(AutosubmitCritical) as exc_info:
+        _ = as_conf.platforms_data
+
+    assert exc_info.value.code == 7014
+    assert "PLATFORMS section not found in configuration file" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "platform_description",
+    [
+        {
+            "PYTEST-UNDEFINED": {
+                "host": "",
+                "user": "",
+                "project": "",
+                "scratch_dir": "",
+                "MAX_WALLCLOCK": "",
+                "DISABLE_RECOVERY_THREADS": True,
+            }
+        },
+        "not_a_dict",
+    ],
+)
+def test_platforms_not_dict(
+    autosubmit_config: "AutosubmitConfigFactory", platform_description
+):
+    """Test that if PLATFORMS is not a dictionary, we raise an AutosubmitCritical."""
+    as_conf: AutosubmitConfig = autosubmit_config(
+        expid="a000",
+        experiment_data={
+            "PLATFORMS": platform_description,
+            "DEFAULT": {"HPCARCH": "MARENOSTRUM5"},
+        },
+    )
+
+    if not isinstance(platform_description, dict):
+        with pytest.raises(AutosubmitCritical) as exc_info:
+            _ = as_conf.platforms_data
+
+        assert exc_info.value.code == 7014
+        assert "PLATFORMS section is malformed in configuration file" in str(
+            exc_info.value
+        )
+    else:
+        assert platform_description == as_conf.platforms_data


### PR DESCRIPTION
Closes [#1131](https://github.com/BSC-ES/autosubmit/issues/1131)

Fixes error raised during command execution ```autosubmit create <EXPID>``` for those experiments that run on LOCAL system (-H local) and do not have a defined ```PLATFORMS``` configuration file ```platforms_<EXPID>.yml```.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
