### PR TITLE
Priority and retro-compatibility with autosubmitrc 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 - Reduce the frequency with which energy data was not being stored for the last job of the batch #2657 #2418
 - Fixed issue with experiments running on LOCAL platform without a defined LOCAL entry in platforms.yml config file #1131
 - Fixed an issue with the ECMWF platform not working with the new online recovery
-- Changed logic in Slurm submission to look for submitted messaged (hotfix) #2886" 
+- Changed logic in Slurm submission to look for submitted messaged (hotfix) #2886
 - Calendar splits: last split boundaries #2866, last split not exported #2099 and splitsize not working at experiment level #2016.
 - Accept local/intranet email addresses in validation #1471
 - Set PROJECT_TYPE, PROJECT_DESTINATION and CUSTOM_CONFIG for experiments without minimal configuration #2864
+- Added priority and retro-compatibility for etc/autosubmitrc over etc/.autosubmitrc #2312
 
 **Enhancements:**
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -3454,7 +3454,6 @@ class Autosubmit:
         filename = '.autosubmitrc'
         if level == 'All':
             base_path = Path('/etc')
-            write_path = base_path / 'autosubmitrc'
             # Retro-compatibility: load legacy first, then current with higher priority
             read_options = [
                 base_path / ".autosubmitrc",
@@ -3480,7 +3479,13 @@ class Autosubmit:
         try:
             parser = ConfigParser()
             parser.optionxform = str
-            parser.read([str(p) for p in read_options])
+            for option in read_options:
+                if option.exists():
+                    if option == base_path / ".autosubmitrc":
+                        Log.warning(
+                            "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
+                        )
+                    parser.read(str(option))
             if parser.sections():
                 if parser.has_option('database', 'path'):
                     database_path = parser.get('database', 'path')

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -3453,13 +3453,21 @@ class Autosubmit:
 
         filename = '.autosubmitrc'
         if level == 'All':
-            path = '/etc'
-            filename = 'autosubmitrc'
+            base_path = Path('/etc')
+            write_path = base_path / 'autosubmitrc'
+            # Retro-compatibility: load legacy first, then current with higher priority
+            read_options = [
+                base_path / ".autosubmitrc",
+                base_path / "autosubmitrc"
+            ]
         elif level == 'User':
-            path = home_path
+            base_path = Path(home_path)
+            write_path = base_path / filename
+            read_options = [write_path]
         else:
-            path = '.'
-        path = os.path.join(path, filename)
+            base_path = Path('.')
+            write_path = base_path / filename
+            read_options = [write_path]
 
         # Setting default values
         database_path = home_path
@@ -3470,10 +3478,10 @@ class Autosubmit:
 
         d.infobox("Reading configuration file...", width=50, height=5)
         try:
-            if os.path.isfile(path):
-                parser = ConfigParser()
-                parser.optionxform = str
-                parser.load(path)
+            parser = ConfigParser()
+            parser.optionxform = str
+            parser.read([str(p) for p in read_options])
+            if parser.sections():
                 if parser.has_option('database', 'path'):
                     database_path = parser.get('database', 'path')
                 if parser.has_option('database', 'filename'):
@@ -3587,7 +3595,6 @@ class Autosubmit:
                 break
                 # TODO: Check that is a valid config?
 
-        config_file = open(path, 'w')
         d.infobox("Writing configuration file...", width=50, height=5)
         try:
             parser = ConfigParser()
@@ -3606,8 +3613,8 @@ class Autosubmit:
             parser.add_section('mail')
             parser.set('mail', 'smtp_server', smtp_hostname)
             parser.set('mail', 'mail_from', mail_from)
-            parser.write(config_file)
-            config_file.close()
+            with open(write_path, 'w') as config_file:
+                parser.write(config_file)
             d.msgbox("Configuration file written successfully",
                      width=50, height=5)
             os.system('clear')

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -85,8 +85,6 @@ from autosubmit.utils import as_conf_default_values
 if TYPE_CHECKING:
     from rocrate.rocrate import ROCrate
 
-dialog = None
-
 """Main module for autosubmit. Only contains an interface class to all functionality implemented on autosubmit."""
 
 sys.path.insert(0, os.path.abspath('.'))
@@ -801,23 +799,20 @@ class Autosubmit:
             return Autosubmit.create(args.expid, args.noplot, args.hide, args.output, args.group_by, args.expand,
                                      args.expand_status, args.check_wrapper, args.detail, args.profile, args.force)
         elif args.command == 'configure':
-            if not args.advanced or (args.advanced and dialog is None):
-                return Autosubmit.configure(
-                    args.advanced,
-                    args.databasepath,
-                    args.databasefilename,
-                    args.localrootpath,
-                    args.platformsconfpath,
-                    args.jobsconfpath,
-                    args.smtphostname,
-                    args.mailfrom,
-                    args.all,
-                    args.local,
-                    args.database_backend,
-                    args.database_conn_url,
-                )
-            else:
-                return Autosubmit.configure_dialog()
+            return Autosubmit.configure(
+                args.advanced,
+                args.databasepath,
+                args.databasefilename,
+                args.localrootpath,
+                args.platformsconfpath,
+                args.jobsconfpath,
+                args.smtphostname,
+                args.mailfrom,
+                args.all,
+                args.local,
+                args.database_backend,
+                args.database_conn_url,
+            )
         elif args.command == 'install':
             return Autosubmit.install()
         elif args.command == 'setstatus':
@@ -3410,229 +3405,6 @@ class Autosubmit:
         except BaseException as e:
             raise AutosubmitCritical(str(e), 7014)
         return True
-
-    @staticmethod
-    def configure_dialog():
-        """Configure several paths for autosubmit interactively: database, local root and others.
-        Can be configured at system, user or local levels. Local level configuration precedes user level and user level
-        precedes system configuration. """
-        home_path = Path("~").expanduser().resolve()
-
-        try:
-            d = dialog.Dialog(
-                dialog="dialog", autowidgetsize=True, screen_color='GREEN')
-        except dialog.DialogError:
-            raise AutosubmitCritical(
-                "Graphical visualization failed, not enough screen size", 7060)
-        except Exception:
-            raise AutosubmitCritical(
-                "Dialog libs aren't found in your Operational system", 7060)
-
-        d.set_background_title("Autosubmit configure utility")
-        if os.geteuid() == 0:
-            text = ''
-            choice = [
-                ("All", "All users on this machine (may require root privileges)")]
-        else:
-            text = "If you want to configure Autosubmit for all users, you will need to provide root privileges"
-            choice = []
-
-        choice.append(("User", "Current user"))
-        choice.append(
-            ("Local", "Only when launching Autosubmit from this path"))
-
-        try:
-            code, level = d.menu(text, choices=choice, width=60,
-                                 title="Choose when to apply the configuration")
-            if code != dialog.Dialog.OK:
-                os.system('clear')
-                return False
-        except dialog.DialogError:
-            raise AutosubmitCritical(
-                "Graphical visualization failed, not enough screen size", 7060)
-
-        filename = ".autosubmitrc"
-        if level == "All":
-            base_path = Path("/etc")
-            write_path = base_path / "autosubmitrc"
-            # log warning always if legacy exists
-            if (base_path / ".autosubmitrc").exists():
-                Log.warning(
-                    "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc")
-            # Retro-compatibility: load legacy first, then current with higher priority
-            read_options = [base_path / ".autosubmitrc", base_path / "autosubmitrc"]
-        elif level == "User":
-            base_path = Path(home_path)
-            write_path = base_path / filename
-            read_options = [write_path]
-        else:
-            base_path = Path(".")
-            write_path = base_path / filename
-            read_options = [write_path]
-
-        # Setting default values
-        database_path = home_path
-        local_root_path = home_path
-        database_filename = 'autosubmit.db'
-        jobs_conf_path = ''
-        platforms_conf_path = ''
-
-        d.infobox("Reading configuration file...", width=50, height=5)
-        try:
-            parser = ConfigParser()
-            parser.optionxform = str
-            parser.read([str(p) for p in read_options])
-            if parser.sections():
-                if parser.has_option('database', 'path'):
-                    database_path = parser.get('database', 'path')
-                if parser.has_option('database', 'filename'):
-                    database_filename = parser.get('database', 'filename')
-                if parser.has_option('local', 'path'):
-                    local_root_path = parser.get('local', 'path')
-                if parser.has_option('conf', 'platforms'):
-                    platforms_conf_path = parser.get('conf', 'platforms')
-                if parser.has_option('conf', 'jobs'):
-                    jobs_conf_path = parser.get('conf', 'jobs')
-
-        except (IOError, OSError) as e:
-            raise AutosubmitCritical(
-                "Can not read config file", 7014, e.message)
-
-        while True:
-            try:
-                code, database_path = d.dselect(database_path, width=80, height=20,
-                                                title='\\Zb\\Z1Select path to database\\Zn', colors='enable')
-            except dialog.DialogError:
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, not enough screen size", 7060)
-            if Autosubmit._requested_exit(code, d):
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, requested exit", 7060)
-            elif code == dialog.Dialog.OK:
-                database_path = database_path.replace('~', home_path)
-                if not os.path.exists(database_path):
-                    d.msgbox(
-                        "Database path does not exist.\nPlease, insert the right path", width=50, height=6)
-                else:
-                    break
-
-        while True:
-            try:
-                code, local_root_path = d.dselect(local_root_path, width=80, height=20,
-                                                  title='\\Zb\\Z1Select path to experiments repository\\Zn',
-                                                  colors='enable')
-            except dialog.DialogError:
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, not enough screen size", 7060)
-
-            if Autosubmit._requested_exit(code, d):
-                raise AutosubmitCritical(
-                    "Graphical visualization failed,requested exit", 7060)
-            elif code == dialog.Dialog.OK:
-                database_path = database_path.replace('~', home_path)
-                if not os.path.exists(database_path):
-                    d.msgbox(
-                        "Local root path does not exist.\nPlease, insert the right path", width=50, height=6)
-                else:
-                    break
-        while True:
-            try:
-                (code, tag) = d.form(text="",
-                                     elements=[("Database filename", 1, 1, database_filename, 1, 40, 20, 20),
-                                               (
-                                                   "Default platform.yml path", 2, 1, platforms_conf_path, 2, 40, 40,
-                                                   200),
-                                               ("Default jobs.yml path", 3, 1, jobs_conf_path, 3, 40, 40, 200)],
-                                     height=20,
-                                     width=80,
-                                     form_height=10,
-                                     title='\\Zb\\Z1Just a few more options:\\Zn', colors='enable')
-            except dialog.DialogError:
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, not enough screen size", 7060)
-
-            if Autosubmit._requested_exit(code, d):
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, _requested_exit", 7060)
-            elif code == dialog.Dialog.OK:
-                database_filename = tag[0]
-                platforms_conf_path = tag[1]
-                jobs_conf_path = tag[2]
-
-                platforms_conf_path = platforms_conf_path.replace(
-                    '~', home_path).strip()
-                jobs_conf_path = jobs_conf_path.replace('~', home_path).strip()
-
-                if platforms_conf_path and not os.path.exists(platforms_conf_path):
-                    d.msgbox(
-                        "Platforms conf path does not exist.\nPlease, insert the right path", width=50, height=6)
-                elif jobs_conf_path and not os.path.exists(jobs_conf_path):
-                    d.msgbox(
-                        "Jobs conf path does not exist.\nPlease, insert the right path", width=50, height=6)
-                else:
-                    break
-
-        smtp_hostname = "mail.bsc.es"
-        mail_from = "automail@bsc.es"
-        while True:
-            try:
-                (code, tag) = d.form(text="",
-                                     elements=[("SMTP server hostname", 1, 1, smtp_hostname, 1, 40, 20, 20),
-                                               ("Notifications sender address", 2, 1, mail_from, 2, 40, 40, 200)],
-                                     height=20,
-                                     width=80,
-                                     form_height=10,
-                                     title='\\Zb\\Z1Mail notifications configuration:\\Zn', colors='enable')
-            except dialog.DialogError:
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, not enough screen size", 7060)
-
-            if Autosubmit._requested_exit(code, d):
-                raise AutosubmitCritical(
-                    "Graphical visualization failed, requested exit", 7060)
-            elif code == dialog.Dialog.OK:
-                smtp_hostname = tag[0]
-                mail_from = tag[1]
-                break
-                # TODO: Check that is a valid config?
-
-        d.infobox("Writing configuration file...", width=50, height=5)
-        try:
-            parser = ConfigParser()
-            parser.add_section('database')
-            parser.set('database', 'path', database_path)
-            if database_filename:
-                parser.set('database', 'filename', database_filename)
-            parser.add_section('local')
-            parser.set('local', 'path', local_root_path)
-            if jobs_conf_path or platforms_conf_path:
-                parser.add_section('conf')
-                if jobs_conf_path:
-                    parser.set('conf', 'jobs', jobs_conf_path)
-                if platforms_conf_path:
-                    parser.set('conf', 'platforms', platforms_conf_path)
-            parser.add_section('mail')
-            parser.set('mail', 'smtp_server', smtp_hostname)
-            parser.set('mail', 'mail_from', mail_from)
-            with open(write_path, 'w') as config_file:
-                parser.write(config_file)
-            d.msgbox("Configuration file written successfully",
-                     width=50, height=5)
-            os.system('clear')
-        except (IOError, OSError) as e:
-            raise AutosubmitCritical(
-                "Can not write config file", 7012, e.message)
-        return True
-
-    @staticmethod
-    def _requested_exit(code, d):
-        if code != dialog.Dialog.OK:
-            code = d.yesno(
-                'Exit configure utility without saving?', width=50, height=5)
-            if code == dialog.Dialog.OK:
-                os.system('clear')
-                return True
-        return False
 
     @staticmethod
     def install():

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -3451,20 +3451,18 @@ class Autosubmit:
             raise AutosubmitCritical(
                 "Graphical visualization failed, not enough screen size", 7060)
 
-        filename = '.autosubmitrc'
-        if level == 'All':
-            base_path = Path('/etc')
+        filename = ".autosubmitrc"
+        if level == "All":
+            base_path = Path("/etc")
+            write_path = base_path / "autosubmitrc"
             # Retro-compatibility: load legacy first, then current with higher priority
-            read_options = [
-                base_path / ".autosubmitrc",
-                base_path / "autosubmitrc"
-            ]
-        elif level == 'User':
+            read_options = [base_path / ".autosubmitrc", base_path / "autosubmitrc"]
+        elif level == "User":
             base_path = Path(home_path)
             write_path = base_path / filename
             read_options = [write_path]
         else:
-            base_path = Path('.')
+            base_path = Path(".")
             write_path = base_path / filename
             read_options = [write_path]
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -480,10 +480,11 @@ class Autosubmit:
             subparser.add_argument(
                 '-f', '--force', action='store_true', default=False, help='force regenerate job_list')
             # Configure
-            subparser = subparsers.add_parser('configure', description="configure database and path for autosubmit. It "
-                                                                       "can be done at machine, user or local level."
-                                                                       "If no arguments specified configure will "
-                                                                       "display dialog boxes (if installed)")
+            subparser = subparsers.add_parser(
+                "configure",
+                description="configure database and path for autosubmit. It "
+                "can be done at machine, user or local level.",
+            )
             subparser.add_argument(
                 '--advanced', action="store_true", help="Open advanced configuration of autosubmit")
             subparser.add_argument(

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -3455,6 +3455,10 @@ class Autosubmit:
         if level == "All":
             base_path = Path("/etc")
             write_path = base_path / "autosubmitrc"
+            # log warning always if legacy exists
+            if (base_path / ".autosubmitrc").exists():
+                Log.warning(
+                    "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc")
             # Retro-compatibility: load legacy first, then current with higher priority
             read_options = [base_path / ".autosubmitrc", base_path / "autosubmitrc"]
         elif level == "User":
@@ -3477,13 +3481,7 @@ class Autosubmit:
         try:
             parser = ConfigParser()
             parser.optionxform = str
-            for option in read_options:
-                if option.exists():
-                    if option == base_path / ".autosubmitrc":
-                        Log.warning(
-                            "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
-                        )
-                    parser.read(str(option))
+            parser.read([str(p) for p in read_options])
             if parser.sections():
                 if parser.has_option('database', 'path'):
                     database_path = parser.get('database', 'path')

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -205,16 +205,16 @@ class BasicConfig:
             # Call read_file_config with the value of the environment variable
             BasicConfig.__read_file_config(config_file_path)
         else:
-            if os.path.exists(os.path.join("", filename)):
-                BasicConfig.__read_file_config(os.path.join("", filename))
-            elif os.path.exists(os.path.join("", "." + filename)):
+            if os.path.exists(os.path.join("", "." + filename)):
                 BasicConfig.__read_file_config(os.path.join("", "." + filename))
             elif os.path.exists(os.path.join(os.path.expanduser("~"), "." + filename)):
                 BasicConfig.__read_file_config(
                     os.path.join(os.path.expanduser("~"), "." + filename)
                 )
-            else:
+            elif os.path.exists(os.path.join("/etc", filename)):
                 BasicConfig.__read_file_config(os.path.join("/etc", filename))
+            else:
+                BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))
 
             # Check if the environment variable is defined
 

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -213,14 +213,14 @@ class BasicConfig:
                     os.path.join(os.path.expanduser("~"), "." + filename)
                 )
             else:
