### PR TITLE
Use a Slurm Docker image maintained by giovtorres

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
     env:
       COVERAGE_PROCESS_START: .coveragerc
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -147,13 +147,32 @@ jobs:
           retention-days: 7
 
       - name: Tar logs
+        id: tar_logs
         if: failure()
         run: |
-          mv ../container_logs_ssh_server/ container_logs_integration 
-          mv ../container_logs_git_server/ container_logs_integration_git
+          logs_found=false
+          
+          if [ -d ../container_logs_ssh_server ]; then
+            echo "Found container logs for SSH server, moving them to container_logs_integration"
+            mv ../container_logs_ssh_server/ container_logs_integration
+            logs_found=true
+          else
+            echo "No container logs found for SSH server"
+          fi
+          
+          if [ -d ../container_logs_git_server ]; then
+            echo "Found container logs for Git server, moving them to container_logs_integration_git"
+            mv ../container_logs_git_server/ container_logs_integration_git
+            logs_found=true
+          else
+            echo "No container logs found for Git server"
+          fi
+          
+          # Write the value to the GH Actions step output, so other steps can use it.
+          echo "logs_found=$logs_found" >> $GITHUB_OUTPUT
 
       - name: Upload logs to GitHub
-        if: failure()
+        if: failure() && steps.tar_logs.outputs.logs_found == 'true'
         uses: actions/upload-artifact@master
         with:
           name: container_logs_integration_${{ github.run_id }}
@@ -228,9 +247,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install system dependencies
-        run: sudo apt-get install -y curl git graphviz rsync
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip packaging
@@ -246,8 +262,8 @@ jobs:
 
       - name: Integration tests
         run: |
-          pytest \
-            -n $(nproc) \
+          pytest -x \
+            -n 3 \
             --cov=autosubmit --cov-config=.coveragerc \
             --cov-report=xml:test/coverage.xml --cov-append \
             test/integration \
@@ -266,17 +282,29 @@ jobs:
           retention-days: 7
 
       - name: Tar logs
+        id: tar_logs
         if: failure()
         run: |
-          mv ../container_logs_slurm_server/ container_logs_slurm.tgz 
+          logs_found=false
+          
+          if [ -d ../container_logs_slurm_server ]; then
+            echo "Found container logs for SLURM server, moving them to container_logs_slurm"
+            mv ../container_logs_slurm_server/ container_logs_slurm
+            logs_found=true
+          else
+            echo "No container logs found for SLURM server"
+          fi
+          
+          # Write the value to the GH Actions step output, so other steps can use it.
+          echo "logs_found=$logs_found" >> $GITHUB_OUTPUT
 
       - name: Upload logs to GitHub
-        if: failure()
+        if: failure() && steps.tar_logs.outputs.logs_found == 'true'
         uses: actions/upload-artifact@master
         with:
           name: container_logs_slurm_${{ github.run_id }}
           path: |
-            container_logs_slurm.tgz
+            container_logs_slurm
           retention-days: 1
           overwrite: true
 
@@ -352,6 +380,7 @@ jobs:
       - name: Validate citation file
         run: |
           cffconvert --validate -i CITATION.cff
+
 
   coverage:
     needs: [test-unit, test-integration, test-regression, test-slurm, test-docs]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Every YAML file loaded is now printed in the debug log (use -lc DEBUG in the
   command line if you want this) #2879
 - Allow to set AS variables as lowercase/uppercase (,,/^^) #2504
+- Slurm tests in CICD are using a new container by @giovtorres #2871
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -29,6 +29,7 @@ import signal
 import subprocess
 import sys
 import tarfile
+import threading
 import time
 import warnings
 from collections import defaultdict
@@ -1940,7 +1941,10 @@ class Autosubmit:
             except BaseException as e:
                 raise AutosubmitCritical("Failure during setting the start time check trace for details", 7014, str(e))
             os.system('clear')
-            signal.signal(signal.SIGINT, signal_handler)
+            if threading.current_thread().name is threading.main_thread():
+                signal.signal(signal.SIGINT, signal_handler)
+            else:
+                Log.debug('Not setting signal handler: Autosubmit running within a thread.')
             # The time between running iterations, default to 10 seconds. Can be changed by the user
             safetysleeptime = as_conf.get_safetysleeptime()
             retrials = as_conf.get_retrials()
@@ -2126,6 +2130,7 @@ class Autosubmit:
         :return: exit status
 
         """
+        Autosubmit.exit = False
         # Start profiling if the flag has been used
         if profile is not None:
             from .profiler.profiler import Profiler
@@ -2999,6 +3004,10 @@ class Autosubmit:
         if save:
             offline_jobs = []
             for job in current_active_jobs:
+                if not job.id:
+                    Log.warning(f"Skipping cancellation of job with invalid ID: {job.id}")
+                    continue
+
                 if offline or not job.platform.connected:
                     offline_jobs.append(job.name)
                 else:

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -3132,8 +3132,7 @@ class WrapperJob(Job):
             elif reason == '(JobHeldAdmin)':
                 Log.debug(
                     f"Job {self.name} Failed to be HELD, canceling... ", )
-                self._platform.send_command(
-                    self._platform.cancel_cmd + f" {self.id}")
+                self._platform.send_command(self._platform.cancel_cmd + f" {self.id}")
                 self.status = Status.WAITING
             else:
                 Log.info(f"Job {self.name} is QUEUING {reason}")

--- a/autosubmit/platforms/locplatform.py
+++ b/autosubmit/platforms/locplatform.py
@@ -70,7 +70,7 @@ class LocalPlatform(ParamikoPlatform):
         """Updates commands for platforms."""
         self.root_dir = os.path.join(BasicConfig.LOCAL_ROOT_DIR, self.expid)
         self.remote_log_dir = os.path.join(self.root_dir, "tmp", 'LOG_' + self.expid)
-        self.cancel_cmd = "kill -SIGINT"
+        self.cancel_cmd = "kill -2"
         self._checkhost_cmd = "echo 1"
         self.put_cmd = "cp -p"
         self.get_cmd = "cp"
@@ -152,24 +152,41 @@ class LocalPlatform(ParamikoPlatform):
         for job, prev_job_status in job_list:
             self.check_job(job)
 
-    def send_command(self, command, ignore_log=False, x11=False) -> bool:
-
-        lang = locale.getlocale()[1]
-        if lang is None:
-            lang = locale.getdefaultlocale()[1]
-            if lang is None:
-                lang = 'UTF-8'
+    def send_command(self, command: str, ignore_log=False, x11=False) -> bool:
         try:
-            output = subprocess.check_output(command.encode(lang), shell=True)
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            self._ssh_output = result.stdout.strip()
+
+            if result.stderr and not ignore_log:
+                Log.warning(f"Command '{command}' succeeded with warning: {result.stderr.strip()}")
+
+            Log.debug(f"Sent command {command} successfully: {self._ssh_output}")
+
+            self._check_for_unrecoverable_errors()
+
+            return True
         except subprocess.CalledProcessError as e:
             if not ignore_log:
-                Log.error(f'Could not execute command {e.cmd} on {self.host}')
+                error_trace = (
+                    f"Execution failed on {self.host}\n"
+                    f"Command: {e.cmd}\n"
+                    f"Exit Code: {e.returncode}\n"
+                    f"Stdout: {e.stdout.strip() if e.stdout else 'None'}\n"
+                    f"Stderr: {e.stderr.strip() if e.stderr else 'None'}"
+                )
+                Log.error(error_trace)
+            self._ssh_output = e.stderr or e.stdout
             return False
-        self._ssh_output = output.decode(lang)
-        Log.debug(f"Command '{command}': {self._ssh_output}")
-        self._check_for_unrecoverable_errors()
-
-        return True
+        except Exception as e:
+            if not ignore_log:
+                Log.error(f"Unexpected error executing command: {str(e)}")
+            return False
 
     def send_file(self, filename: str, check: bool = True) -> bool:
         """Sends a file to a specified location using a command.