-                if os.path.exists(os.path.join("/etc", filename)):
-                    BasicConfig.__read_file_config(os.path.join("/etc", filename))
-                # only for backward compatibility
-                elif os.path.exists(os.path.join("/etc", "." + filename)):
+                if os.path.exists(os.path.join("/etc", "." + filename)):
                     Log.warning(
                         "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
                     )
-                    BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))         
+                    BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))     
+                # Overwrite legacy config
+                if os.path.exists(os.path.join("/etc", filename)):
+                    BasicConfig.__read_file_config(os.path.join("/etc", filename))
 
             # Check if the environment variable is defined
 

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -217,7 +217,9 @@ class BasicConfig:
                     BasicConfig.__read_file_config(os.path.join("/etc", filename))
                 # only for backward compatibility
                 elif os.path.exists(os.path.join("/etc", "." + filename)):
-                    Log.warning('The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc')
+                    Log.warning(
+                        "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
+                    )
                     BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))         
 
             # Check if the environment variable is defined

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -197,19 +197,24 @@ class BasicConfig:
         Reads configuration from .autosubmitrc files, first from /etc., then for user
         directory and last for current path.
         """
-        filename = 'autosubmitrc'
-        if 'AUTOSUBMIT_CONFIGURATION' in os.environ and os.path.exists(os.environ['AUTOSUBMIT_CONFIGURATION']):
-            config_file_path = os.environ['AUTOSUBMIT_CONFIGURATION']
+        filename = "autosubmitrc"
+        if "AUTOSUBMIT_CONFIGURATION" in os.environ and os.path.exists(
+            os.environ["AUTOSUBMIT_CONFIGURATION"]
+        ):
+            config_file_path = os.environ["AUTOSUBMIT_CONFIGURATION"]
             # Call read_file_config with the value of the environment variable
             BasicConfig.__read_file_config(config_file_path)
         else:
-            if os.path.exists(os.path.join('', '.' + filename)):
-                BasicConfig.__read_file_config(os.path.join('', '.' + filename))
-            elif os.path.exists(os.path.join(os.path.expanduser('~'), '.' + filename)):
-                BasicConfig.__read_file_config(os.path.join(
-                    os.path.expanduser('~'), '.' + filename))
+            if os.path.exists(os.path.join("", filename)):
+                BasicConfig.__read_file_config(os.path.join("", filename))
+            elif os.path.exists(os.path.join("", "." + filename)):
+                BasicConfig.__read_file_config(os.path.join("", "." + filename))
+            elif os.path.exists(os.path.join(os.path.expanduser("~"), "." + filename)):
+                BasicConfig.__read_file_config(
+                    os.path.join(os.path.expanduser("~"), "." + filename)
+                )
             else:
-                BasicConfig.__read_file_config(os.path.join('/etc', filename))
+                BasicConfig.__read_file_config(os.path.join("/etc", filename))
 
             # Check if the environment variable is defined
 

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -98,7 +98,7 @@ class BasicConfig:
     @staticmethod
     def __read_file_config(file_path):
         """
-        Reads configuration file. If configuration file dos not exist in given path,
+        Reads configuration file. If configuration file does not exist in given path,
         no error is raised. Configuration options also are not required to exist
 
         :param file_path: configuration file to read
@@ -199,30 +199,34 @@ class BasicConfig:
         directory and last for current path.
         """
         filename = "autosubmitrc"
-        if "AUTOSUBMIT_CONFIGURATION" in os.environ and os.path.exists(
-            os.environ["AUTOSUBMIT_CONFIGURATION"]
+        # Check if the environment variable is defined
+        if (
+            "AUTOSUBMIT_CONFIGURATION" in os.environ
+            and Path(os.environ["AUTOSUBMIT_CONFIGURATION"]).exists()
         ):
             config_file_path = os.environ["AUTOSUBMIT_CONFIGURATION"]
             # Call read_file_config with the value of the environment variable
             BasicConfig.__read_file_config(config_file_path)
         else:
-            if os.path.exists(os.path.join("", "." + filename)):
-                BasicConfig.__read_file_config(os.path.join("", "." + filename))
-            elif os.path.exists(os.path.join(os.path.expanduser("~"), "." + filename)):
-                BasicConfig.__read_file_config(
-                    os.path.join(os.path.expanduser("~"), "." + filename)
-                )
+            user_config_path = str(Path("", "." + filename))
+            home_user_config_path = str(Path("~", "." + filename).expanduser())
+            etc_rc_path = str(Path("/etc", filename))
+            legacy_etc_rc_path = str(Path("/etc", "." + filename))
+
+            if os.path.exists(user_config_path):
+                BasicConfig.__read_file_config(user_config_path)
+            elif os.path.exists(home_user_config_path):
+                print(f"Reading configuration from {home_user_config_path}")
+                BasicConfig.__read_file_config(home_user_config_path)
             else:
-                if os.path.exists(os.path.join("/etc", "." + filename)):
+                if os.path.exists(legacy_etc_rc_path):
                     Log.warning(
                         "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
                     )
-                    BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))     
+                    BasicConfig.__read_file_config(legacy_etc_rc_path)
                 # Overwrite legacy config
-                if os.path.exists(os.path.join("/etc", filename)):
-                    BasicConfig.__read_file_config(os.path.join("/etc", filename))
-
-            # Check if the environment variable is defined
+                if os.path.exists(etc_rc_path):
+                    BasicConfig.__read_file_config(etc_rc_path)
 
         BasicConfig._update_config()
         return

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -20,6 +20,7 @@ import os
 from configparser import ConfigParser
 from pathlib import Path
 from typing import Union
+from autosubmit.log.log import Log
 
 
 class BasicConfig:
@@ -212,11 +213,12 @@ class BasicConfig:
                     os.path.join(os.path.expanduser("~"), "." + filename)
                 )
             else:
-                # First check the legacy filename, then the new one
-                if os.path.exists(os.path.join("/etc", "." + filename)):
-                    BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))
                 if os.path.exists(os.path.join("/etc", filename)):
                     BasicConfig.__read_file_config(os.path.join("/etc", filename))
+                # only for backward compatibility
+                elif os.path.exists(os.path.join("/etc", "." + filename)):
+                    Log.warning('The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc')
+                    BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))         
 
             # Check if the environment variable is defined
 

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -199,6 +199,7 @@ class BasicConfig:
         directory and last for current path.
         """
         filename = "autosubmitrc"
+        dot_filename = f".{filename}"
         # Check if the environment variable is defined
         if (
             "AUTOSUBMIT_CONFIGURATION" in os.environ
@@ -208,24 +209,23 @@ class BasicConfig:
             # Call read_file_config with the value of the environment variable
             BasicConfig.__read_file_config(config_file_path)
         else:
-            user_config_path = str(Path("", "." + filename))
-            home_user_config_path = str(Path("~", "." + filename).expanduser())
-            etc_rc_path = str(Path("/etc", filename))
-            legacy_etc_rc_path = str(Path("/etc", "." + filename))
+            user_config_path = Path(Path.cwd(), dot_filename)
+            home_user_config_path = Path(Path.home(), dot_filename)
+            etc_rc_path = Path("/etc", filename)
+            legacy_etc_rc_path = Path("/etc", dot_filename)
 
-            if os.path.exists(user_config_path):
+            if user_config_path.exists():
                 BasicConfig.__read_file_config(user_config_path)
-            elif os.path.exists(home_user_config_path):
-                print(f"Reading configuration from {home_user_config_path}")
+            elif home_user_config_path.exists():
                 BasicConfig.__read_file_config(home_user_config_path)
             else:
-                if os.path.exists(legacy_etc_rc_path):
+                if legacy_etc_rc_path.exists():
                     Log.warning(
                         "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
                     )
                     BasicConfig.__read_file_config(legacy_etc_rc_path)
                 # Overwrite legacy config
-                if os.path.exists(etc_rc_path):
+                if etc_rc_path.exists():
                     BasicConfig.__read_file_config(etc_rc_path)
 
         BasicConfig._update_config()

--- a/autosubmit/config/basicconfig.py
+++ b/autosubmit/config/basicconfig.py
@@ -211,10 +211,12 @@ class BasicConfig:
                 BasicConfig.__read_file_config(
                     os.path.join(os.path.expanduser("~"), "." + filename)
                 )
-            elif os.path.exists(os.path.join("/etc", filename)):
-                BasicConfig.__read_file_config(os.path.join("/etc", filename))
             else:
-                BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))
+                # First check the legacy filename, then the new one
+                if os.path.exists(os.path.join("/etc", "." + filename)):
+                    BasicConfig.__read_file_config(os.path.join("/etc", "." + filename))
+                if os.path.exists(os.path.join("/etc", filename)):
+                    BasicConfig.__read_file_config(os.path.join("/etc", filename))
 
             # Check if the environment variable is defined
 

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -292,7 +292,7 @@ def get_rc_path(machine: bool, local: bool) -> Path:
     If the environment variable ``AUTOSUBMIT_CONFIGURATION`` is specified in the
     system, this function will return a ``Path`` pointing to that value.
 