--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -884,7 +884,7 @@ class ParamikoPlatform(Platform):
             cmd = f"find {self.remote_log_dir} -maxdepth 1 \\( {pattern} \\) -type f"
             self.send_command(cmd)
             output = self.get_ssh_output()
-            completed_files = output.strip().split('\n') if output else []
+            completed_files = [f for f in output.strip().split("\n") if f]
             final_job_names = [Path(file).name.replace('_COMPLETED', '') for file in completed_files]
         return final_job_names
 
@@ -1382,7 +1382,18 @@ class ParamikoPlatform(Platform):
                                     stdout_chunks.append(job_id[0].encode(lang))
                                     x11_exit = True
                     else:
-                        x11_exit = True
+                        # No stderr from the select() readq this iteration. Before declaring
+                        # x11_exit, drain any data Paramiko may have buffered internally
+                        # (select() can miss it due to timing). Only exit if the channel is
+                        # truly done (exit_status_ready), otherwise loop again to give the
+                        # remote command time to produce stderr output.
+                        if channel.recv_stderr_ready():
+                            aux_stderr.append(
+                                stderr.channel.recv_stderr(len(channel.in_stderr_buffer) or 4096)
+                            )
+                            x11_exit = True
+                        elif channel.exit_status_ready():
+                            x11_exit = True
                     if not x11_exit:
                         stderr_readlines = []
                     else:

--- a/autosubmit/platforms/psplatform.py
+++ b/autosubmit/platforms/psplatform.py
@@ -60,7 +60,7 @@ class PsPlatform(ParamikoPlatform):
         """Updates commands for platforms."""
         self.root_dir = os.path.join(self.scratch, self.project_dir, self.user, self.expid)
         self.remote_log_dir = os.path.join(self.root_dir, "LOG_" + self.expid)
-        self.cancel_cmd = "kill -SIGINT"
+        self.cancel_cmd = "kill -2"
         self._checkhost_cmd = "echo 1"
         self.put_cmd = "scp"
         self.get_cmd = "scp"

--- a/test/integration/commands/conftest.py
+++ b/test/integration/commands/conftest.py
@@ -1,6 +1,25 @@
-import pytest
-from typing import Dict, Any
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+from getpass import getuser
 from pathlib import Path
+from typing import Dict, Any
+
+import pytest
 
 
 @pytest.fixture(scope="function")
@@ -41,7 +60,7 @@ def general_data(tmp_path: Path) -> dict[str, Any]:
                 'QUEUE': 'gp_debug',
                 'SCRATCH_DIR': '/tmp/scratch',
                 'TEMP_DIR': '',
-                'USER': 'root',
+                'USER': getuser(),
                 'PROCESSORS': '1',
                 'MAX_PROCESSORS': '128',
                 'PROCESSORS_PER_NODE': '128',
@@ -55,15 +74,15 @@ def general_data(tmp_path: Path) -> dict[str, Any]:
                 'QUEUE': 'gp_debug',
                 'SCRATCH_DIR': '/tmp/scratch',
                 'TEMP_DIR': '',
-                'USER': 'root',
+                'USER': getuser(),
                 'PROCESSORS': '1',
                 'MAX_PROCESSORS': '128',
                 'PROCESSORS_PER_NODE': '128',
             },
-            # TODO: Containarize ecaccess to be able to run these tests in CI/CD.
+            # TODO: Containerize ecaccess to be able to run these tests in CI/CD.
             'TEST_EC': {
                 'TYPE': 'ecaccess',  # enables the usage of ecaccess commands, requires a valid .eccert in ~/.eccert
-                'VERSION': 'slurm',  # HPC scheduler accesed via ecaccess commands
+                'VERSION': 'slurm',  # HPC scheduler accessed via ecaccess commands
                 'ADD_PROJECT_TO_HOST': 'False',
                 'HOST': 'hpc-login',  # Can only run locally with a valid .eccert, see https://gitlab.earth.bsc.es/es/auto-ecearth3/-/wikis/Running-on-ECMWF-HPC2020
                 'MAX_WALLCLOCK': '48:00',
@@ -169,7 +188,7 @@ def jobs_data(tmp_path: Path) -> Dict[str, object]:
     }
 
 