-    If ``machine`` is ``True``, it will use the file from ``/etc/.autosubmitrc``
+    If ``machine`` is ``True``, it will use the file from ``/etc/autosubmitrc``
     (pay attention to the dot prefix).
 
     Else, if ``local`` is ``True``, it will use the file from  ``./.autosubmitrc``
@@ -306,7 +306,7 @@ def get_rc_path(machine: bool, local: bool) -> Path:
 
     rc_path: Union[str, Path]
     if machine:
-        rc_path = '/etc'
+        return Path('/etc/autosubmitrc') # Higher priority than /etc/.autosubmitrc
     elif local:
         rc_path = '.'
     else:

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -301,18 +301,18 @@ def get_rc_path(machine: bool, local: bool) -> Path:
     Otherwise, it will load the file from ``~/.autosubmitrc``, for the user
     currently running Autosubmit.
     """
-    if 'AUTOSUBMIT_CONFIGURATION' in os.environ:
-        return Path(os.environ['AUTOSUBMIT_CONFIGURATION'])
+    if "AUTOSUBMIT_CONFIGURATION" in os.environ:
+        return Path(os.environ["AUTOSUBMIT_CONFIGURATION"])
 
     rc_path: Union[str, Path]
     if machine:
-        return Path('/etc/autosubmitrc') # Higher priority than /etc/.autosubmitrc
+        return Path("/etc/autosubmitrc")  # Higher priority than /etc/.autosubmitrc
     elif local:
-        rc_path = '.'
+        rc_path = "."
     else:
         rc_path = Path.home()
 
-    return Path(rc_path) / '.autosubmitrc'
+    return Path(rc_path) / ".autosubmitrc"
 
 
 def user_yes_no_query(question: str) -> bool:

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -292,8 +292,7 @@ def get_rc_path(machine: bool, local: bool) -> Path:
     If the environment variable ``AUTOSUBMIT_CONFIGURATION`` is specified in the
     system, this function will return a ``Path`` pointing to that value.
 
-    If ``machine`` is ``True``, it will use the file from ``/etc/autosubmitrc``
-    (pay attention to the dot prefix).
+    If ``machine`` is ``True``, it will use the file from ``/etc/autosubmitrc``.
 
     Else, if ``local`` is ``True``, it will use the file from  ``./.autosubmitrc``
     (i.e. it will use the current working directory for the process).

--- a/test/unit/helpers/test_utils.py
+++ b/test/unit/helpers/test_utils.py
@@ -65,8 +65,8 @@ def test_strtobool(val, expected):
         (Path('/tmp/hello/scooby/doo/ooo.txt'), True, True, {
             'AUTOSUBMIT_CONFIGURATION': '/tmp/hello/scooby/doo/ooo.txt'
         }),
-        (Path('/etc/.autosubmitrc'), True, True, {}),
-        (Path('/etc/.autosubmitrc'), True, False, {}),
+        (Path('/etc/autosubmitrc'), True, True, {}),
+        (Path('/etc/autosubmitrc'), True, False, {}),
         (Path('./.autosubmitrc'), False, True, {}),
         (Path(Path.home(), '.autosubmitrc'), False, False, {})
     ],

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -51,101 +51,70 @@ def test_read_makes_the_right_method_calls():
 
 
 @pytest.mark.parametrize(
-    "etc_rc, legacy_etc_rc",
+    "user_config, home_user_config, etc_rc, legacy_etc_rc",
     [
-        [os.path.join("/etc", "autosubmitrc"), os.path.join("/etc", ".autosubmitrc")],
-        [os.path.join("/etc", "autosubmitrc"), None],
-        [None, os.path.join("/etc", ".autosubmitrc")],
+        [True, True, True, True],
+        [True, True, True, False],
+        [True, True, False, True],
+        [True, True, False, False],
+        [True, False, True, True],
+        [True, False, True, False],
+        [True, False, False, True],
+        [True, False, False, False],
+        [False, True, True, True],
+        [False, True, True, False],
+        [False, True, False, True],
+        [False, True, False, False],
+        [False, False, True, True],
+        [False, False, True, False],
+        [False, False, False, True],
+        [False, False, False, False]
     ],
 )
-def test_read_loads_etc_files_with_priority(etc_rc, legacy_etc_rc):
-    """
-    Test that the read method loads configuration files with the correct priority.
-    """
-    # mock the os.environ dictionary to empty values to prevent entering the first conditional
+def test_read_loads_etc_files_with_priority(user_config, home_user_config, etc_rc, legacy_etc_rc):
+    """Test read precedence among local, home and /etc rc files."""
     with patch.dict(os.environ, {}, clear=True):
-        # mock os.path.exists
         with patch("autosubmit.config.basicconfig.os.path.exists") as mock_exists:
-            # mock __read_file_config
-            # As it's a private static method, access it with name mangling: _BasicConfig__read_file_config
             with patch(
                 "autosubmit.config.basicconfig.BasicConfig._BasicConfig__read_file_config"
             ) as mock_read:
-                # mock _update_config
                 with patch(
                     "autosubmit.config.basicconfig.BasicConfig._update_config", Mock()
                 ):
                     with patch("autosubmit.config.basicconfig.Log.warning") as mock_log_warning:
                         filename = "autosubmitrc"
-                        # mock os.path.exists to return True for the two /etc files and False for the others
-                        mock_exists.side_effect = lambda x: x in [etc_rc, legacy_etc_rc]
+                        user_config_path = os.path.join("", "." + filename)
+                        home_user_config_path = os.path.join(os.path.expanduser("~"), "." + filename)
+                        etc_rc_path = os.path.join("/etc", filename)
+                        legacy_etc_rc_path = os.path.join("/etc", "." + filename)
+
+                        mock_exists.side_effect = lambda path: (
+                            (user_config and path == os.path.join("", "." + filename)) or
+                            (home_user_config and path == os.path.join(os.path.expanduser("~"), "." + filename)) or
+                            (etc_rc and path == os.path.join("/etc", filename)) or
+                            (legacy_etc_rc and path == os.path.join("/etc", "." + filename))
+                        )
 
                         BasicConfig.read()
 
-                        if etc_rc and legacy_etc_rc:
-                            mock_exists.assert_has_calls(
-                                [
-                                    call(os.path.join("", "." + filename)),
-                                    call(
-                                        os.path.join(
-                                            os.path.expanduser("~"), "." + filename
-                                        )
-                                    ),
-                                    call(legacy_etc_rc),
-                                    call(etc_rc),
-                                ],
-                                any_order=False,
-                            )
-                            # assert and check that the files are checked in the right order
-                            assert mock_read.call_args_list == [call(legacy_etc_rc), call(etc_rc)]
-                            assert mock_read.call_count == 2
-                            mock_log_warning.assert_called_once_with(
-                                "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
-                            )
-
-                        elif legacy_etc_rc and not etc_rc:
-                            mock_exists.assert_has_calls(
-                                [
-                                    call(os.path.join("", "." + filename)),
-                                    call(
-                                        os.path.join(
-                                            os.path.expanduser("~"), "." + filename
-                                        )
-                                    ),
-                                    call(legacy_etc_rc),
-                                    call(os.path.join("/etc", "autosubmitrc")),
-                                ],
-                                any_order=False,
-                            )
-                            # if only legacy_etc_rc exists only legacy_etc_rc should be read
-                            assert mock_read.call_args_list == [call(legacy_etc_rc)]
-                            assert mock_read.call_count == 1
-                            mock_log_warning.assert_called_once_with(
-                                "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
-                            )
-
-                        elif etc_rc and not legacy_etc_rc:
-                            mock_exists.assert_has_calls(
-                                [
-                                    call(os.path.join("", "." + filename)),
-                                    call(
-                                        os.path.join(
-                                            os.path.expanduser("~"), "." + filename
-                                        )
-                                    ),
-                                    call(os.path.join("/etc", "." + filename)),
-                                    call(etc_rc),
-                                ],
-                                any_order=False,
-                            )
-                            # if only etc_rc exists only etc_rc should be read
-                            assert mock_read.call_args_list == [call(etc_rc)]
-                            assert mock_read.call_count == 1
-                            mock_log_warning.assert_not_called()
-
+                        expected_read_calls = []
+                        if user_config:
+                            expected_read_calls = [call(user_config_path)]
+                        elif home_user_config:
+                            expected_read_calls = [call(home_user_config_path)]
                         else:
-                            # if none of the files exist no file should be read
-                            assert mock_read.call_count == 0
+                            if legacy_etc_rc:
+                                expected_read_calls.append(call(legacy_etc_rc_path))
+                            if etc_rc:
+                                expected_read_calls.append(call(etc_rc_path))
+
+                        assert mock_read.call_args_list == expected_read_calls
+
+                        if (not user_config) and (not home_user_config) and legacy_etc_rc:
+                            mock_log_warning.assert_called_once_with(
+                                "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
+                            )
+                        else:
                             mock_log_warning.assert_not_called()
 
 

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -121,7 +121,7 @@ def test_read_loads_etc_files_with_priority(user_config, home_user_config, etc_r
 def test_read_overwrites_config_with_etc_files(tmp_path):
     """
     Precedence: if two autosubmitrc files exist,
-    the /etc/ version should take precedence over the /etc/.autosubmitrc version
+    the /etc/autosubmitrc version should take precedence over the /etc/.autosubmitrc version
     """
     filename = "autosubmitrc"
     legacy_etc_rc = tmp_path / ("." + filename)

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -16,8 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from mock import Mock
-from mock import patch
+from mock import Mock, patch, call
 
 from autosubmit.config.basicconfig import BasicConfig
 
@@ -47,3 +46,43 @@ def test_read_makes_the_right_method_calls():
         # assert
         BasicConfig._update_config.assert_called_once_with()  # type: ignore
 
+
+def test_read_loads_etc_files_with_priority():
+    # mock the os.environ dictionary to empty values to prevent entering the first conditional
+    with patch.dict(os.environ, {}, clear=True):
+        # mock os.path.exists
+        with patch("autosubmit.config.basicconfig.os.path.exists") as mock_exists:
+            # mock __read_file_config
+            # As it's a private static method, access it with name mangling: _BasicConfig__read_file_config
+            with patch(
+                "autosubmit.config.basicconfig.BasicConfig._BasicConfig__read_file_config"
+            ) as mock_read:
+                # mock _update_config
+                with patch(
+                    "autosubmit.config.basicconfig.BasicConfig._update_config", Mock()
+                ):
+                    filename = "autosubmitrc"
+                    local_rc = os.path.join("", "." + filename)
+                    home_rc = os.path.join(os.path.expanduser("~"), "." + filename)
+                    legacy_etc_rc = os.path.join("/etc", "." + filename)
+                    etc_rc = os.path.join("/etc", filename)
+                    # mock os.path.exists to return True for the two /etc files and False for the others
+                    mock_exists.side_effect = lambda x: x in [etc_rc, legacy_etc_rc]
+
+                    BasicConfig.read()
+
+                    # assert and check that the files are checked in the right order
+                    mock_exists.assert_has_calls(
+                        [
+                            call(local_rc),
+                            call(home_rc),
+                            call(legacy_etc_rc),
+                            call(etc_rc),
+                        ]
+                    )
+                    assert mock_read.call_args_list == [
+                        call(legacy_etc_rc),
+                        call(etc_rc),
+                    ]
+
+                    assert mock_read.call_count == 2

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -77,7 +77,17 @@ def test_read_loads_etc_files_with_priority(
 ):
     """Test read precedence among local, home and /etc rc files."""
     with patch.dict(os.environ, {}, clear=True):
-        with patch("pathlib.Path.exists", autospec=True) as mock_exists:
+        with patch.object(
+            Path,
+            "exists",
+            autospec=True,
+            side_effect=lambda path_obj: (
+                (user_config and path_obj == Path(Path.cwd(), ".autosubmitrc"))
+                or (home_user_config and path_obj == Path(Path.home(), ".autosubmitrc"))
+                or (etc_rc and path_obj == Path("/etc", "autosubmitrc"))
+                or (legacy_etc_rc and path_obj == Path("/etc", ".autosubmitrc"))
+            ),
+        ):
             with patch(
                 "autosubmit.config.basicconfig.BasicConfig._BasicConfig__read_file_config"
             ) as mock_read:
@@ -93,13 +103,6 @@ def test_read_loads_etc_files_with_priority(
                         home_user_config_path = Path(Path.home(), dot_filename)
                         etc_rc_path = Path("/etc", filename)
                         legacy_etc_rc_path = Path("/etc", dot_filename)
-
-                        mock_exists.side_effect = lambda path_obj: (
-                            (user_config and path_obj == user_config_path)
-                            or (home_user_config and path_obj == home_user_config_path)
-                            or (etc_rc and path_obj == etc_rc_path)
-                            or (legacy_etc_rc and path_obj == legacy_etc_rc_path)
-                        )
 
                         BasicConfig.read()
 

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -17,6 +17,7 @@
 
 import os
 from mock import Mock, patch, call
+from textwrap import dedent
 
 from autosubmit.config.basicconfig import BasicConfig
 
@@ -48,6 +49,9 @@ def test_read_makes_the_right_method_calls():
 
 
 def test_read_loads_etc_files_with_priority():
+    """
+    Test that the read method loads configuration files with the correct priority.
+    """
     # mock the os.environ dictionary to empty values to prevent entering the first conditional
     with patch.dict(os.environ, {}, clear=True):
         # mock os.path.exists
@@ -78,7 +82,8 @@ def test_read_loads_etc_files_with_priority():
                             call(home_rc),
                             call(legacy_etc_rc),
                             call(etc_rc),
-                        ]
+                        ],
+                        any_order=False,
                     )
                     assert mock_read.call_args_list == [
                         call(legacy_etc_rc),
@@ -86,3 +91,56 @@ def test_read_loads_etc_files_with_priority():
                     ]
 
                     assert mock_read.call_count == 2
+
+
+def test_read_overwrites_config_with_etc_files(tmp_path):
+    """
+    Precedence: if two autosubmitrc files exist, 
+    the /etc/ version should take precedence over the /etc/.autosubmitrc version
+    """
+    filename = "autosubmitrc"
+    legacy_etc_rc =  tmp_path / ("." + filename)
+    etc_rc = tmp_path / filename
+
+    legacy_db_dir = tmp_path / "legacy.db"
+    etc_db_dir = tmp_path / "etc.db"
+
+    legacy_etc_rc.write_text(dedent(f"""
+        [database]
+        path = {legacy_db_dir}
+        filename = legacy.db
+    """))
+        
+    with open(etc_rc, 'w') as f:
+        f.write(dedent(f"""
+        [database]
+        path = {etc_db_dir}
+        filename = etc.db
+    """))
+
+    # original values
+    original_db_dir = BasicConfig.DB_DIR
+    original_db_file = BasicConfig.DB_FILE
+    original_db_path = BasicConfig.DB_PATH
+    original_config_file_found = BasicConfig.CONFIG_FILE_FOUND
+    try:
+        # reset config to force reading the files again
+        BasicConfig.CONFIG_FILE_FOUND = False
+        
+        # act: read files in order: legacy first, modern second
+        BasicConfig._BasicConfig__read_file_config(str(legacy_etc_rc))
+        BasicConfig._BasicConfig__read_file_config(str(etc_rc))
+        BasicConfig._update_config()
+
+        # assert
+        assert BasicConfig.CONFIG_FILE_FOUND is True
+        assert BasicConfig.DB_DIR == str(etc_db_dir)
+        assert BasicConfig.DB_FILE == "etc.db"
+        assert BasicConfig.DB_PATH == os.path.join(str(etc_db_dir), "etc.db")
+
+    finally:
+        # restore original values
+        BasicConfig.DB_DIR = original_db_dir
+        BasicConfig.DB_FILE = original_db_file
+        BasicConfig.DB_PATH = original_db_path
+        BasicConfig.CONFIG_FILE_FOUND = original_config_file_found

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -46,3 +46,4 @@ def test_read_makes_the_right_method_calls():
         BasicConfig.read()
         # assert
         BasicConfig._update_config.assert_called_once_with()  # type: ignore
+

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -49,19 +49,16 @@ def test_read_makes_the_right_method_calls():
         # assert
         BasicConfig._update_config.assert_called_once_with()  # type: ignore
 
+
 @pytest.mark.parametrize(
-    'etc_rc, legacy_etc_rc',
+    "etc_rc, legacy_etc_rc",
     [
         [os.path.join("/etc", "autosubmitrc"), os.path.join("/etc", ".autosubmitrc")],
         [os.path.join("/etc", "autosubmitrc"), None],
-        [None, os.path.join("/etc", ".autosubmitrc")]
-    ]
+        [None, os.path.join("/etc", ".autosubmitrc")],
+    ],
 )
-
-def test_read_loads_etc_files_with_priority(
-    etc_rc,
-    legacy_etc_rc
-):
+def test_read_loads_etc_files_with_priority(etc_rc, legacy_etc_rc):
     """
     Test that the read method loads configuration files with the correct priority.
     """
@@ -79,82 +76,89 @@ def test_read_loads_etc_files_with_priority(
                     "autosubmit.config.basicconfig.BasicConfig._update_config", Mock()
                 ):
                     filename = "autosubmitrc"
-                    local_rc = os.path.join("", "." + filename)
-                    home_rc = os.path.join(os.path.expanduser("~"), "." + filename)
-                    legacy_etc_rc = legacy_etc_rc
-                    etc_rc = etc_rc
                     # mock os.path.exists to return True for the two /etc files and False for the others
                     mock_exists.side_effect = lambda x: x in [etc_rc, legacy_etc_rc]
 
                     BasicConfig.read()
 
                     if etc_rc and legacy_etc_rc:
-                        # assert and check that the files are checked in the right order
                         mock_exists.assert_has_calls(
                             [
-                                call(local_rc),
-                                call(home_rc),
+                                call(os.path.join("", "." + filename)),
+                                call(
+                                    os.path.join(
+                                        os.path.expanduser("~"), "." + filename
+                                    )
+                                ),
                                 call(etc_rc),
                             ],
                             any_order=False,
                         )
-                        assert mock_read.call_args_list == [
-                            call(etc_rc)
-                        ]
+                        # assert and check that the files are checked in the right order
+                        assert mock_read.call_args_list == [call(etc_rc)]
                         assert mock_read.call_count == 1
-                    
+
                     elif legacy_etc_rc and not etc_rc:
-                        # if only legacy_etc_rc exists only legacy_etc_rc should be read
-                        mock_exists.assert_called_with(legacy_etc_rc)
-                        assert mock_read.call_args_list == [
-                            call(legacy_etc_rc)
-                        ]
-                        assert mock_read.call_count == 1
-                    
-                    elif etc_rc and not legacy_etc_rc:
-                        # if only etc_rc exists -> only etc_rc should be read
-                        mock_exists.assert_called_with(etc_rc)
-                        assert mock_read.call_args_list == [
-                            call(etc_rc)
-                        ]
-                        assert mock_read.call_count == 1
-                    
-                    else:
-                        # if none of the files exist no file should be read
                         mock_exists.assert_has_calls(
                             [
-                                call(etc_rc),
+                                call(os.path.join("", "." + filename)),
+                                call(
+                                    os.path.join(
+                                        os.path.expanduser("~"), "." + filename
+                                    )
+                                ),
+                                call(os.path.join("/etc", "autosubmitrc")),
                                 call(legacy_etc_rc),
                             ],
                             any_order=False,
                         )
+                        # if only legacy_etc_rc exists only legacy_etc_rc should be read
+                        assert mock_read.call_args_list == [call(legacy_etc_rc)]
+                        assert mock_read.call_count == 1
+
+                    elif etc_rc and not legacy_etc_rc:
+                        assert mock_exists.call_args_list == [
+                            call(os.path.join("", "." + filename)),
+                            call(os.path.join(os.path.expanduser("~"), "." + filename)),
+                            call(etc_rc),
+                        ]
+                        # if only etc_rc exists only etc_rc should be read
+                        assert mock_read.call_args_list == [call(etc_rc)]
+                        assert mock_read.call_count == 1
+
+                    else:
+                        # if none of the files exist no file should be read
                         assert mock_read.call_count == 0
 
 
 def test_read_overwrites_config_with_etc_files(tmp_path):
     """