-def wrapped_jobs(wrapper_type: str, structure: dict, size: dict) -> Dict[str, object]:
+def wrapped_jobs(wrapper_type: str, structure: dict, size: dict) -> Dict[str, Any]:
     """Provides a `jobs_data` dictionary with wrapped jobs used by the
     integration tests in `commands`.
 

--- a/test/integration/commands/inspect/test_inspect_local.py
+++ b/test/integration/commands/inspect/test_inspect_local.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
 # This file is part of Autosubmit.
 #
@@ -155,7 +155,9 @@ def test_inspect(
         additional_data: str,
         general_data: dict[str, Any],
 ):
-    """Test inspect command for local platform with different job types to see that HPC parameters are correctly set in the job scripts."""
+    """Test inspect command for LOCAL platform.
+
+     Uses different job types to see that HPC parameters are correctly set in the job scripts."""
     yaml = YAML(typ='rt')
 
     if 'FILE' in additional_data:
@@ -168,7 +170,8 @@ def test_inspect(
         script_file.write_text(_TEMPLATE_CONTENT)
         script_file.chmod(0o755)
 
-    # TODO: This should be 'local' but we can't customaize LOCAL platform yet, also scratch_dir, user, host, project shouldn't be modificable at all
+    # TODO: This should be 'local' but we can't customize LOCAL platform yet,
+    #       also scratch_dir, user, host, project shouldn't be allowed to be modified.
     general_data['PLATFORMS']['LOCAL'] = {'TYPE': 'ps', 'HOST': "127.0.0.1", 'SCRATCH_DIR': str(tmp_path), 'USER': ""}
 
     for hpcarch in ['TEST_PS', 'TEST_SLURM', 'LOCAL']:
@@ -177,7 +180,7 @@ def test_inspect(
         general_data['PLATFORMS'][hpcarch]['CUSTOM_DIR_POINTS_TO_OTHER_DIR'] = '%TEST_REFERENCE%'
         as_exp = autosubmit_exp(experiment_data=general_data | yaml.load(additional_data), include_jobs=False, create=True)
 
-        # TODO: This shouldn't be needed but we can't customaize LOCAL platform yet
+        # TODO: This shouldn't be needed but we can't customize LOCAL platform yet
         if hpcarch == 'LOCAL':
             general_data['PLATFORMS'][hpcarch]['PROJECT'] = as_exp.expid
 
@@ -185,7 +188,8 @@ def test_inspect(
         as_conf.set_last_as_command('inspect')
         hpcarch_info = as_conf.experiment_data.get('PLATFORMS', {}).get('TEST_PS', {})
 
-        # TODO: This shouldn't be needed 'local' platform info should be inyected in the memory of the experiment_data when creating the experiment
+        # TODO: This shouldn't be needed 'local' platform info should be injected in
+        #       the memory of the experiment_data when creating the experiment.
         if hpcarch == 'LOCAL':
             expected_hpcrootdir = Path(BasicConfig.LOCAL_ROOT_DIR) / as_exp.expid / Path(BasicConfig.LOCAL_TMP_DIR)
             expected_hpclogdir = expected_hpcrootdir / f"LOG_{as_exp.expid}"

--- a/test/integration/commands/run/conftest.py
+++ b/test/integration/commands/run/conftest.py
@@ -28,7 +28,7 @@ import pwd
 import sqlite3
 from pathlib import Path
 from threading import Thread
-from typing import Any, Callable, TYPE_CHECKING
+from typing import cast, Any, Callable, Optional, TYPE_CHECKING
 
 import pytest
 
@@ -103,7 +103,7 @@ def _print_db_results(db_check_list, rows_as_dicts, run_tmpdir):
                 print(f"Job entry: {job_name} assert {str(all_ok).upper()}")
 
 
-def run_in_thread(target: Callable[..., Any], *args, **kwargs) -> Thread:
+def run_in_thread(target: Callable[..., Any], *args, **kwargs) -> tuple[Thread, Optional[Exception], int]:
     """Run the given target function in a separate thread.
 
     :param target: The function to execute in the thread.
@@ -115,9 +115,17 @@ def run_in_thread(target: Callable[..., Any], *args, **kwargs) -> Thread:
     :return: The started Thread object.
     :rtype: Thread
     """
-    thread = Thread(target=target, args=args, kwargs=kwargs)
+    result = {"exit_code": -1, "exception": None}
+
+    def wrap_thread(*args, **kwargs) -> None:
+        try:
+            result["exit_code"] = target(*args, **kwargs)
+        except Exception as e:
+            result["exception"] = e  # type: ignore
+
+    thread = Thread(target=wrap_thread, args=args, kwargs=kwargs)
     thread.start()
-    return thread
+    return thread, result["exception"], cast(int, result["exit_code"])
 
 
 def _check_db_fields(run_tmpdir: Path, expected_entries, final_status, expid, wrapper_type="simple") -> dict[str, (bool, str)]:

--- a/test/integration/commands/run/test_run_ps_scenarios.py
+++ b/test/integration/commands/run/test_run_ps_scenarios.py
@@ -1,6 +1,25 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests that run diverse scenarios for Autosubmit run with a ``ps`` platform
+and checks the database for expected results."""
+
 from pathlib import Path
 from textwrap import dedent
-from time import sleep
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,6 +28,7 @@ from ruamel.yaml import YAML
 from autosubmit.config.basicconfig import BasicConfig
 from test.integration.commands.run.conftest import _check_db_fields, _assert_exit_code, _check_files_recovered, \
     _assert_db_fields, _assert_files_recovered, run_in_thread
+from test.integration.test_utils.misc import wait_locker
 
 if TYPE_CHECKING:
     from docker.models.containers import Container
@@ -17,46 +37,50 @@ if TYPE_CHECKING:
 # -- Tests
 
 @pytest.mark.docker
-@pytest.mark.slurm
 @pytest.mark.ssh
-@pytest.mark.parametrize("jobs_data,expected_db_entries,final_status,wrapper_type", [
-    # Success
-    (dedent("""\
-    EXPERIMENT:
-        NUMCHUNKS: '3'
-    JOBS:
-        JOB:
-            SCRIPT: |
-                echo "Hello World with id=Success"
-                sleep 1
-            PLATFORM: TEST_PS
-            RUNNING: chunk
-            WALLCLOCK: 00:01
-            RETRIALS: 0
-    """), 3, "COMPLETED", "simple"),  # No wrappers, simple type
-
-    # Failure
-    (dedent("""\
-    EXPERIMENT:
-        NUMCHUNKS: '2'
-    JOBS:
-        JOB:
-            SCRIPT: |
-                sleep 2
-                d_echo "Hello World with id=FAILED"
-            PLATFORM: TEST_PS
-            RUNNING: chunk
-            WALLCLOCK: 00:01
-            RETRIALS: 2
-    """), (2 + 1) * 2, "FAILED", "simple"),  # No wrappers, simple type
-], ids=["Success", "Failure"])
+@pytest.mark.parametrize(
+    "jobs_data,expected_db_entries,final_status,wrapper_type", [
+        # Success
+        (
+                dedent("""\
+                EXPERIMENT:
+                    NUMCHUNKS: '3'
+                JOBS:
+                    JOB:
+                        SCRIPT: |
+                            echo "Hello World with id=Success"
+                            sleep 1
+                        PLATFORM: TEST_PS
+                        RUNNING: chunk
+                        WALLCLOCK: 00:01
+                        RETRIALS: 0
+                """), 3, "COMPLETED", "simple"
+        ),  # No wrappers, simple type
+        # Failure
+        (
+                dedent("""\
+                EXPERIMENT:
+                    NUMCHUNKS: '2'
+                JOBS:
+                    JOB:
+                        SCRIPT: |
+                            sleep 2
+                            d_echo "Hello World with id=FAILED"
+                        PLATFORM: TEST_PS
+                        RUNNING: chunk
+                        WALLCLOCK: 00:01
+                        RETRIALS: 2
+                """), (2 + 1) * 2, "FAILED", "simple"
+        ),  # No wrappers, simple type
+    ],
+    ids=["Success", "Failure"])
 def test_run_uninterrupted(
         autosubmit_exp,
         jobs_data: str,
         expected_db_entries,
         final_status,
         wrapper_type,
-        slurm_server: 'Container',
+        ssh_server: 'Container',
         prepare_scratch,
         general_data,
 ):