-    Precedence: if two autosubmitrc files exist, 
+    Precedence: if two autosubmitrc files exist,
     the /etc/ version should take precedence over the /etc/.autosubmitrc version
     """
     filename = "autosubmitrc"
-    legacy_etc_rc =  tmp_path / ("." + filename)
+    legacy_etc_rc = tmp_path / ("." + filename)
     etc_rc = tmp_path / filename
 
     legacy_db_dir = tmp_path / "legacy.db"
     etc_db_dir = tmp_path / "etc.db"
 
-    legacy_etc_rc.write_text(dedent(f"""
+    legacy_etc_rc.write_text(
+        dedent(f"""
         [database]
         path = {legacy_db_dir}
         filename = legacy.db
-    """))
-        
-    with open(etc_rc, 'w') as f:
-        f.write(dedent(f"""
+    """)
+    )
+
+    with open(etc_rc, "w") as f:
+        f.write(
+            dedent(f"""
         [database]
         path = {etc_db_dir}
         filename = etc.db
-    """))
+    """)
+        )
 
     # original values
     original_db_dir = BasicConfig.DB_DIR
@@ -164,7 +168,7 @@ def test_read_overwrites_config_with_etc_files(tmp_path):
     try:
         # reset config to force reading the files again
         BasicConfig.CONFIG_FILE_FOUND = False
-        
+
         # act: read files in order: legacy first, modern second
         BasicConfig._BasicConfig__read_file_config(str(legacy_etc_rc))
         BasicConfig._BasicConfig__read_file_config(str(etc_rc))

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -19,6 +19,8 @@ import os
 from mock import Mock, patch, call
 from textwrap import dedent
 
+import pytest
+
 from autosubmit.config.basicconfig import BasicConfig
 
 """TODO: This class has a static private (__named) method which is impossible to be tested.
@@ -47,8 +49,19 @@ def test_read_makes_the_right_method_calls():
         # assert
         BasicConfig._update_config.assert_called_once_with()  # type: ignore
 
+@pytest.mark.parametrize(
+    'etc_rc, legacy_etc_rc',
+    [
+        [os.path.join("/etc", "autosubmitrc"), os.path.join("/etc", ".autosubmitrc")],
+        [os.path.join("/etc", "autosubmitrc"), None],
+        [None, os.path.join("/etc", ".autosubmitrc")]
+    ]
+)
 
-def test_read_loads_etc_files_with_priority():
+def test_read_loads_etc_files_with_priority(
+    etc_rc,
+    legacy_etc_rc
+):
     """
     Test that the read method loads configuration files with the correct priority.
     """
@@ -68,29 +81,54 @@ def test_read_loads_etc_files_with_priority():
                     filename = "autosubmitrc"
                     local_rc = os.path.join("", "." + filename)
                     home_rc = os.path.join(os.path.expanduser("~"), "." + filename)
-                    legacy_etc_rc = os.path.join("/etc", "." + filename)
-                    etc_rc = os.path.join("/etc", filename)
+                    legacy_etc_rc = legacy_etc_rc
+                    etc_rc = etc_rc
                     # mock os.path.exists to return True for the two /etc files and False for the others
                     mock_exists.side_effect = lambda x: x in [etc_rc, legacy_etc_rc]
 
                     BasicConfig.read()
 
-                    # assert and check that the files are checked in the right order
-                    mock_exists.assert_has_calls(
-                        [
-                            call(local_rc),
-                            call(home_rc),
-                            call(legacy_etc_rc),
-                            call(etc_rc),
-                        ],
-                        any_order=False,
-                    )
-                    assert mock_read.call_args_list == [
-                        call(legacy_etc_rc),
-                        call(etc_rc),
-                    ]
-
-                    assert mock_read.call_count == 2
+                    if etc_rc and legacy_etc_rc:
+                        # assert and check that the files are checked in the right order
+                        mock_exists.assert_has_calls(
+                            [
+                                call(local_rc),
+                                call(home_rc),
+                                call(etc_rc),
+                            ],
+                            any_order=False,
+                        )
+                        assert mock_read.call_args_list == [
+                            call(etc_rc)
+                        ]
+                        assert mock_read.call_count == 1
+                    
+                    elif legacy_etc_rc and not etc_rc:
+                        # if only legacy_etc_rc exists only legacy_etc_rc should be read
+                        mock_exists.assert_called_with(legacy_etc_rc)
+                        assert mock_read.call_args_list == [
+                            call(legacy_etc_rc)
+                        ]
+                        assert mock_read.call_count == 1
+                    
+                    elif etc_rc and not legacy_etc_rc:
+                        # if only etc_rc exists -> only etc_rc should be read
+                        mock_exists.assert_called_with(etc_rc)
+                        assert mock_read.call_args_list == [
+                            call(etc_rc)
+                        ]
+                        assert mock_read.call_count == 1
+                    
+                    else:
+                        # if none of the files exist no file should be read
+                        mock_exists.assert_has_calls(
+                            [
+                                call(etc_rc),
+                                call(legacy_etc_rc),
+                            ],
+                            any_order=False,
+                        )
+                        assert mock_read.call_count == 0
 
 
 def test_read_overwrites_config_with_etc_files(tmp_path):

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -77,7 +77,7 @@ def test_read_loads_etc_files_with_priority(
 ):
     """Test read precedence among local, home and /etc rc files."""
     with patch.dict(os.environ, {}, clear=True):