@@ -101,7 +125,6 @@ def test_run_uninterrupted(
 
 
 @pytest.mark.docker
-@pytest.mark.slurm
 @pytest.mark.ssh
 @pytest.mark.parametrize("jobs_data,expected_db_entries,final_status,wrapper_type", [
     # Success
@@ -139,7 +162,7 @@ def test_run_interrupted(
         expected_db_entries,
         final_status,
         wrapper_type,
-        slurm_server: 'Container',
+        ssh_server: 'Container',
         prepare_scratch,
         general_data,
 ):
@@ -154,10 +177,19 @@ def test_run_interrupted(
 
     # Run the experiment
     # This was not being interrupted, so we run it in a thread to simulate the interruption and then stop it.
-    run_in_thread(as_exp.autosubmit.run_experiment, expid=as_exp.expid)
-    sleep(2)
+    as_thread, exception, _ = run_in_thread(as_exp.autosubmit.run_experiment, expid=as_exp.expid)
+    if exception:
+        pytest.fail(f"Exception raised: {exception}")
+    # Instead of using sleep(N), we wait until the file lock is confirmed by portalocker.
+    # Once locked, we know Autosubmit has started the main loop (context manager does it).
+    lock_file = Path(BasicConfig.LOCAL_ROOT_DIR, as_exp.expid, BasicConfig.LOCAL_TMP_DIR, "autosubmit.lock")
+    wait_locker(lock_file, expect_locked=True, timeout=20, interval=0.5)
+
+    # Here we issue an ``autosubmit stop`` and then join the thread where Autosubmit is running as, otherwise,
+    # we may get a timeout error where the thread stack printed shows Paramiko threads are still running
+    # (waiting on ``recv()``).
     current_statuses = 'SUBMITTED, QUEUING, RUNNING'
-    as_exp.autosubmit.stop(
+    assert as_exp.autosubmit.stop(
         all_expids=False,
         cancel=False,
         current_status=current_statuses,
@@ -165,6 +197,9 @@ def test_run_interrupted(
         force=True,
         force_all=True,
         status='FAILED')
+    as_thread.join(timeout=20)
+    assert not as_thread.is_alive(), "Autosubmit thread did not stop"
+    wait_locker(lock_file, expect_locked=False, timeout=20, interval=0.5)
 
     exit_code = as_exp.autosubmit.run_experiment(expid=as_exp.expid)
 

--- a/test/integration/commands/run/test_run_slurm_scenarios.py
+++ b/test/integration/commands/run/test_run_slurm_scenarios.py
@@ -1,7 +1,27 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests that run diverse scenarios for Autosubmit run with a ``slurm`` platform
+and checks the database for expected results."""
+
 from getpass import getuser
 from pathlib import Path
 from textwrap import dedent
-from time import sleep
+from test.integration.test_utils.misc import wait_locker
 from typing import TYPE_CHECKING
 
 import pytest
@@ -344,8 +364,11 @@ def test_run_interrupted(
 
     # Run the experiment
     # This was not being interrupted, so we run it in a thread to simulate the interruption and then stop it.
-    run_in_thread(as_exp.autosubmit.run_experiment, expid=as_exp.expid)
-    sleep(2)
+    lock_file = Path(BasicConfig.LOCAL_ROOT_DIR, as_exp.expid, BasicConfig.LOCAL_TMP_DIR, "autosubmit.lock")
+    as_thread, exception, _ = run_in_thread(as_exp.autosubmit.run_experiment, expid=as_exp.expid)
+    if exception:
+        pytest.fail(f"Exception raised: {exception}")
+    wait_locker(lock_file, expect_locked=True, timeout=30, interval=0.5)
     current_statuses = 'SUBMITTED, QUEUING, RUNNING'
     as_exp.autosubmit.stop(
         all_expids=False,
@@ -355,6 +378,10 @@ def test_run_interrupted(
         force=True,
         force_all=True,
         status='FAILED')
+
+    as_thread.join(timeout=60)
+    assert not as_thread.is_alive(), "Autosubmit thread did not stop after stop() call"
+    wait_locker(lock_file, expect_locked=False, timeout=30, interval=0.5)
 
     exit_code = as_exp.autosubmit.run_experiment(expid=as_exp.expid)
 
@@ -730,7 +757,7 @@ def test_run_with_additional_files(
     ),
 ])
 def test_wrapper_config(
-        wrappers: str,
+        wrappers: dict,
         run_type: str,
         autosubmit_exp,
         slurm_server: 'Container',
@@ -784,12 +811,12 @@ def test_wrapper_config(
             as_exp.as_conf.set_last_as_command('inspect')
             as_exp.autosubmit.inspect(
                 expid=as_exp.expid,
-                lst=None,
+                lst=None,  # type: ignore
                 check_wrapper=True,
                 force=True,
-                filter_chunks=None,
-                filter_section=None,
-                filter_status=None,
+                filter_chunks=None,  # type: ignore
+                filter_section=None,  # type: ignore
+                filter_status=None,  # type: ignore
                 quick=True if run_type == "quick-inspect" else False
             )
         templates_dir = Path(tmp_path) / as_exp.expid / "tmp"

--- a/test/integration/commands/test_recovery.py
+++ b/test/integration/commands/test_recovery.py
@@ -16,6 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from getpass import getuser
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
@@ -66,11 +67,11 @@ def prepare_scratch(as_exp, tmp_path: Path, job_list, job_names_to_recover, slur
     :type job_names_to_recover: Any
     :type slurm_server: Any
     """
-    slurm_root = f"/tmp/scratch/group/root/{as_exp.expid}/"
+    slurm_root = f"/tmp/scratch/group/{getuser()}/{as_exp.expid}/"
     log_dir = Path(slurm_root) / f'LOG_{as_exp.expid}/'
     local_completed_dir = tmp_path / as_exp.expid / "tmp" / f'LOG_{as_exp.expid}/'
     # combining this with the touch, makes the touch generates a folder instead of a file. I have no idea why.
-    slurm_server.exec_run(f'mkdir -p {log_dir}')
+    slurm_server.exec_run(['bash', '-c', f'mkdir -p {log_dir}'])
 
     cmds = []
     for name in job_names_to_recover:
@@ -80,7 +81,8 @@ def prepare_scratch(as_exp, tmp_path: Path, job_list, job_names_to_recover, slur
         else:
             cmds.append(f'touch {log_dir}/{name}_COMPLETED')
     full_cmd = " && ".join(cmds)
-    slurm_server.exec_run(full_cmd)
+    # exec_run with a string uses shlex.split which breaks shell operators like &&
+    slurm_server.exec_run(['bash', '-c', full_cmd])
 
 
 @pytest.fixture(scope="function")
@@ -102,19 +104,24 @@ def job_names_to_recover(job_list):
     "No_Active_jobs&Force == recover_all",
     "No_Active_jobs&No_Force == recover_all",
 ])
-def test_online_recovery(as_exp, prepare_scratch, submitter, slurm_server, job_names_to_recover, active_jobs, force):
+def test_online_recovery(
+        as_exp,
+        prepare_scratch,
+        submitter,
+        slurm_server,
+        job_names_to_recover,
+        active_jobs: bool,
+        force: bool
+):
     """Test the recovery of an experiment.
 
     :param as_exp: The Autosubmit experiment object.
     :param prepare_scratch: Fixture to prepare the scratch directory.
-    :type as_exp: Any
-    :type prepare_scratch: Any
     """
-    job_list_ = as_exp.autosubmit.load_job_list(
-        as_exp.expid, as_exp.as_conf, new=False)
+    job_list_ = as_exp.autosubmit.load_job_list(as_exp.expid, as_exp.as_conf, new=False)
     db_manager = SqlAlchemyExperimentHistoryDbManager(as_exp.expid, BasicConfig.JOBDATA_DIR, f'job_data_{as_exp.expid}.db')
     db_manager.initialize()
-    # Save fails if platform is not set ( in 4.2 this is not the case )
+    # Save fails if the platform is not set. In 4.2 this will not happen.
     submitter = ParamikoSubmitter(as_conf=as_exp.as_conf)
     submitter.load_platforms(as_exp.as_conf)
     platforms = submitter.platforms
@@ -134,11 +141,11 @@ def test_online_recovery(as_exp, prepare_scratch, submitter, slurm_server, job_n
         with pytest.raises(AutosubmitCritical):
             as_exp.autosubmit.recovery(
                 as_exp.expid,
-                noplot=False,  # Just test that is called without errors
+                noplot=False,
                 save=True,
                 all_jobs=True,
-                hide=True,  # Just test that is called without errors
-                group_by="date",  # Just test that is called without errors
+                hide=True,
+                group_by="date",
                 expand=[],
                 expand_status=[],
                 detail=True,
@@ -160,13 +167,12 @@ def test_online_recovery(as_exp, prepare_scratch, submitter, slurm_server, job_n
             offline=False
         )
 
-        job_list_ = as_exp.autosubmit.load_job_list(
-            as_exp.expid, as_exp.as_conf, new=False)
+        job_list_ = as_exp.autosubmit.load_job_list(as_exp.expid, as_exp.as_conf, new=False)
 
         completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
 
         for name in job_names_to_recover:
-            # 2nd split is not completed, so the 3º split was marked as COMPLETED ( file found) and then WAITING
+            # 2nd split is not completed, so the 3rd split was marked as the COMPLETED file was found, and then WAITING.
             split_number = name.split('_')[-2]
             if split_number == "3":
                 assert name not in completed_jobs

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -31,6 +31,7 @@ from typing import Any, Callable, Generator, Iterator, Optional, Protocol, TYPE_
 import pytest
 from ruamel.yaml import YAML
 from sqlalchemy import create_engine
+from testcontainers.core.container import DockerContainer  # type: ignore
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from autosubmit.autosubmit import Autosubmit
@@ -59,7 +60,6 @@ if TYPE_CHECKING:
     from py._path.local import LocalPath  # type: ignore
     from pytest_mock import MockerFixture
     from pytest import FixtureRequest
-    from testcontainers.core.container import DockerContainer  # type: ignore
 
 _PG_USER = 'postgres'
 _PG_PASSWORD = 'postgres'
@@ -88,6 +88,7 @@ class AutosubmitExperimentFixture(Protocol):
             experiment_data: Optional[dict] = None,
             wrapper: Optional[bool] = False,
             create: Optional[bool] = True,
+            include_jobs: Optional[bool] = False,
             reload: Optional[bool] = True,
             mock_last_name_used: Optional[bool] = True,
             *args: Any,
@@ -155,6 +156,8 @@ def autosubmit_exp(
             wrapper: Optional[bool] = False,
             create: Optional[bool] = True,
             include_jobs: Optional[bool] = False,
+            reload: Optional[bool] = True,
+            mock_last_name_used: Optional[bool] = True,
             *_,
             **kwargs
     ) -> AutosubmitExperiment:
@@ -253,15 +256,15 @@ def autosubmit_exp(
             config.experiment_data['JOBS'] = {}
 
         # ensure that it is always the first file loaded by Autosubmit
-        with open(conf_dir / 'aaaaaabasic_structure.yml', 'w') as f:
-            YAML().dump(config.experiment_data, f)
+        with open(conf_dir / 'aaaaaabasic_structure.yml', 'w') as fh:
+            YAML().dump(config.experiment_data, fh)
 
         other_yaml = {
             k: v for k, v in experiment_data.items()
         }
         if other_yaml:
-            with open(conf_dir / 'additional_data.yml', 'w') as f:
-                YAML().dump(other_yaml, f)
+            with open(conf_dir / 'additional_data.yml', 'w') as fh:
+                YAML().dump(other_yaml, fh)
 
         config.reload(force_load=True)
 
@@ -380,17 +383,17 @@ def ssh_x11_mfa_server(request, tmp_path: 'LocalPath', mocker: 'MockerFixture') 
 
 @pytest.fixture(scope="function")
 def slurm_server(request, tmp_path, mocker) -> Generator['Container', Any, None]:
-    """Session fixture that creates a singleton Slurm server container."""
-    container, ssh_port = get_slurm_container()
+    """Function-scoped fixture that creates a Slurm server container per test."""
     # TODO: Needed? If so, explain why.
     mocker.patch(
         'autosubmit.platforms.platform.Platform.get_mp_context',
         return_value=multiprocessing.get_context('fork')
     )
+    container, ssh_port = get_slurm_container()
     with container:
         prepare_and_test_slurm_container(container, ssh_port, Path(tmp_path, 'ssh/'), mocker)
         yield container.get_wrapped_container()
-        copy_content_from_containers(request, 'slurm_server', 'tmp/scratch/group/root/')
+        copy_content_from_containers(request, 'slurm_server', '/tmp/scratch/group/root/')
 
 
 @pytest.fixture
@@ -530,10 +533,16 @@ def setup_as_logs_pytest(tmp_path: 'LocalPath') -> None:
 
 
 def copy_content_from_containers(request, log_name, path_to_docker=""):
-    """Copy data from the experiment from within the container to export"""
+    """Copy data from the experiment from within the container to export.
+
+    Only executed on GitHub Actions.
+    """
+    if 'GITHUB_ACTIONS' not in os.environ:
+        return
     has_failures = request.session.testsfailed
     func_args = request.node.funcargs
     if has_failures and log_name in func_args and func_args[log_name]:
+        container_in_use: 'Container'
         if log_name == 'git_server':
             container_in_use: 'Container' = func_args[log_name][0].get_wrapped_container()
         else:
@@ -541,13 +550,13 @@ def copy_content_from_containers(request, log_name, path_to_docker=""):
 
         if "No such file" not in str(container_in_use.exec_run(f"ls {path_to_docker}").output):
             stream = (container_in_use.get_archive(path_to_docker))[0]
-            fileobj = io.BytesIO()
+            file_object = io.BytesIO()
 
             for chunk in stream:
-                fileobj.write(chunk)
-            fileobj.seek(0)
+                file_object.write(chunk)
+            file_object.seek(0)
 
             target_path = Path(f"../container_logs_{log_name}/")
             target_path.mkdir(parents=True, exist_ok=True)
             with open(target_path/f"{request.node.name}.tar.gz",'w') as f:
-                f.buffer.write(fileobj.read())
+                f.buffer.write(file_object.read())

--- a/test/integration/test_paramiko_platform.py
+++ b/test/integration/test_paramiko_platform.py
@@ -1,4 +1,6 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
+# This file is part of Autosubmit.
 #
 # Autosubmit is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,7 +40,6 @@ from autosubmit.platforms.slurmplatform import SlurmPlatform
 
 if TYPE_CHECKING:
     from autosubmit.platforms.psplatform import PsPlatform
-    from autosubmit.platforms.slurmplatform import SlurmPlatform
     from docker.models.containers import Container
     # noinspection PyProtectedMember
     from _pytest._py.path import LocalPath
@@ -131,7 +132,12 @@ class CreateJobParametersPlatformFixture(Protocol):
 @pytest.fixture
 def create_job_parameters_platform(
         autosubmit_exp, get_next_expid: Callable[[], str]) -> CreateJobParametersPlatformFixture:
-    def job_parameters_platform(experiment_data: Optional[dict]) -> JobParametersPlatform:
+    def job_parameters_platform(
+            experiment_data: Optional[dict] = None,
+            /,
+            *args: Any,
+            **kwargs: Any
+    ) -> JobParametersPlatform:
         exp = autosubmit_exp(get_next_expid(), experiment_data=experiment_data, include_jobs=True)
         slurm_platform: 'SlurmPlatform' = cast('SlurmPlatform', exp.platform)
 
@@ -443,6 +449,7 @@ def test_exec_command_invalid_command(
             # The stdout contents should be [b"user_name\n"]; thus the ugly list comprehension + extra code.
             assert expected == str(''.join([x.decode('UTF-8').strip() for x in stdout.readlines()]))
         else:
+            assert isinstance(stderr, ChannelFile)
             err_output = str(''.join([x.decode('UTF-8').strip() for x in stderr.readlines()]))
             # cmd not found error
             assert command in err_output
@@ -511,7 +518,7 @@ def test_exec_command_ssh_session_not_active(
         #       But while that's OK, we can also avoid mocking by simply
         #       closing the connection.
 
-        assert exp_ps_platform.transport
+        assert exp_ps_platform.transport is not None
         exp_ps_platform.transport.close()
 
         stdin, stdout, stderr = exp_ps_platform.exec_command(
@@ -524,6 +531,7 @@ def test_exec_command_ssh_session_not_active(
         assert isinstance(stdout, ChannelFile)
         assert stdin is not False
         assert stderr is not False
+        assert isinstance(stdout, ChannelFile)
         # The stdout contents should be [b"user_name\n"]; thus the ugly list comprehension + extra code.
         assert user == str(''.join([x.decode('UTF-8').strip() for x in stdout.readlines()]))
     finally:

--- a/test/integration/test_utils/docker.py
+++ b/test/integration/test_utils/docker.py
@@ -16,11 +16,11 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utilities for Docker."""
+import multiprocessing
 from getpass import getuser
 from os import environ
 from pathlib import Path
 from pwd import getpwnam
-from textwrap import dedent
 from time import sleep, time
 from typing import TYPE_CHECKING
 
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     'get_container_by_id',
+    'get_containers_by_filter',
     'get_git_container',
     'prepare_and_test_git_container',
     'get_slurm_container',
@@ -54,7 +55,7 @@ _SSH_DOCKER_IMAGE_X11_MFA = 'autosubmit/linuxserverio-ssh-2fa-x11:latest'
 _SSH_DOCKER_PASSWORD = 'password'
 """Common password used in SSH containers; we mock the SSH Client of Paramiko to avoid hassle with keys."""
 
-_SLURM_DOCKER_IMAGE = 'autosubmit/slurm-openssh-container:25-05-0-1'
+_SLURM_DOCKER_IMAGE = 'giovtorres/slurm-docker:25.11.2-v0.1.7'
 """The Slurm Docker image. About 600 MB. It contains 2 cores, 1 node."""
 
 _GIT_DOCKER_IMAGE = 'githttpd/githttpd:latest'
@@ -82,6 +83,25 @@ def get_container_by_id(container_id: str) -> 'Container':
     """
     client = from_env()
     return client.containers.get(container_id)
+
+
+def get_containers_by_filter(filters: dict) -> list['Container']:
+    """Gets Docker containers by a filter.
+
+    The filter is passed down to ``.list(filters=*)``. Useful for
+    GitHub Actions, for instance, where the ``ancestor`` attribute
+    contains the image used.
+
+    E.g.,
+
+        {"ancestor": "giovtorres/slurm-docker:25.11.2-v0.1.5"}
+
+    :param: filters: dictionary with the filters to apply.
+    :return: The docker containers that match the filter.
+    """
+    client = from_env()
+    return client.containers.list(filters=filters)
+
 
 
 def _create_git_container(git_repos_path: Path, http_port: int) -> DockerContainer:
@@ -131,50 +151,58 @@ def get_git_container(git_repos_path: Path) -> tuple['DockerContainer', int]:
 def prepare_and_test_slurm_container(
         container: 'DockerContainer', ssh_port: int, ssh_path: Path, mocker: 'MockerFixture') -> None:
     # TODO: or maybe wait for 'debug:  sched: Running job scheduler for full queue.'?
-    wait_for_logs(container, lambda logs: 'No fed_mgr state file' in logs)
+    wait_for_logs(container, lambda logs: 'All services started' in logs)
 
     container.exec('sinfo')
+    container.exec('mkdir -p /tmp/scratch/group/root')
 
-    sshd_config_text = dedent('''\
-        Include /etc/ssh/sshd_config.d/*.conf
+    user = getuser()
+    container.exec(['bash', '-c', f'useradd -m {user} 2>/dev/null || true'])
+    container.exec(['bash', '-c', f'echo "{user}:{_SSH_DOCKER_PASSWORD}" | chpasswd'])
+    container.exec(['bash', '-c', f'mkdir -p /tmp/scratch/group/{user} && chmod -R 777 /tmp/scratch'])
+    container.exec(['bash', '-c',
+                    f'mkdir -p /home/{user}/.ssh && chmod 700 /home/{user}/.ssh && chown -R {user} /home/{user}/.ssh'])
 
-        PasswordAuthentication yes
-        KbdInteractiveAuthentication no
-        UsePAM yes
-        X11Forwarding yes
-        PrintMotd no
-        AcceptEnv LANG LC_* COLORTERM NO_COLOR
-        Subsystem	sftp	/usr/lib/openssh/sftp-server
-        Port 2222
-        PermitRootLogin yes
-        # MaxStartups 10:0:10
-        LoginGraceTime 120
-        UseDNS no
-        ''')
-    sshd_config = Path(ssh_path, 'slurm_sshd_config')
-    sshd_config.parent.mkdir(parents=True, exist_ok=True)
-    sshd_config.touch()
-    sshd_config.write_text(sshd_config_text)
-    container.exec([
-        "sh", "-c",
-        "cat <<'EOF' > /etc/ssh/sshd_config\n"
-        f"{sshd_config_text}\n"
-        "EOF"
-    ])
+    # sshd_config_text = dedent('''\
+    #     Include /etc/ssh/sshd_config.d/*.conf
+    #
+    #     PasswordAuthentication yes
+    #     KbdInteractiveAuthentication no
+    #     UsePAM yes
+    #     X11Forwarding yes
+    #     PrintMotd no
+    #     AcceptEnv LANG LC_* COLORTERM NO_COLOR
+    #     Subsystem	sftp	/usr/lib/openssh/sftp-server
+    #     Port 2222
+    #     PermitRootLogin yes
+    #     # MaxStartups 10:0:10
+    #     LoginGraceTime 120
+    #     UseDNS no
+    #     ''')
+    # sshd_config = Path(ssh_path, 'slurm_sshd_config')
+    # sshd_config.parent.mkdir(parents=True, exist_ok=True)
+    # sshd_config.touch()
+    # sshd_config.write_text(sshd_config_text)
+    # container.exec([
+    #     "sh", "-c",
+    #     "cat <<'EOF' > /etc/ssh/sshd_config\n"
+    #     f"{sshd_config_text}\n"
+    #     "EOF"
+    # ])
 
     priv, pubkey, ssh_config = create_ssh_keypair_and_config(ssh_port, ssh_path, 'config_slurm')
 
-    ssh_authorized_keys = Path('/root/.ssh/authorized_keys')
-    # noinspection PyProtectedMember
-    exec_result = _write_authorized_keys(container._container, pubkey, ssh_authorized_keys)
-    exit_code = exec_result.exit_code
-
-    if exit_code != 0:
+    for authorized_keys_path in [Path('/root/.ssh/authorized_keys'), Path(f'/home/{user}/.ssh/authorized_keys')]:
         # noinspection PyProtectedMember
-        raise RuntimeError(f'Failed to write authorized_keys to test container {container._container.id}')
+        exec_result = _write_authorized_keys(container._container, pubkey, authorized_keys_path)
+        exit_code = exec_result.exit_code
 
-    container.exec('pkill sshd')
-    container.exec('/usr/sbin/sshd')
+        if exit_code != 0:
+            # noinspection PyProtectedMember
+            raise RuntimeError(f'Failed to write authorized_keys to test container {container._container.id}')
+
+    # container.exec('pkill sshd')
+    # container.exec('/usr/sbin/sshd')
 
     wait_for_ssh_port('localhost', ssh_port, timeout=30)
 
@@ -204,6 +232,7 @@ def _create_slurm_container(ssh_port: int) -> DockerContainer:
     docker_args = {
         'cgroupns': 'host',
         'privileged': True,
+        'init': True,
         'labels': {
             _AS_SLURM_CONTAINER_LABEL: 'true',
         }
@@ -212,7 +241,7 @@ def _create_slurm_container(ssh_port: int) -> DockerContainer:
     docker_container = DockerContainer(
         image=_SLURM_DOCKER_IMAGE,
         remove=True,
-        hostname='slurmctld',
+        hostname='slurmctl',
         **docker_args
     )
 
@@ -222,6 +251,12 @@ def _create_slurm_container(ssh_port: int) -> DockerContainer:
 
     container = docker_container \
         .with_env('TZ', 'Etc/UTC') \
+        .with_env('MYSQL_USER', 'autosubmit') \
+        .with_env('MYSQL_PASSWORD', 'autosubmit') \
+        .with_env('ROOT_PASSWORD', 'autosubmit') \
+        .with_env('SSH_PORT', '2222') \
+        .with_env('SSH_PERMIT_ROOT_LOGIN', 'yes') \
+        .with_env('SSH_PASSWORD_AUTH', 'yes') \
         .with_bind_ports(2222, ssh_port)
 
     return container
@@ -253,6 +288,8 @@ def prepare_and_test_ssh_container(
     if exec_result.exit_code != 0:
         raise RuntimeError(f'Failed to run whoami on test container {container.get_wrapped_container().id}')
 
+    container.exec(['bash', '-c', f'mkdir -p /tmp/scratch/group/{getuser()} && chmod -R 777 /tmp/scratch'])
+
     ssh_path.mkdir()
 
     priv, pubkey, ssh_config = create_ssh_keypair_and_config(ssh_port, ssh_path, 'config')
@@ -266,6 +303,8 @@ def prepare_and_test_ssh_container(
     if exit_code != 0:
         raise RuntimeError(f'Failed to write authorized_keys to test container {container.get_wrapped_container().id}')
 
+    mocker.patch('autosubmit.platforms.platform.Platform.get_mp_context',
+                 return_value = multiprocessing.get_context('fork'))
     mock_ssh_config_and_client(ssh_config, ssh_port, _SSH_DOCKER_PASSWORD, mocker)
 
 
@@ -358,7 +397,7 @@ def stop_test_containers(stop_timeout=1, stop_all_timeout=30) -> None:
             # from_env().containers.prune(
             #     filters={"label": f"{label}={_AS_SINGLETON_CONTAINER_VALUE}"}
             # )
-            containers: list['Container'] = from_env().containers.list(
+            containers = from_env().containers.list(
                 filters={
                     "status": "running",
                     "label": f"{label}=true"
@@ -381,7 +420,7 @@ def stop_test_containers(stop_timeout=1, stop_all_timeout=30) -> None:
             # from_env().containers.prune(
             #     filters={"label": f"{label}={_AS_SINGLETON_CONTAINER_VALUE}"}
             # )
-            containers: list['Container'] = from_env().containers.list(
+            containers = from_env().containers.list(
                 filters={
                     "status": "running",
                     "label": f"{label}=true"

--- a/test/integration/test_utils/misc.py
+++ b/test/integration/test_utils/misc.py
@@ -65,6 +65,9 @@ def wait_locker(file_lock: Path, expect_locked: bool, timeout: int, interval=0.0
             raise TimeoutError(f"File lock {'not ' if expect_locked else ''}acquired at {file_lock} "
                                f"({timeout}s timeout, {elapsed:.2f}s elapsed)")
 
+        if not file_lock.exists():
+            continue
+
         if expect_locked:
             # Check if the file is locked by attempting to acquire it non-blocking
             try:

--- a/test/integration/test_utils/ssh.py
+++ b/test/integration/test_utils/ssh.py
@@ -87,10 +87,10 @@ def make_ssh_client(ssh_port: int, password: Optional[str], key: Optional[Union[
             kwargs['password'] = password
             kwargs['look_for_keys'] = False
             kwargs['allow_agent'] = False
+        args_list = list(args)
         if len(args) > 1:
             # tuple to list, and then replace the port...
-            args = [x for x in args]
-            args[1] = ssh_port
+            args_list[1] = ssh_port
 
         if key is not None:
             kwargs['key_filename'] = str(key)
@@ -99,7 +99,7 @@ def make_ssh_client(ssh_port: int, password: Optional[str], key: Optional[Union[
         for timeout in ['banner_timeout', 'auth_timeout', 'channel_timeout']:
             kwargs[timeout] = ssh_timeout
 
-        return orig_ssh_client_connect(*args, **kwargs)
+        return orig_ssh_client_connect(*args_list, **kwargs)
 
     ssh_client.connect = _ssh_connect
     return ssh_client
@@ -127,6 +127,7 @@ def _generate_ssh_keypair(path: Path):
                                              format=serialization.PrivateFormat.OpenSSH,
                                              encryption_algorithm=serialization.NoEncryption())
     # print(private_key.decode())
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.touch()
     path.write_text(private_key.decode('utf-8'))
     path.chmod(0o600)

--- a/test/unit/platforms/test_cancel_jobs.py
+++ b/test/unit/platforms/test_cancel_jobs.py
@@ -44,8 +44,8 @@ def test_cancel_jobs_empty_list_sends_no_command(
 @pytest.mark.parametrize("platform_fixture,job_id,expected_command", [
     ("slurm_platform", "42", "scancel 42"),
     ("ec_platform", "9001", "ecaccess-job-delete 9001"),
-    ("local_platform", "1234", "kill -SIGINT 1234"),
-    ("ps_platform", "5678", "kill -SIGINT 5678"),
+    ("local_platform", "1234", "kill -2 1234"),
+    ("ps_platform", "5678", "kill -2 5678"),
 ])
 def test_cancel_jobs_single_id(
         platform_fixture: str,
@@ -67,10 +67,10 @@ def test_cancel_jobs_single_id(
 @pytest.mark.parametrize("platform_fixture,job_ids,expected_command", [
     ("slurm_platform", ["1", "2", "3"], "scancel 1,2,3"),
     ("slurm_platform", ["100", "200"], "scancel 100,200"),
-    ("local_platform", ["100", "200", "300"], "kill -SIGINT 100 200 300"),
-    ("local_platform", ["10", "20"], "kill -SIGINT 10 20"),
-    ("ps_platform", ["10", "20", "30"], "kill -SIGINT 10 20 30"),
-    ("ps_platform", ["11", "22"], "kill -SIGINT 11 22"),
+    ("local_platform", ["100", "200", "300"], "kill -2 100 200 300"),
+    ("local_platform", ["10", "20"], "kill -2 10 20"),
+    ("ps_platform", ["10", "20", "30"], "kill -2 10 20 30"),
+    ("ps_platform", ["11", "22"], "kill -2 11 22"),
 ])
 def test_cancel_jobs_multiple_ids(
         platform_fixture: str,


### PR DESCRIPTION
This PR replaces our custom Slurm image made by @manuel-g-castro by the one used by him, I believe, initially as reference: https://hub.docker.com/r/giovtorres/slurm-docker/

Huge thanks to @giovtorres who opened [a discussion asking for feature requests](https://github.com/giovtorres/slurm-docker-cluster/discussions/88#discussioncomment-16044448) and promptly answered my question about having a self-contained Slurm for CICD.

I got one test from `test_slurm` passing locally after some trial and error, so I think this might be ready to be tested on GH Actions.

We had some intermittent failures on Slurm, and I also had some during winter break while trying to use a single container. In most errors, I saw a banner timeout that I believe might be related to throttling on the SSH server. @giovtorres included the SSH settings to disable throttling (thanks again!) so once this works, we can monitor the tests and check if that banner timeout error is gone, or if that persists (in which case, we now will know that it must be something else).

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