-        with patch("autosubmit.config.basicconfig.os.path.exists") as mock_exists:
+        with patch("pathlib.Path.exists", autospec=True) as mock_exists:
             with patch(
                 "autosubmit.config.basicconfig.BasicConfig._BasicConfig__read_file_config"
             ) as mock_read:
@@ -88,18 +88,17 @@ def test_read_loads_etc_files_with_priority(
                         "autosubmit.config.basicconfig.Log.warning"
                     ) as mock_log_warning:
                         filename = "autosubmitrc"
-                        user_config_path = str(Path("", "." + filename))
-                        home_user_config_path = str(
-                            Path("~", "." + filename).expanduser()
-                        )
-                        etc_rc_path = str(Path("/etc", filename))
-                        legacy_etc_rc_path = str(Path("/etc", "." + filename))
+                        dot_filename = f".{filename}"
+                        user_config_path = Path(Path.cwd(), dot_filename)
+                        home_user_config_path = Path(Path.home(), dot_filename)
+                        etc_rc_path = Path("/etc", filename)
+                        legacy_etc_rc_path = Path("/etc", dot_filename)
 
-                        mock_exists.side_effect = lambda path: (
-                            (user_config and path == user_config_path)
-                            or (home_user_config and path == home_user_config_path)
-                            or (etc_rc and path == etc_rc_path)
-                            or (legacy_etc_rc and path == legacy_etc_rc_path)
+                        mock_exists.side_effect = lambda path_obj: (
+                            (user_config and path_obj == user_config_path)
+                            or (home_user_config and path_obj == home_user_config_path)
+                            or (etc_rc and path_obj == etc_rc_path)
+                            or (legacy_etc_rc and path_obj == legacy_etc_rc_path)
                         )
 
                         BasicConfig.read()
@@ -135,7 +134,8 @@ def test_read_overwrites_config_with_etc_files(tmp_path):
     the /etc/autosubmitrc version should take precedence over the /etc/.autosubmitrc version
     """
     filename = "autosubmitrc"
-    legacy_etc_rc = tmp_path / ("." + filename)
+    dot_filename = f".{filename}"
+    legacy_etc_rc = tmp_path / dot_filename
     etc_rc = tmp_path / filename
 
     legacy_db_dir = tmp_path / "legacy.db"

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -16,6 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from pathlib import Path
 from mock import Mock, patch, call
 from textwrap import dedent
 
@@ -68,10 +69,12 @@ def test_read_makes_the_right_method_calls():
         [False, False, True, True],
         [False, False, True, False],
         [False, False, False, True],
-        [False, False, False, False]
+        [False, False, False, False],
     ],
 )
-def test_read_loads_etc_files_with_priority(user_config, home_user_config, etc_rc, legacy_etc_rc):
+def test_read_loads_etc_files_with_priority(
+    user_config, home_user_config, etc_rc, legacy_etc_rc
+):
     """Test read precedence among local, home and /etc rc files."""
     with patch.dict(os.environ, {}, clear=True):
         with patch("autosubmit.config.basicconfig.os.path.exists") as mock_exists:
@@ -81,18 +84,22 @@ def test_read_loads_etc_files_with_priority(user_config, home_user_config, etc_r
                 with patch(
                     "autosubmit.config.basicconfig.BasicConfig._update_config", Mock()
                 ):
-                    with patch("autosubmit.config.basicconfig.Log.warning") as mock_log_warning:
+                    with patch(
+                        "autosubmit.config.basicconfig.Log.warning"
+                    ) as mock_log_warning:
                         filename = "autosubmitrc"
-                        user_config_path = os.path.join("", "." + filename)
-                        home_user_config_path = os.path.join(os.path.expanduser("~"), "." + filename)
-                        etc_rc_path = os.path.join("/etc", filename)
-                        legacy_etc_rc_path = os.path.join("/etc", "." + filename)
+                        user_config_path = str(Path("", "." + filename))
+                        home_user_config_path = str(
+                            Path("~", "." + filename).expanduser()
+                        )
+                        etc_rc_path = str(Path("/etc", filename))
+                        legacy_etc_rc_path = str(Path("/etc", "." + filename))
 
                         mock_exists.side_effect = lambda path: (
-                            (user_config and path == os.path.join("", "." + filename)) or
-                            (home_user_config and path == os.path.join(os.path.expanduser("~"), "." + filename)) or
-                            (etc_rc and path == os.path.join("/etc", filename)) or
-                            (legacy_etc_rc and path == os.path.join("/etc", "." + filename))
+                            (user_config and path == user_config_path)
+                            or (home_user_config and path == home_user_config_path)
+                            or (etc_rc and path == etc_rc_path)
+                            or (legacy_etc_rc and path == legacy_etc_rc_path)
                         )
 
                         BasicConfig.read()
@@ -110,7 +117,11 @@ def test_read_loads_etc_files_with_priority(user_config, home_user_config, etc_r
 
                         assert mock_read.call_args_list == expected_read_calls
 
-                        if (not user_config) and (not home_user_config) and legacy_etc_rc:
+                        if (
+                            (not user_config)
+                            and (not home_user_config)
+                            and legacy_etc_rc
+                        ):
                             mock_log_warning.assert_called_once_with(
                                 "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
                             )

--- a/test/unit/test_basic_config.py
+++ b/test/unit/test_basic_config.py
@@ -75,60 +75,78 @@ def test_read_loads_etc_files_with_priority(etc_rc, legacy_etc_rc):
                 with patch(
                     "autosubmit.config.basicconfig.BasicConfig._update_config", Mock()
                 ):
-                    filename = "autosubmitrc"
-                    # mock os.path.exists to return True for the two /etc files and False for the others
-                    mock_exists.side_effect = lambda x: x in [etc_rc, legacy_etc_rc]
+                    with patch("autosubmit.config.basicconfig.Log.warning") as mock_log_warning:
+                        filename = "autosubmitrc"
+                        # mock os.path.exists to return True for the two /etc files and False for the others
+                        mock_exists.side_effect = lambda x: x in [etc_rc, legacy_etc_rc]
 
-                    BasicConfig.read()
+                        BasicConfig.read()
 
-                    if etc_rc and legacy_etc_rc:
-                        mock_exists.assert_has_calls(
-                            [
-                                call(os.path.join("", "." + filename)),
-                                call(
-                                    os.path.join(
-                                        os.path.expanduser("~"), "." + filename
-                                    )
-                                ),
-                                call(etc_rc),
-                            ],
-                            any_order=False,
-                        )
-                        # assert and check that the files are checked in the right order
-                        assert mock_read.call_args_list == [call(etc_rc)]
-                        assert mock_read.call_count == 1
+                        if etc_rc and legacy_etc_rc:
+                            mock_exists.assert_has_calls(
+                                [
+                                    call(os.path.join("", "." + filename)),
+                                    call(
+                                        os.path.join(
+                                            os.path.expanduser("~"), "." + filename
+                                        )
+                                    ),
+                                    call(legacy_etc_rc),
+                                    call(etc_rc),
+                                ],
+                                any_order=False,
+                            )
+                            # assert and check that the files are checked in the right order
+                            assert mock_read.call_args_list == [call(legacy_etc_rc), call(etc_rc)]
+                            assert mock_read.call_count == 2
+                            mock_log_warning.assert_called_once_with(
+                                "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
+                            )
 
-                    elif legacy_etc_rc and not etc_rc:
-                        mock_exists.assert_has_calls(
-                            [
-                                call(os.path.join("", "." + filename)),
-                                call(
-                                    os.path.join(
-                                        os.path.expanduser("~"), "." + filename
-                                    )
-                                ),
-                                call(os.path.join("/etc", "autosubmitrc")),
-                                call(legacy_etc_rc),
-                            ],
-                            any_order=False,
-                        )
-                        # if only legacy_etc_rc exists only legacy_etc_rc should be read
-                        assert mock_read.call_args_list == [call(legacy_etc_rc)]
-                        assert mock_read.call_count == 1
+                        elif legacy_etc_rc and not etc_rc:
+                            mock_exists.assert_has_calls(
+                                [
+                                    call(os.path.join("", "." + filename)),
+                                    call(
+                                        os.path.join(
+                                            os.path.expanduser("~"), "." + filename
+                                        )
+                                    ),
+                                    call(legacy_etc_rc),
+                                    call(os.path.join("/etc", "autosubmitrc")),
+                                ],
+                                any_order=False,
+                            )
+                            # if only legacy_etc_rc exists only legacy_etc_rc should be read
+                            assert mock_read.call_args_list == [call(legacy_etc_rc)]
+                            assert mock_read.call_count == 1
+                            mock_log_warning.assert_called_once_with(
+                                "The legacy configuration file /etc/.autosubmitrc is deprecated and will be removed in future versions. Please, rename it to /etc/autosubmitrc"
+                            )
 
-                    elif etc_rc and not legacy_etc_rc:
-                        assert mock_exists.call_args_list == [
-                            call(os.path.join("", "." + filename)),
-                            call(os.path.join(os.path.expanduser("~"), "." + filename)),
-                            call(etc_rc),
-                        ]
-                        # if only etc_rc exists only etc_rc should be read
-                        assert mock_read.call_args_list == [call(etc_rc)]
-                        assert mock_read.call_count == 1
+                        elif etc_rc and not legacy_etc_rc:
+                            mock_exists.assert_has_calls(
+                                [
+                                    call(os.path.join("", "." + filename)),
+                                    call(
+                                        os.path.join(
+                                            os.path.expanduser("~"), "." + filename
+                                        )
+                                    ),
+                                    call(os.path.join("/etc", "." + filename)),
+                                    call(etc_rc),
+                                ],
+                                any_order=False,
+                            )
+                            # if only etc_rc exists only etc_rc should be read
+                            assert mock_read.call_args_list == [call(etc_rc)]
+                            assert mock_read.call_count == 1
+                            mock_log_warning.assert_not_called()
 
-                    else:
-                        # if none of the files exist no file should be read
-                        assert mock_read.call_count == 0
+                        else:
+                            # if none of the files exist no file should be read
+                            assert mock_read.call_count == 0
+                            mock_log_warning.assert_not_called()
 
 
 def test_read_overwrites_config_with_etc_files(tmp_path):

--- a/test/unit/test_configure.py
+++ b/test/unit/test_configure.py
@@ -20,20 +20,17 @@ from textwrap import dedent
 import pytest
 
 
-@pytest.mark.parametrize('suffix', [
-    '',
-    '/',
-    '//'
-])
+@pytest.mark.parametrize("suffix", ["", "/", "//"])
 def test_configure(mocker, tmp_path, suffix: str, autosubmit) -> None:
     # To update ``Path.home`` appending the provided suffix.
-    mocker.patch('autosubmit.autosubmit.get_rc_path').return_value = \
-        Path(str(tmp_path) + suffix, '.autosubmitrc')
+    mocker.patch("autosubmit.autosubmit.get_rc_path").return_value = Path(
+        str(tmp_path) + suffix, ".autosubmitrc"
+    )
 
     # assign values that will be passed on cmd
     database_filename = "autosubmit.db"
-    db_path = tmp_path / 'database'
-    lr_path = tmp_path / 'experiments'
+    db_path = tmp_path / "database"
+    lr_path = tmp_path / "experiments"
 
     autosubmit.configure(
         advanced=False,
@@ -45,7 +42,8 @@ def test_configure(mocker, tmp_path, suffix: str, autosubmit) -> None:
         smtp_hostname=None,
         mail_from=None,
         machine=False,
-        local=False)
+        local=False,
+    )
 
     expected = dedent(f"""\
         [database]
@@ -73,27 +71,24 @@ def test_configure(mocker, tmp_path, suffix: str, autosubmit) -> None:
         
         """)
 
-    with open(tmp_path / '.autosubmitrc', 'r') as file:
+    with open(tmp_path / ".autosubmitrc", "r") as file:
         assert file.read() == expected
 
 
-@pytest.mark.parametrize('suffix', [
-    '',
-    '/',
-    '//'
-])
+@pytest.mark.parametrize("suffix", ["", "/", "//"])
 def test_configure_advanced(mocker, tmp_path, suffix: str, autosubmit) -> None:
     """Test the advanced configuration options."""
     # To update ``Path.home`` appending the provided suffix.
-    mocker.patch('autosubmit.autosubmit.get_rc_path').return_value = \
-        Path(str(tmp_path) + suffix, '.autosubmitrc')
+    mocker.patch("autosubmit.autosubmit.get_rc_path").return_value = Path(
+        str(tmp_path) + suffix, ".autosubmitrc"
+    )
 
     # assign values that will be passed on cmd
     database_filename = "autosubmit.db"
-    db_path = tmp_path / 'database'
-    lr_path = tmp_path / 'experiments'
-    platforms_conf = tmp_path / 'platforms.yml'
-    jobs_conf = tmp_path / 'jobs.yml'
+    db_path = tmp_path / "database"
+    lr_path = tmp_path / "experiments"
+    platforms_conf = tmp_path / "platforms.yml"
+    jobs_conf = tmp_path / "jobs.yml"
     smtp_hostname = "smtp.example.com"
     mail_from = "autosubmit@example.com"
 
@@ -111,7 +106,8 @@ def test_configure_advanced(mocker, tmp_path, suffix: str, autosubmit) -> None:
         smtp_hostname=smtp_hostname,
         mail_from=mail_from,
         machine=False,
-        local=False)
+        local=False,
+    )
 
     expected = dedent(f"""\
         [database]
@@ -147,6 +143,5 @@ def test_configure_advanced(mocker, tmp_path, suffix: str, autosubmit) -> None:
         
         """)
 
-    with open(tmp_path / '.autosubmitrc', 'r') as file:
+    with open(tmp_path / ".autosubmitrc", "r") as file:
         assert file.read() == expected
-

--- a/test/unit/test_configure.py
+++ b/test/unit/test_configure.py
@@ -75,3 +75,78 @@ def test_configure(mocker, tmp_path, suffix: str, autosubmit) -> None:
 
     with open(tmp_path / '.autosubmitrc', 'r') as file:
         assert file.read() == expected
+
+
+@pytest.mark.parametrize('suffix', [
+    '',
+    '/',
+    '//'
+])
+def test_configure_advanced(mocker, tmp_path, suffix: str, autosubmit) -> None:
+    """Test the advanced configuration options."""
+    # To update ``Path.home`` appending the provided suffix.
+    mocker.patch('autosubmit.autosubmit.get_rc_path').return_value = \
+        Path(str(tmp_path) + suffix, '.autosubmitrc')
+
+    # assign values that will be passed on cmd
+    database_filename = "autosubmit.db"
+    db_path = tmp_path / 'database'
+    lr_path = tmp_path / 'experiments'
+    platforms_conf = tmp_path / 'platforms.yml'
+    jobs_conf = tmp_path / 'jobs.yml'
+    smtp_hostname = "smtp.example.com"
+    mail_from = "autosubmit@example.com"
+
+    # Create the platform and jobs config files
+    platforms_conf.write_text("# Platforms configuration\n")
+    jobs_conf.write_text("# Jobs configuration\n")
+
+    autosubmit.configure(
+        advanced=True,
+        database_path=str(db_path),
+        database_filename=database_filename,
+        local_root_path=str(lr_path),
+        platforms_conf_path=str(platforms_conf),
+        jobs_conf_path=str(jobs_conf),
+        smtp_hostname=smtp_hostname,
+        mail_from=mail_from,
+        machine=False,
+        local=False)
+
+    expected = dedent(f"""\
+        [database]
+        backend = sqlite
+        path = {str(tmp_path)}/database
+        filename = autosubmit.db
+        
+        [local]
+        path = {str(tmp_path)}/experiments
+        
+        [conf]
+        jobs = {str(jobs_conf)}
+        platforms = {str(platforms_conf)}
+        
+        [mail]
+        smtp_server = smtp.example.com
+        mail_from = autosubmit@example.com
+        
+        [globallogs]
+        path = {str(tmp_path)}/experiments/logs
+        
+        [structures]
+        path = {str(tmp_path)}/experiments/metadata/structures
+        
+        [historicdb]
+        path = {str(tmp_path)}/experiments/metadata/data
+        
+        [historiclog]
+        path = {str(tmp_path)}/experiments/metadata/logs
+        
+        [autosubmitapi]
+        url = http://192.168.11.91:8081 # Replace me?
+        
+        """)
+
+    with open(tmp_path / '.autosubmitrc', 'r') as file:
+        assert file.read() == expected
+


### PR DESCRIPTION
Closes [#2312](https://github.com/BSC-ES/autosubmit/issues/2312)

**Things done**
- modified ```read()``` function in ```basicconfig.py``` to assign priority to filename ```/etc/autosubmitrc``` over ```/etc/.autosubmitrc```.
- modified ```get_rc_path``` to return ```/etc/autosubmitrc``` if ```machine``` boolean set to true
-  modified test ```test_strtobool``` in ```test_utils``` with the updated filenames
- implemented two unit tests in test_basic_config in order to address how the autosubmitrc loading priority is handled and the correct content in case of both etc/autosubmitrc and etc/.autosubmitrc present.
- deleted ```configure_dialog()``` in ```autosubmit.py``` as it was not called anywhere in the code and was using  ```/etc/.autosubmitrc``` deprecated configuration.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
