### PR TITLE
Allow intersection of multiple filters in ```setstatus``` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   added to check that we produce valid crates with the `rocrate-validator` #2816
 - Changed Yaml load mode from 'safe' to 'rt' #2851
 - Add issues URL to error message #2888
+- Allow multiple filters in `setstatus` command #1250
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4971,10 +4971,10 @@ class Autosubmit:
         filter_chunk_section_split = filter_chunks or filter_type_chunk or filter_type_chunk_split
 
         check_ownership(expid, raise_error=True)
-        exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
-        tmp_path = os.path.join(exp_path, BasicConfig.LOCAL_TMP_DIR)
+        exp_path = Path(BasicConfig.LOCAL_ROOT_DIR) / expid
+        tmp_path = exp_path / BasicConfig.LOCAL_TMP_DIR
         try:
-            with Lock(os.path.join(tmp_path, 'autosubmit.lock'), timeout=1):
+            with Lock(Path(tmp_path, 'autosubmit.lock'), timeout=1):
                 Log.info(
                     "Preparing .lock file to avoid multiple instances with same expid.")
 
@@ -5117,8 +5117,7 @@ class Autosubmit:
                     if as_conf.get_wrapper_type() != 'none' and check_wrapper:
                         packages_persistence = JobPackagePersistence(expid)
                         if BasicConfig.DATABASE_BACKEND == 'sqlite':
-                            os.chmod(os.path.join(BasicConfig.LOCAL_ROOT_DIR,
-                                                  expid, "pkl", "job_packages_" + expid + ".db"), 0o775)
+                            Path(BasicConfig.LOCAL_ROOT_DIR, expid, "pkl", "job_packages_" + expid + ".db").chmod(0o775)
                         packages_persistence.reset_table(True)
                         job_list_wr = Autosubmit.load_job_list(expid, as_conf, monitor=True, new=False)
 
@@ -5144,8 +5143,7 @@ class Autosubmit:
                     monitor_exp = Monitor()
                     monitor_exp.generate_output(expid,
                                                 job_list.get_job_list(),
-                                                os.path.join(
-                                                    exp_path, "/tmp/LOG_", expid),
+                                                Path(exp_path, "tmp", "LOG_" + expid),
                                                 output_format=output_type,
                                                 packages=packages,
                                                 show=not hide,

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -5143,7 +5143,7 @@ class Autosubmit:
                     monitor_exp = Monitor()
                     monitor_exp.generate_output(expid,
                                                 job_list.get_job_list(),
-                                                Path(exp_path, "tmp", "LOG_" + expid),
+                                                str(Path(exp_path, "tmp", "LOG_" + expid)),
                                                 output_format=output_type,
                                                 packages=packages,
                                                 show=not hide,

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -596,7 +596,7 @@ class Autosubmit:
                 "-ftc",
                 "--filter_type_chunk",
                 type=str,
-                help='[Deprecated] EQuivalent behaviour can be obtained combining achieved by combining -ft and -fc. \
+                help='[Deprecated] Equivalent behaviour can be achieved by combining -ft and -fc. \
                                Supply the list of chunks to change the status. Default = "Any". When the member name "all" is set, all the chunks \
                                selected from for that member will be updated for all the members. Example: all [1], will have as a result that the \
                                    chunks 1 for all the members will be updated. Follow the format: '
@@ -606,7 +606,7 @@ class Autosubmit:
                 "-ftcs",
                 "--filter_type_chunk_split",
                 type=str,
-                help='Deprecated] EQuivalent behaviour can be obtained combining achieved by combining -ft and -fc. \
+                help='[Deprecated] Equivalent behaviour can be achieved by combining -ft and -fc. \
                                 Supply the list of chunks & splits to change the status. Default = "Any". When the member name "all" is set, all the chunks \
                                            selected from for that member will be updated for all the members. Example: all [1], will have as a result that the \
                                                chunks 1 for all the members will be updated. Follow the format: '
@@ -4586,7 +4586,10 @@ class Autosubmit:
                 if reference not in status_list:
                     status_list.append(reference)
             for status in status_filter:
+                if status == "ANY":
+                    continue
                 if status not in status_list:
+                    print(status)
                     status_validation_error = True
                     status_validation_message += "\n\t There are no jobs with status " + \
                                                  status + " in this experiment."
@@ -4961,12 +4964,12 @@ class Autosubmit:
         selected_chunk_filters = [name for name, value in provided_chunk_filters if value]
         if len(selected_chunk_filters) > 1:
             Log.warning(
-                "Multiple chunk filters provided (%s). Using -fc first, then -ftc, and finally -ftcs."
-                "Use only one of them to avoid ambiguity."
+                "Multiple chunk filters provided (%s). Using -fc first, then -ftc, and finally -ftcs." 
+                " Use only one of them to avoid ambiguity."
                 % ", ".join(selected_chunk_filters)
             )
         # keep retro-compatibility with legacy filters while prioritizing -fc, then -ftc, and finally -ftcs
-        filter_chunk_section_split = filter_chunks or filter_type_chunk_split or filter_type_chunk
+        filter_chunk_section_split = filter_chunks or filter_type_chunk or filter_type_chunk_split
 
         check_ownership(expid, raise_error=True)
         exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
@@ -5030,27 +5033,35 @@ class Autosubmit:
                 all_jobs = job_list.get_job_list()
                 selected_job_names = {job.name for job in all_jobs}
 
-                def intersect_with(job_names: set[str]) -> None:
-                    nonlocal selected_job_names
-                    selected_job_names &= job_names
+                def intersect_with(current_names: set[str], job_names: set[str]) -> set[str]:
+                    return current_names & job_names
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
                     ft = filter_section.split()
-                    if str(ft).upper() != 'ANY':
-                        intersect_with({job.name for job in all_jobs if job.section in ft})
+                    if not (len(ft) == 1 and ft[0].upper() == 'ANY'):
+                        selected_job_names = intersect_with(
+                            selected_job_names,
+                            {job.name for job in all_jobs if job.section in ft},
+                        )
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()
-                    intersect_with({job.name for job in Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)})
+                    selected_job_names = intersect_with(
+                        selected_job_names,
+                        {job.name for job in Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)},
+                    )
                     Log.info(f"Chunk filtering took {time.time() - start:.2f} seconds.")
 
                 if filter_status:
                     status_list = filter_status.split()
                     Log.debug(f"Filtering jobs with status {filter_status}")
-                    if str(status_list).upper() != 'ANY':
+                    if not (len(status_list) == 1 and status_list[0].upper() == 'ANY'):
                         allowed_statuses = {Autosubmit._get_status(s) for s in status_list}
-                        intersect_with({job.name for job in all_jobs if job.status in allowed_statuses})
+                        selected_job_names = intersect_with(
+                            selected_job_names,
+                            {job.name for job in all_jobs if job.status in allowed_statuses},
+                        )
 
                 if filter_list:
                     jobs = filter_list.split()
@@ -5061,8 +5072,11 @@ class Autosubmit:
                         wrongExpid = len(jobs) - expidJoblist[expid]
                     if wrongExpid > 0:
                         Log.warning(f"There are {wrongExpid} job.name with an invalid Expid")
-                    if str(jobs).upper() != 'ANY':
-                        intersect_with({job.name for job in all_jobs if job.name in jobs})
+                    if not (len(jobs) == 1 and jobs[0].upper() == 'ANY'):
+                        selected_job_names = intersect_with(
+                            selected_job_names,
+                            {job.name for job in all_jobs if job.name in jobs},
+                        )
                 # preserve job list ordering
                 final_list = [job for job in all_jobs if job.name in selected_job_names]
                 # Time to change status

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4943,12 +4943,30 @@ class Autosubmit:
         """
         if filter_status:
             filter_status = filter_status.upper()
-        # TODO: unify filters. There is already an issue for that
-        # TODO: Normalize some filters that are the same ( To avoid changing the usage ... FIX in another PR)
-        filter_chunk_section_split = None
-        # TODO: TMP fix until the previous TODO is resolved. Select the one that is filled
-        for f in [filter_chunks, filter_type_chunk, filter_type_chunk_split]:
-            filter_chunk_section_split = f if f else filter_chunk_section_split
+        # legacy filters
+        if filter_type_chunk:
+            Log.warning(
+                "--filter_type_chunk is deprecated and will be removed in future versions. Use a combination of -ft and -fc."
+            )
+        if filter_type_chunk_split:
+            Log.warning(
+                "--filter_type_chunk_split is deprecated and will be removed in future versions. Use a combination of -ft and -fc."
+            )
+        # multiple overlapping filters selected
+        provided_chunk_filters = [
+            ("-fc/--filter_chunks", filter_chunks),
+            ("-ftc/--filter_type_chunk", filter_type_chunk),
+            ("-ftcs/--filter_type_chunk_split", filter_type_chunk_split)
+        ]
+        selected_chunk_filters = [name for name, value in provided_chunk_filters if value]
+        if len(selected_chunk_filters) > 1:
+            Log.warning(
+                "Multiple chunk filters provided (%s). Using -fc first, then -ftc, and finally -ftcs."
+                " Use only one of them to avoid ambiguity."
+                ", ".join(selected_chunk_filters)
+            )
+        # keep retro-compatibility with legacy filters while prioritizing -fc, then -ftc, and finally -ftcs
+        filter_chunk_section_split = filter_chunks or filter_type_chunk_split or filter_type_chunk
 
         check_ownership(expid, raise_error=True)
         exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
@@ -5009,59 +5027,45 @@ class Autosubmit:
                                                         filter_section)
                 #### Starts the filtering process ####
                 Log.info("Filtering jobs...")
-                final_list = []
+                all_jobs = job_list.get_job_list()
+                selected_job_names = {job.name for job in all_jobs}
+
+                def intersect_with(job_names: set[str]) -> None:
+                    nonlocal selected_job_names
+                    selected_job_names &= job_names
+                
                 final_status = Autosubmit._get_status(final)
-                # I have the impression that whoever did this function thought about the possibility of having multiple filters at the same time
-                # But, as it was, it is not possible to have multiple filters at the same time due to the way the code is written
                 if filter_section:
                     ft = filter_section.split()
-                    if str(ft).upper() == 'ANY':
-                        for job in job_list.get_job_list():
-                            final_list.append(job)
-                    else:
-                        for section in ft:
-                            for job in job_list.get_job_list():
-                                if job.section == section:
-                                    final_list.append(job)
-                # TODO: unify filters in the args. There is already an issue for that
-                if filter_chunks or filter_type_chunk or filter_chunk_section_split:
+                    if str(ft).upper() != 'ANY':
+                        intersect_with({job.name for job in all_jobs if job.section in ft})
+
+                if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()
-                    # The extend is because the code was thought to have multiple filters at the same time (but it is not possible for some combinations)
-                    final_list.extend(Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split))
-                    final_list = list(set(final_list))
+                    intersect_with({job.name for job in Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)})
                     Log.info(f"Chunk filtering took {time.time() - start:.2f} seconds.")
 
                 if filter_status:
                     status_list = filter_status.split()
                     Log.debug(f"Filtering jobs with status {filter_status}")
-                    if str(status_list).upper() == 'ANY':
-                        for job in job_list.get_job_list():
-                            final_list.append(job)
-                    else:
-                        for status in status_list:
-                            fs = Autosubmit._get_status(status)
-                            for job in [j for j in job_list.get_job_list() if j.status == fs]:
-                                final_list.append(job)
+                    if str(status_list).upper() != 'ANY':
+                        allowed_statuses = {Autosubmit._get_status(s) for s in status_list}
+                        intersect_with({job.name for job in all_jobs if job.status in allowed_statuses})
 
                 if filter_list:
                     jobs = filter_list.split()
                     expidJoblist = defaultdict(int)
-                    for x in filter_list.split():
+                    for x in jobs:
                         expidJoblist[str(x[0:4])] += 1
                     if str(expid) in expidJoblist:
-                        wrongExpid = jobs.__len__() - expidJoblist[expid]
+                        wrongExpid = len(jobs) - expidJoblist[expid]
                     if wrongExpid > 0:
                         Log.warning(f"There are {wrongExpid} job.name with an invalid Expid")
-                    if str(jobs).upper() == 'ANY':
-                        for job in job_list.get_job_list():
-                            final_list.append(job)
-                    else:
-                        for job in job_list.get_job_list():
-                            if job.name in jobs:
-                                final_list.append(job)
-
+                    if str(jobs).upper() != 'ANY':
+                        intersect_with({job.name for job in all_jobs if job.name in jobs})
+                # preserve job list ordering
+                final_list = [job for job in all_jobs if job.name in selected_job_names]
                 # Time to change status
-                final_list = list(set(final_list))
                 performed_changes = {}
                 Log.info(f"The selected number of jobs to change is: {len(final_list)}")
                 for job in final_list:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4962,8 +4962,8 @@ class Autosubmit:
         if len(selected_chunk_filters) > 1:
             Log.warning(
                 "Multiple chunk filters provided (%s). Using -fc first, then -ftc, and finally -ftcs."
-                " Use only one of them to avoid ambiguity."
-                ", ".join(selected_chunk_filters)
+                "Use only one of them to avoid ambiguity."
+                % ", ".join(selected_chunk_filters)
             )
         # keep retro-compatibility with legacy filters while prioritizing -fc, then -ftc, and finally -ftcs
         filter_chunk_section_split = filter_chunks or filter_type_chunk_split or filter_type_chunk

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -528,57 +528,130 @@ class Autosubmit:
 
             # Set status
             subparser = subparsers.add_parser(
-                'setstatus', description="sets job status for an experiment")
-            subparser.add_argument('expid', help='experiment identifier')
+                "setstatus", description="sets job status for an experiment"
+            )
+            subparser.add_argument("expid", help="experiment identifier")
             subparser.add_argument(
-                '-np', '--noplot', action='store_true', default=False, help='omit plot')
+                "-np", "--noplot", action="store_true", default=False, help="omit plot"
+            )
             subparser.add_argument(
-                '-s', '--save', action="store_true", default=False, help='Save changes to disk')
-            subparser.add_argument('-t', '--status_final',
-                                   choices=('READY', 'COMPLETED', 'WAITING', 'SUSPENDED', 'FAILED', 'UNKNOWN',
-                                            'QUEUING', 'RUNNING', 'HELD'),
-                                   required=True,
-                                   help='Supply the target status')
-            subparser.add_argument('-v', '--update_version', action='store_true',
-                                   default=False, help='Update experiment version')
-            group = subparser.add_mutually_exclusive_group(required=True)
-            group.add_argument('-fl', '--list', type=str,
-                               help='Supply the list of job names to be changed. Default = "Any". '
-                                    'LIST = "b037_20101101_fc3_21_sim b037_20111101_fc4_26_sim"')
-            group.add_argument('-fc', '--filter_chunks', type=str,
-                               help='Supply the list of chunks to change the status. Default = "Any". '
-                                    'LIST = "[ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]"')
-            group.add_argument('-fs', '--filter_status', type=str,
-                               help='Select the status (one or more) to filter the list of jobs.'
-                                    "Valid values = ['Any', 'READY', 'COMPLETED', 'WAITING', 'SUSPENDED', 'FAILED', 'UNKNOWN']")
-            group.add_argument('-ft', '--filter_type', type=str,
-                               help='Select the job type to filter the list of jobs')
-            group.add_argument('-ftc', '--filter_type_chunk', type=str,
-                               help='Supply the list of chunks to change the status. Default = "Any". When the member name "all" is set, all the chunks \
+                "-s",
+                "--save",
+                action="store_true",
+                default=False,
+                help="Save changes to disk",
+            )
+            subparser.add_argument(
+                "-t",
+                "--status_final",
+                choices=(
+                    "READY",
+                    "COMPLETED",
+                    "WAITING",
+                    "SUSPENDED",
+                    "FAILED",
+                    "UNKNOWN",
+                    "QUEUING",
+                    "RUNNING",
+                    "HELD",
+                ),
+                required=True,
+                help="Supply the target status",
+            )
+            subparser.add_argument(
+                "-v",
+                "--update_version",
+                action="store_true",
+                default=False,
+                help="Update experiment version",
+            )
+            subparser.add_argument(
+                "-fl",
+                "--list",
+                type=str,
+                help='Supply the list of job names to be changed. Default = "Any". '
+                'LIST = "b037_20101101_fc3_21_sim b037_20111101_fc4_26_sim"',
+            )
+            subparser.add_argument(
+                "-fc",
+                "--filter_chunks",
+                type=str,
+                help='Supply the list of chunks to change the status. Default = "Any". '
+                'LIST = "[ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]"',
+            )
+            subparser.add_argument(
+                "-fs",
+                "--filter_status",
+                type=str,
+                help="Select the status (one or more) to filter the list of jobs."
+                "Valid values = ['Any', 'READY', 'COMPLETED', 'WAITING', 'SUSPENDED', 'FAILED', 'UNKNOWN']",
+            )
+            subparser.add_argument(
+                "-ft",
+                "--filter_type",
+                type=str,
+                help="Select the job type to filter the list of jobs",
+            )
+            subparser.add_argument(
+                "-ftc",
+                "--filter_type_chunk",
+                type=str,
+                help='[Deprecated] EQuivalent behaviour can be obtained combining achieved by combining -ft and -fc. \
+                               Supply the list of chunks to change the status. Default = "Any". When the member name "all" is set, all the chunks \
                                selected from for that member will be updated for all the members. Example: all [1], will have as a result that the \
                                    chunks 1 for all the members will be updated. Follow the format: '
-                                    '"[ 19601101 [ fc0 [1 2 3 4] Any [1] ] 19651101 [ fc0 [16-30] ] ],SIM,SIM2,SIM3"')
-            group.add_argument('-ftcs', '--filter_type_chunk_split', type=str,
-                               help='Supply the list of chunks & splits to change the status. Default = "Any". When the member name "all" is set, all the chunks \
+                '"[ 19601101 [ fc0 [1 2 3 4] Any [1] ] 19651101 [ fc0 [16-30] ] ],SIM,SIM2,SIM3"',
+            )
+            subparser.add_argument(
+                "-ftcs",
+                "--filter_type_chunk_split",
+                type=str,
+                help='Deprecated] EQuivalent behaviour can be obtained combining achieved by combining -ft and -fc. \
+                                Supply the list of chunks & splits to change the status. Default = "Any". When the member name "all" is set, all the chunks \
                                            selected from for that member will be updated for all the members. Example: all [1], will have as a result that the \
                                                chunks 1 for all the members will be updated. Follow the format: '
-                                    '"[ 19601101 [ fc0 [1 [1 2] 2 3 4] Any [1] ] 19651101 [ fc0 [16-30] ] ],SIM,SIM2,SIM3"')
+                '"[ 19601101 [ fc0 [1 [1 2] 2 3 4] Any [1] ] 19651101 [ fc0 [16-30] ] ],SIM,SIM2,SIM3"',
+            )
 
-            subparser.add_argument('--hide', action='store_true', default=False,
-                                   help='hides plot window')
-            subparser.add_argument('-group_by', choices=('date', 'member', 'chunk', 'split', 'automatic'), default=None,
-                                   help='Groups the jobs automatically or by date, member, chunk or split')
-            subparser.add_argument('-expand', type=str,
-                                   help='Supply the list of dates/members/chunks to filter the list of jobs. Default = "Any". '
-                                        'LIST = "[ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]"')
             subparser.add_argument(
-                '-expand_status', type=str, help='Select the statuses to be expanded')
-            subparser.add_argument('-nt', '--notransitive', action='store_true',
-                                   default=False, help='Disable transitive reduction')
-            subparser.add_argument('-cw', '--check_wrapper', action='store_true',
-                                   default=False, help='Generate possible wrapper in the current workflow')
-            subparser.add_argument('-d', '--detail', action='store_true',
-                                   default=False, help='Generate detailed view of changes')
+                "--hide", action="store_true", default=False, help="hides plot window"
+            )
+            subparser.add_argument(
+                "-group_by",
+                choices=("date", "member", "chunk", "split", "automatic"),
+                default=None,
+                help="Groups the jobs automatically or by date, member, chunk or split",
+            )
+            subparser.add_argument(
+                "-expand",
+                type=str,
+                help='Supply the list of dates/members/chunks to filter the list of jobs. Default = "Any". '
+                'LIST = "[ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]"',
+            )
+            subparser.add_argument(
+                "-expand_status", type=str, help="Select the statuses to be expanded"
+            )
+            subparser.add_argument(
+                "-nt",
+                "--notransitive",
+                action="store_true",
+                default=False,
+                help="Disable transitive reduction",
+            )
+            subparser.add_argument(
+                "-cw",
+                "--check_wrapper",
+                action="store_true",
+                default=False,
+                help="Generate possible wrapper in the current workflow",
+            )
+            subparser.add_argument(
+                "-d",
+                "--detail",
+                action="store_true",
+                default=False,
+                help="Generate detailed view of changes",
+            )
 
             # Test Case
             subparser = subparsers.add_parser(

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -5032,25 +5032,16 @@ class Autosubmit:
                 Log.info("Filtering jobs...")
                 all_jobs = job_list.get_job_list()
                 selected_job_names = {job.name for job in all_jobs}
-
-                def intersect_with(current_names: set[str], job_names: set[str]) -> set[str]:
-                    return current_names & job_names
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
                     ft = filter_section.split()
                     if not (len(ft) == 1 and ft[0].upper() == 'ANY'):
-                        selected_job_names = intersect_with(
-                            selected_job_names,
-                            {job.name for job in all_jobs if job.section in ft},
-                        )
+                        selected_job_names &= {job.name for job in all_jobs if job.section in ft}
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()
-                    selected_job_names = intersect_with(
-                        selected_job_names,
-                        {job.name for job in Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)},
-                    )
+                    selected_job_names &={job.name for job in Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)}
                     Log.info(f"Chunk filtering took {time.time() - start:.2f} seconds.")
 
                 if filter_status:
@@ -5058,10 +5049,7 @@ class Autosubmit:
                     Log.debug(f"Filtering jobs with status {filter_status}")
                     if not (len(status_list) == 1 and status_list[0].upper() == 'ANY'):
                         allowed_statuses = {Autosubmit._get_status(s) for s in status_list}
-                        selected_job_names = intersect_with(
-                            selected_job_names,
-                            {job.name for job in all_jobs if job.status in allowed_statuses},
-                        )
+                        selected_job_names &= {job.name for job in all_jobs if job.status in allowed_statuses}
 
                 if filter_list:
                     jobs = filter_list.split()
@@ -5073,10 +5061,7 @@ class Autosubmit:
                     if wrongExpid > 0:
                         Log.warning(f"There are {wrongExpid} job.name with an invalid Expid")
                     if not (len(jobs) == 1 and jobs[0].upper() == 'ANY'):
-                        selected_job_names = intersect_with(
-                            selected_job_names,
-                            {job.name for job in all_jobs if job.name in jobs},
-                        )
+                        selected_job_names &= {job.name for job in all_jobs if job.name in jobs}
                 # preserve job list ordering
                 final_list = [job for job in all_jobs if job.name in selected_job_names]
                 # Time to change status

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4589,7 +4589,6 @@ class Autosubmit:
                 if status == "ANY":
                     continue
                 if status not in status_list:
-                    print(status)
                     status_validation_error = True
                     status_validation_message += "\n\t There are no jobs with status " + \
                                                  status + " in this experiment."

--- a/docs/source/userguide/index.rst
+++ b/docs/source/userguide/index.rst
@@ -25,31 +25,31 @@ User Guide
 Command list
 ============
 
-* expid  Create a new experiment
-* create  Create specified experiment workflow
-* check  Check configuration for specified experiment
-* describe  Show details for specified experiments
-* run  Run specified experiment
-* inspect  Generate cmd files
-* test  Test experiment
-* testcase  Test case experiment
-* monitor  Plot specified experiment
-* stats  Plot statistics and summaries for specified experiment
-* setstatus  Sets job status for an experiment
-* recovery  Recover specified experiment
-* clean  Clean specified experiment
-* refresh  Refresh project directory for an experiment
-* delete  Delete specified experiments
-* configure  Configure database and path for autosubmit
-* install  Install database for Autosubmit on the configured folder
-* archive  Clean, compress and remove from the experiments' folder a finalized experiment
-* unarchive  Restores an archived experiment
-* migrate_exp  Migrates an experiment from one user to another
-* report  extract experiment parameters
-* updateversion  Updates the Autosubmit version of your experiment with the current version of the module you are using
-* dbfix  Fixes the database malformed error in the historical database of your experiment
-* pklfix  Fixes the blank pkl error of your experiment
-* updatedescrip  Updates the description of your experiment (See: :ref:`updateDescrip`)
+* ``expid``  Create a new experiment
+* ``create``  Create specified experiment workflow
+* ``check``  Check configuration for specified experiment
+* ``describe``  Show details for specified experiments
+* ``run``  Run specified experiment
+* ``inspect``  Generate cmd files
+* ``test``  Test experiment
+* ``testcase``  Test case experiment
+* ``monitor``  Plot specified experiment
+* ``stats``  Plot statistics and summaries for specified experiment
+* ``setstatus``  Sets job status for an experiment
+* ``recovery``  Recover specified experiment
+* ``clean``  Clean specified experiment
+* ``refresh``  Refresh project directory for an experiment
+* ``delete``  Delete specified experiments
+* ``configure``  Configure database and path for autosubmit
+* ``install``  Install database for Autosubmit on the configured folder
+* ``archive``  Clean, compress and remove from the experiments' folder a finalized experiment
+* ``unarchive``  Restores an archived experiment
+* ``migrate_exp``  Migrates an experiment from one user to another
+* ``report``  extract experiment parameters
+* ``updateversion``  Updates the Autosubmit version of your experiment with the current version of the module you are using
+* ``dbfix``  Fixes the database malformed error in the historical database of your experiment
+* ``pklfix``  Fixes the blank pkl error of your experiment
+* ``updatedescrip``  Updates the description of your experiment (See: :ref:`updateDescrip`)
 
 
 Tutorials (How to)

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -287,9 +287,11 @@ Result:
 
 Date (day) range example:
 ::
+
     autosubmit setstatus <EXPID> -fc "[ 1960(1101-1105) [ fc1 [1] ] ]" -ft "SIM" -t SUSPENDED -s
 Result:
 ::
+
     <EXPID>_19601101_fc1_1_SIM
     <EXPID>_19601102_fc1_1_SIM
     <EXPID>_19601103_fc1_1_SIM

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -289,6 +289,7 @@ Date (day) range example:
 ::
 
     autosubmit setstatus <EXPID> -fc "[ 1960(1101-1105) [ fc1 [1] ] ]" -ft "SIM" -t SUSPENDED -s
+    
 Result:
 ::
 

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -117,10 +117,11 @@ where *<EXPID>* is the experiment identifier.
 It checks the experiment configuration and copies code from the original repository to project directory.
 
 .. warning:: THIS WILL OVERWRITE LOCAL CHANGES!
-    Project directory ( <EXPID>/proj will be overwritten and you may loose local changes.
+    Project directory ``<EXPID>/proj`` will be overwritten and you may loose local changes.
 
 
 Options:
+
 .. runcmd:: autosubmit refresh -h
 
 Example:

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -180,26 +180,31 @@ Mandatory arguments:
 Optional filter arguments (combine multiple for granular selection):
 
 * ``-fl``: space-separated list of job names
+
 ::
 
     autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_sim <EXPID>_20111101_fc4_26_sim" -t READY -s
 
 * ``-fc``: chunk/section/split filter (JSON-like format, takes precedence over legacy filters)
+
 ::
 
     autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc1 [1] ] ]" -t READY -s
 
 * ``-fs``: space-separated job statuses. The available statuses are: ``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``FAILED``, and ``UNKNOWN``.
+
 ::
 
     autosubmit setstatus <EXPID> -fs FAILED -t READY -s
 
 * ``-ft``: space-separated job types
+
 ::
 
     autosubmit setstatus <EXPID> -ft TRANSFER -t SUSPENDED -s
 
 * ``-ftc``: **[DEPRECATED]** legacy chunk/type filter (use a combination of ``-fc`` and ``-ft`` instead).
+
 Command:
 ::
 
@@ -211,6 +216,7 @@ Can be replaced with:
     autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc0 [1 2 3 4] ] ]" -ft SIM -t READY -s
 
 * ``-ftcs``: **[DEPRECATED]** legacy chunk/type/split filter (use a combination of ``-fc`` and ``-ft`` instead).
+
 Command:
 ::
 

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -167,100 +167,161 @@ This procedure allows you to modify the status of your jobs.
 You must execute:
 ::
 
-    autosubmit setstatus <EXPID> -fs STATUS_ORIGINAL -t STATUS_FINAL -s
+    autosubmit setstatus <EXPID> -f{ l | s | t | c } <VALUE_TO_FILTER> -t <STATUS_FINAL> -s
 
-*<EXPID>* is the experiment identifier.
-*STATUS_ORIGINAL* is the original status to filter by the list of jobs.
-*STATUS_FINAL* the desired target status.
+If multiple filters are provided (``-f{ l | s | t | c }``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will have their status changed.
+
+Mandatory arguments:
+
+* ``<EXPID>``: experiment identifier
+* ``-f{ l | s | t | c } <VALUE_TO_FILTER>``: at least one filter is required to select jobs (see below for filter options)
+* ``-t STATUS_FINAL``: target status (``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``FAILED``, ``UNKNOWN``)
+
+Optional filter arguments (combine multiple for granular selection):
+
+* ``-fl``: space-separated list of job names
+::
+
+    autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_sim <EXPID>_20111101_fc4_26_sim" -t READY -s
+
+* ``-fc``: chunk/section/split filter (JSON-like format, takes precedence over legacy filters)
+::
+
+    autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc1 [1] ] ]" -t READY -s
+
+* ``-fs``: space-separated job statuses. The available statuses are: ``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``FAILED``, and ``UNKNOWN``.
+::
+
+    autosubmit setstatus <EXPID> -fs FAILED -t READY -s
+
+* ``-ft``: space-separated job types
+::
+
+    autosubmit setstatus <EXPID> -ft TRANSFER -t SUSPENDED -s
+
+* ``-ftc``: **[DEPRECATED]** legacy chunk/type filter (use a combination of ``-fc`` and ``-ft`` instead).
+Command:
+::
+
+    autosubmit setstatus <EXPID> -ftc "[ 19601101 [ fc0 [1 2 3 4] ] ],SIM" -t READY -s
+
+Can be replaced with:
+::
+
+    autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc0 [1 2 3 4] ] ]" -ft SIM -t READY -s
+
+* ``-ftcs``: **[DEPRECATED]** legacy chunk/type/split filter (use a combination of ``-fc`` and ``-ft`` instead).
+Command:
+::
+
+    autosubmit setstatus <EXPID> -ftcs "[ 19601101 [ fc0 [1 2 3 4] ] ],SIM,1" -t READY -s
+
+Can be replaced with:
+::
+
+    autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc0 [1 2 3 4] ] ]" -ft SIM -t READY -s
 
 Options:
 
 .. runcmd:: autosubmit setstatus -h
 
-Examples:
+Filter precedence (when multiple chunk filters are specified):
+
+When ``-fc``, ``-ftc``, and ``-ftcs`` are combined, precedence is: ``-fc`` → ``-ftc`` → ``-ftcs``. A warning will be logged if multiple chunk filters are detected.
+
+Filter Examples
+~~~~~~~~~~~~~~~
+
+Single filter, by job list:
 ::
 
     autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_sim <EXPID>_20111101_fc4_26_sim" -t READY -s
+
+Single filter, by chunk/section/split:
+::
+
     autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc1 [1] ] ]" -t READY -s
+
+Single filter, by current status:
+::
+
     autosubmit setstatus <EXPID> -fs FAILED -t READY -s
+
+Single filter, by job type:
+::
+
     autosubmit setstatus <EXPID> -ft TRANSFER -t SUSPENDED -s
-    autosubmit setstatus <EXPID> -ftc "[ 19601101 [ fc1 [1] ] ], SIM" -t SUSPENDED -s
+
+Multiple filters combined (AND logic, selects jobs matching ALL filters):
+::
+
+    autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc1 [1] ] ]" -ft "SIM" -t SUSPENDED -s
+
+This selects jobs that are in both the chunk filter AND have type "SIM".
+
+Chunk/Section/Split Filter Details
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Format:
+::
+
+    [ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]
 
 Date (month) range example:
 ::
 
-    autosubmit setstatus <EXPID> -ftc "[ 1960(1101-1201) [ fc1 [1] ] ], SIM" -t SUSPENDED -s
+    autosubmit setstatus <EXPID> -fc "[ 1960(1101-1201) [ fc1 [1] ] ]" -ft "SIM" -t SUSPENDED -s
 
-This example will result changing the following jobs:
+Result:
 ::
 
     <EXPID>_19601101_fc1_1_SIM
     <EXPID>_19601201_fc1_1_SIM
 
+
 Date (day) range example:
 ::
-
-    autosubmit setstatus <EXPID> -ftc "[ 1960(1101-1105) [ fc1 [1] ] ], SIM" -t SUSPENDED -s
-
+    autosubmit setstatus <EXPID> -fc "[ 1960(1101-1105) [ fc1 [1] ] ]" -ft "SIM" -t SUSPENDED -s
 Result:
 ::
-
     <EXPID>_19601101_fc1_1_SIM
     <EXPID>_19601102_fc1_1_SIM
     <EXPID>_19601103_fc1_1_SIM
     <EXPID>_19601104_fc1_1_SIM
     <EXPID>_19601105_fc1_1_SIM
 
-This script has two mandatory arguments.
+Using the "Any" Keyword
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-The -t where you must specify the target status of the jobs you want to change to:
+The keyword ``Any`` (case-insensitive) means "no restriction" in that filter:
+
+* ``-fl Any``: all jobs (no job list restriction)
+* ``-fs Any``: all job statuses (no status restriction)
+* ``-ft Any``: all job types (no type restriction)
+
+Example:
 ::
 
-    {READY,COMPLETED,WAITING,SUSPENDED,FAILED,UNKNOWN}
+    autosubmit setstatus <EXPID> -fs Any -fc "[ 19601101 [ fc1 [1] ] ]" -t READY -s
 
+This changes all jobs in the chunk filter to ``READY``, regardless of their current status.
 
-The second argument has four alternatives, the -fl, -fc, -fs and -ft; with those we can apply a filter for the jobs we want to change:
+Deprecated Filters
+~~~~~~~~~~~~~~~~~~~
 
-* The -fl variable receives a list of job names separated by blank spaces: e.g.:
-    ::
+.. warning:: The ``-ftc`` and ``-ftcs`` filters are deprecated and will be removed in future versions. Use ``-fc`` instead.
 
-     "<EXPID>_20101101_fc3_21_sim <EXPID>_20111101_fc4_26_sim"
+``-ftc`` (deprecated) is similar to ``-fc`` but also accepts job types without separate ``-ft``:
+::
 
-If we supply the key word "Any", all jobs will be changed to the target status.
+    autosubmit setstatus <EXPID> -ftc "[ 19601101 [ fc0 [1 2 3 4] ] ],SIM" -t READY -s
 
-* The variable -fc should be a list of individual chunks or ranges of chunks in the following format:
-    ::
+Use ``-fc`` with ``-ft`` instead:
+::
 
-        [ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]
+    autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc0 [1 2 3 4] ] ]" -ft SIM -t READY -s
 
-* The variable -fs can be the following status for job:
-    ::
-
-        {Any,READY,COMPLETED,WAITING,SUSPENDED,FAILED,UNKNOWN}
-
-* The variable -ft can be one of the defined types of job.
-
-The variable -ftc acts similar to -fc but also accepts the job types. It does not accept chunk ranges e.g. "1-10", but accepts the wildcard "Any" for members and job types. Let's look at some examples.
-
-* Using -ftc to change the chunks "1 2 3 4" of member "fc0" and chunk "1" of member "fc1" for the starting date "19601101", where these changes apply only for the "SIM" jobs:
-    ::
-
-        [ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] ],SIM
-
-* Using -ftc to change the chunks "1 2 3 4" of all members for the starting date "19601101", where these changes apply only for the "SIM" jobs:
-    ::
-
-        [ 19601101 [ Any [1 2 3 4] ] ],SIM
-
-* Using -ftc to change the chunks "1 2 3 4" of "fc0" members for the starting date "19601101", where these changes apply to all jobs:
-    ::
-
-        [ 19601101 [ fc0 [1 2 3 4] ] ],Any
-
-Try the combinations you come up with. Autosubmit will supply with proper feedback when a wrong combination is supplied.
-
-.. hint:: When we are satisfied with the results we can use the parameter -s, which will save the change to the pkl file. In order to understand more the grouping options, which are used for visualization purposes, please check :ref:`grouping`.
-
+.. hint:: When satisfied with your filter selections, use the parameter ``-s`` to save changes to the pkl file. In order to understand more the grouping options, which are used for visualization purposes, please check :ref:`grouping`.
 .. _setstatusno:
 
 How to change the job status without stopping autosubmit

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -17,7 +17,9 @@
 
 
 from autosubmit.config.basicconfig import BasicConfig
-from autosubmit.history.database_managers.experiment_history_db_manager import SqlAlchemyExperimentHistoryDbManager
+from autosubmit.history.database_managers.experiment_history_db_manager import (
+    SqlAlchemyExperimentHistoryDbManager,
+)
 from autosubmit.job.job_common import Status
 import pytest
 
@@ -32,14 +34,17 @@ def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
 
 def reset(as_exp_, target="WAITING"):
     job_list_ = as_exp_.autosubmit.load_job_list(
-        as_exp_.expid, as_exp_.as_conf, new=False)
+        as_exp_.expid, as_exp_.as_conf, new=False
+    )
 
     job_names = " ".join([job.name for job in job_list_.get_job_list()])
     do_setstatus(as_exp_, fl=job_names, target=target)
     return job_list_
 
 
-def do_setstatus(as_exp_, fl=None, fc=None, fct=None, ftcs=None, fs=None, ft=None, target="WAITING"):
+def do_setstatus(
+    as_exp_, fl=None, fc=None, fct=None, ftcs=None, fs=None, ft=None, target="WAITING"
+):
     target = target.upper()
     as_exp_.autosubmit.set_status(
         as_exp_.expid,
@@ -57,19 +62,22 @@ def do_setstatus(as_exp_, fl=None, fc=None, fct=None, ftcs=None, fs=None, ft=Non
         expand=[],
         expand_status=[],
         check_wrapper=False,
-        detail=False
+        detail=False,
     )
-    return as_exp_.autosubmit.load_job_list(
-        as_exp_.expid, as_exp_.as_conf, new=False)
+    return as_exp_.autosubmit.load_job_list(as_exp_.expid, as_exp_.as_conf, new=False)
 
 
 @pytest.mark.docker
 @pytest.mark.ssh
 @pytest.mark.slurm
-@pytest.mark.parametrize("reset_target", ["RUNNING", "WAITING"], ids=["Online", "Offline"])
+@pytest.mark.parametrize(
+    "reset_target", ["RUNNING", "WAITING"], ids=["Online", "Offline"]
+)
 def test_set_status(as_exp, slurm_server, reset_target):
     """Tests the setstatus command with various filters in an offline scenario."""
-    db_manager = SqlAlchemyExperimentHistoryDbManager(as_exp.expid, BasicConfig.JOBDATA_DIR, f'job_data_{as_exp.expid}.db')
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
     db_manager.initialize()
     fl_filter_names = f"{as_exp.expid}_20200101_fc0_1_1_LOCALJOB {as_exp.expid}_20200101_fc0_1_1_PSJOB {as_exp.expid}_20200101_fc0_1_1_SLURMJOB"
     fc_filter = "[20200101 [ fc0 [1] ] ]"
@@ -80,27 +88,49 @@ def test_set_status(as_exp, slurm_server, reset_target):
     target = "COMPLETED"
 
     job_list_ = do_setstatus(as_exp, fl=fl_filter_names, target=target)
-    completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED and job.name in fl_filter_names]
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.name in fl_filter_names
+    ]
     assert len(completed_jobs) == 3
     reset(as_exp, reset_target)
 
     job_list_ = do_setstatus(as_exp, fc=fc_filter, target=target)
-    completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED and job.chunk == 1]
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.chunk == 1
+    ]
     assert len(completed_jobs) == 9
     reset(as_exp, reset_target)
 
     job_list_ = do_setstatus(as_exp, fct=fct_filter, target=target)
-    completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED and job.section == "LOCALJOB"]
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.section == "LOCALJOB"
+    ]
     assert len(completed_jobs) == 3
     reset(as_exp, reset_target)
 
     job_list_ = do_setstatus(as_exp, ftcs=ftcs_filter, target=target)
-    completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED and job.split == 2 and job.section == "LOCALJOB"]
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED
+        and job.split == 2
+        and job.section == "LOCALJOB"
+    ]
     assert len(completed_jobs) == 1
     reset(as_exp, reset_target)
 
     job_list_ = do_setstatus(as_exp, ft=ft_filter, target=target)
-    completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED and job.section == "LOCALJOB"]
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.section == "LOCALJOB"
+    ]
     assert len(completed_jobs) == 24
     reset(as_exp, reset_target)
 
@@ -109,7 +139,11 @@ def test_set_status(as_exp, slurm_server, reset_target):
             do_setstatus(as_exp, fs=fs, target=target)
     else:
         job_list_ = do_setstatus(as_exp, fs=fs, target=target)
-        completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED
+        ]
         assert len(completed_jobs) == len(job_list_.get_job_list())
 
 
@@ -212,14 +246,19 @@ def test_set_status_multiple_chunk_filters_priority(
         completed_jobs = [
             job.name
             for job in job_list_.get_job_list()
-            if job.status == Status.COMPLETED and job.section == "LOCALJOB" and job.chunk == 1
+            if job.status == Status.COMPLETED
+            and job.section == "LOCALJOB"
+            and job.chunk == 1
         ]
     # highest priority is filter by chunk split section
     elif expected_selector == "ftcs_specific":
         completed_jobs = [
             job.name
             for job in job_list_.get_job_list()
-            if job.status == Status.COMPLETED and job.section == "LOCALJOB" and job.chunk == 1 and job.split == 1
+            if job.status == Status.COMPLETED
+            and job.section == "LOCALJOB"
+            and job.chunk == 1
+            and job.split == 1
         ]
 
     # assertions
@@ -234,7 +273,7 @@ def test_set_status_multiple_chunk_filters_priority(
         assert any(
             "Multiple chunk filters provided" in message for message in warning_messages
         )
-    
+
     # If any deprecated filters are used, check deprecation warnings are raised.
     if "fct" in setstatus_kwargs:
         assert any(
@@ -265,8 +304,7 @@ def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
     )
 
     completed_jobs = [
-        job for job in job_list_.get_job_list()
-        if job.status == Status.COMPLETED
+        job for job in job_list_.get_job_list() if job.status == Status.COMPLETED
     ]
     assert len(completed_jobs) == 9
 
@@ -310,7 +348,9 @@ def test_set_status_combined_any_tokens_do_nothing(as_exp):
         target="COMPLETED",
     )
 
-    completed_jobs = [job for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
+    completed_jobs = [
+        job for job in job_list_.get_job_list() if job.status == Status.COMPLETED
+    ]
     assert len(completed_jobs) == len(job_list_.get_job_list())
 
 
@@ -364,7 +404,6 @@ def test_set_status_combined_any_tokens_do_nothing(as_exp):
         ("[ Any [ fc0 [Any] ] ]", 36),
         ("[ Any [ fc0 [Any] fc1 [Any] ] ]", 72),
         ("[ Any [ fc0 [Any] fc1 [Any] ] 20200102 [ fc0 [Any] fc1 [Any] ] ]", 72),
-
         # Good ones // Testing sections and splits
         ("[20200101 [ fc0 [1] ] ],LOCALJOB", 3),
         ("[20200101 [ fc0 [1] ] ],Any", 9),
@@ -376,7 +415,6 @@ def test_set_status_combined_any_tokens_do_nothing(as_exp):
         ("[20200101 [ fc0 [1] ] ],Any [1:2]", 6),
         ("[20200101 [ fc0 [1] ] ],Any [Any]", 9),
         ("[20200101 [ fc0 [1] ] ],Any []", 9),
-
     ],
 )
 def test_set_status_ftcs(as_exp: object, ftcs_filter: str, expected_jobs: int):
@@ -396,7 +434,9 @@ def test_set_status_ftcs(as_exp: object, ftcs_filter: str, expected_jobs: int):
     :type expected_jobs: int
     """
 
-    db_manager = SqlAlchemyExperimentHistoryDbManager(as_exp.expid, BasicConfig.JOBDATA_DIR, f'job_data_{as_exp.expid}.db')
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
     db_manager.initialize()
     target = "COMPLETED"
 
@@ -407,7 +447,11 @@ def test_set_status_ftcs(as_exp: object, ftcs_filter: str, expected_jobs: int):
         print(validation_err.value)
     else:
         job_list_ = do_setstatus(as_exp, fc=ftcs_filter, target=target)
-        completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED
+        ]
         assert len(completed_jobs) == expected_jobs
 
     reset(as_exp, "WAITING")
@@ -418,7 +462,11 @@ def test_set_status_ftcs(as_exp: object, ftcs_filter: str, expected_jobs: int):
         print(validation_err.value)
     else:
         job_list_ = do_setstatus(as_exp, fct=ftcs_filter, target=target)
-        completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED
+        ]
         assert len(completed_jobs) == expected_jobs
 
     reset(as_exp, "WAITING")
@@ -429,5 +477,9 @@ def test_set_status_ftcs(as_exp: object, ftcs_filter: str, expected_jobs: int):
         print(validation_err.value)
     else:
         job_list_ = do_setstatus(as_exp, ftcs=ftcs_filter, target=target)
-        completed_jobs = [job.name for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED
+        ]
         assert len(completed_jobs) == expected_jobs

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -140,13 +140,53 @@ def test_set_status_combined_filters(as_exp):
         job.name for job in job_list.get_job_list() if job.status == Status.COMPLETED
     ]
 
+    # assert
     assert target_job in completed_jobs
     assert no_matching_job not in completed_jobs
     assert len(completed_jobs) == 1
 
 
-def test_set_status_multiple_chunk_filters_set_warning(as_exp, mocker):
-    """Test that a warning is raised when multiple chunk filters are used, as they do the same."""
+@pytest.mark.parametrize(
+    "setstatus_kwargs, expected_jobs, expected_selector, expect_multiple_filters_warning",
+    [
+        pytest.param(
+            {
+                "fc": "[20200101 [ fc0 [1] ] ]",
+                "fct": "[20200101 [ fc0 [1] ] ],LOCALJOB",
+                "ftcs": "[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
+            },
+            9,
+            "chunk",
+            True,
+        ),
+        pytest.param(
+            {
+                "fct": "[20200101 [ fc0 [1] ] ],LOCALJOB",
+                "ftcs": "[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
+            },
+            3,
+            "legacy_chunk",
+            True,
+        ),
+        pytest.param(
+            {
+                "ftcs": "[20200101 [ Any [1] ] ],LOCALJOB [1]",
+            },
+            2,
+            "ftcs_specific",
+            False,
+        ),
+    ],
+)
+def test_set_status_multiple_chunk_filters_priority(
+    as_exp,
+    mocker,
+    setstatus_kwargs,
+    expected_jobs,
+    expected_selector,
+    expect_multiple_filters_warning,
+):
+    """Test that when multiple chunk filters are used, the one with the highest priority is applied."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )
@@ -157,110 +197,55 @@ def test_set_status_multiple_chunk_filters_set_warning(as_exp, mocker):
 
     job_list_ = do_setstatus(
         as_exp,
-        fc="[20200101 [ fc0 [1] ] ]",
-        fct="[20200101 [ fc0 [1] ] ],LOCALJOB",
-        ftcs="[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
         target="COMPLETED",
+        **setstatus_kwargs,
     )
+    # highest priority is filter by chunk
+    if expected_selector == "chunk":
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED and job.chunk == 1
+        ]
+    # highest priority is filter by chunk split
+    elif expected_selector == "legacy_chunk":
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED and job.section == "LOCALJOB" and job.chunk == 1
+        ]
+    # highest priority is filter by chunk split section
+    elif expected_selector == "ftcs_specific":
+        completed_jobs = [
+            job.name
+            for job in job_list_.get_job_list()
+            if job.status == Status.COMPLETED and job.section == "LOCALJOB" and job.chunk == 1 and job.split == 1
+        ]
 
-    # -fc precedence over the other chunk filters
-    completed_jobs = [
-        job.name
-        for job in job_list_.get_job_list()
-        if job.status == Status.COMPLETED and job.chunk == 1
-    ]
-
-    assert len(completed_jobs) == 9
+    # assertions
+    assert len(completed_jobs) == expected_jobs
 
     warning_messages = [
         str(call.args[0]) for call in mocked_warning.call_args_list if call.args
     ]
-    assert any(
-        "Multiple chunk filters provided" in message for message in warning_messages
-    )
 
-
-def test_set_status_multiple_legacy_chunk_filters_precedence(as_exp, mocker):
-    """When only legacy chunk filters overlap, ``-ftc`` should take precedence over ``-ftcs``."""
-    db_manager = SqlAlchemyExperimentHistoryDbManager(
-        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
-    )
-    db_manager.initialize()
-
-    reset(as_exp, "WAITING")
-    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
-
-    job_list_ = do_setstatus(
-        as_exp,
-        fct="[20200101 [ fc0 [1] ] ],LOCALJOB",
-        ftcs="[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
-        target="COMPLETED",
-    )
-
-    # ``-ftc`` should be used before ``-ftcs`` when ``-fc`` is not provided.
-    completed_jobs = [
-        job.name
-        for job in job_list_.get_job_list()
-        if job.status == Status.COMPLETED and job.section == "LOCALJOB" and job.chunk == 1
-    ]
-    assert len(completed_jobs) == 3
-
-    warning_messages = [
-        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
-    ]
-    assert any(
-        "Multiple chunk filters provided" in message for message in warning_messages
-    )
-
-
-def test_set_status_legacy_filter_type_chunk_logs_deprecation_warning(as_exp, mocker):
-    """Legacy ``-ftc`` usage should log its deprecation warning."""
-    db_manager = SqlAlchemyExperimentHistoryDbManager(
-        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
-    )
-    db_manager.initialize()
-
-    reset(as_exp, "WAITING")
-    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
-
-    do_setstatus(
-        as_exp,
-        fct="[20200101 [ fc0 [1] ] ],LOCALJOB",
-        target="COMPLETED",
-    )
-
-    warning_messages = [
-        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
-    ]
-    assert any(
-        "--filter_type_chunk is deprecated" in message
-        for message in warning_messages
-    )
-
-
-def test_set_status_legacy_filter_type_chunk_split_logs_deprecation_warning(as_exp, mocker):
-    """Legacy ``-ftcs`` usage should log its deprecation warning."""
-    db_manager = SqlAlchemyExperimentHistoryDbManager(
-        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
-    )
-    db_manager.initialize()
-
-    reset(as_exp, "WAITING")
-    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
-
-    do_setstatus(
-        as_exp,
-        ftcs="[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
-        target="COMPLETED",
-    )
-
-    warning_messages = [
-        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
-    ]
-    assert any(
-        "--filter_type_chunk_split is deprecated" in message
-        for message in warning_messages
-    )
+    # If at least 2 chunk filters are provided, check warning for overlapping chunk filters.
+    if expect_multiple_filters_warning:
+        assert any(
+            "Multiple chunk filters provided" in message for message in warning_messages
+        )
+    
+    # If any deprecated filters are used, check deprecation warnings are raised.
+    if "fct" in setstatus_kwargs:
+        assert any(
+            "--filter_type_chunk is deprecated" in message
+            for message in warning_messages
+        )
+    if "ftcs" in setstatus_kwargs:
+        assert any(
+            "--filter_type_chunk_split is deprecated" in message
+            for message in warning_messages
+        )
 
 
 def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
@@ -308,7 +293,7 @@ def test_set_status_invalid_job_in_list_raises_validation_error(as_exp):
         )
 
 
-def test_set_status_combined_any_tokens_are_noop(as_exp):
+def test_set_status_combined_any_tokens_do_nothing(as_exp):
     """Any tokens in -ft, -fs and -fl should not restrict selection when used together."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -179,6 +179,82 @@ def test_set_status_multiple_chunk_filters_set_warning(as_exp, mocker):
     )
 
 
+def test_set_status_multiple_legacy_chunk_filters_precedence(as_exp, mocker):
+    """When only legacy chunk filters overlap, ``-ftc`` should take precedence over ``-ftcs``."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        fct="[20200101 [ fc0 [1] ] ],LOCALJOB",
+        ftcs="[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
+        target="COMPLETED",
+    )
+
+    # ``-ftc`` should be used before ``-ftcs`` when ``-fc`` is not provided.
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.section == "LOCALJOB" and job.chunk == 1
+    ]
+    assert len(completed_jobs) == 3
+
+    warning_messages = [
+        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
+    ]
+    assert any(
+        "Multiple chunk filters provided" in message for message in warning_messages
+    )
+
+
+def test_set_status_invalid_job_in_list_raises_validation_error(as_exp):
+    """Invalid job IDs in ``-fl`` must fail validation without bypassing validators."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    valid_job = f"{as_exp.expid}_20200101_fc0_1_1_LOCALJOB"
+    invalid_expid_job = "9999_20200101_fc0_1_1_LOCALJOB"
+    filter_list = f"{valid_job} {invalid_expid_job}"
+
+    with pytest.raises(AutosubmitCritical):
+        do_setstatus(
+            as_exp,
+            fl=filter_list,
+            fs="WAITING",
+            target="COMPLETED",
+        )
+
+
+def test_set_status_combined_any_tokens_are_noop(as_exp):
+    """Any tokens in -ft, -fs and -fl should not restrict selection when used together."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        fl="Any",
+        fs="Any",
+        ft="Any",
+        target="COMPLETED",
+    )
+
+    completed_jobs = [job for job in job_list_.get_job_list() if job.status == Status.COMPLETED]
+    assert len(completed_jobs) == len(job_list_.get_job_list())
+
+
 @pytest.mark.parametrize(
     "ftcs_filter, expected_jobs",
     [

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -213,6 +213,79 @@ def test_set_status_multiple_legacy_chunk_filters_precedence(as_exp, mocker):
     )
 
 
+def test_set_status_legacy_filter_type_chunk_logs_deprecation_warning(as_exp, mocker):
+    """Legacy ``-ftc`` usage should log its deprecation warning."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
+
+    do_setstatus(
+        as_exp,
+        fct="[20200101 [ fc0 [1] ] ],LOCALJOB",
+        target="COMPLETED",
+    )
+
+    warning_messages = [
+        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
+    ]
+    assert any(
+        "--filter_type_chunk is deprecated" in message
+        for message in warning_messages
+    )
+
+
+def test_set_status_legacy_filter_type_chunk_split_logs_deprecation_warning(as_exp, mocker):
+    """Legacy ``-ftcs`` usage should log its deprecation warning."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
+
+    do_setstatus(
+        as_exp,
+        ftcs="[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
+        target="COMPLETED",
+    )
+
+    warning_messages = [
+        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
+    ]
+    assert any(
+        "--filter_type_chunk_split is deprecated" in message
+        for message in warning_messages
+    )
+
+
+def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
+    """When ``-ft Any`` is combined with chunk filtering, section filtering must be a no-op."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        fc="[20200101 [ fc0 [1] ] ]",
+        ft="Any",
+        target="COMPLETED",
+    )
+
+    completed_jobs = [
+        job for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED
+    ]
+    assert len(completed_jobs) == 9
+
+
 def test_set_status_invalid_job_in_list_raises_validation_error(as_exp):
     """Invalid job IDs in ``-fl`` must fail validation without bypassing validators."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -169,6 +169,7 @@ def test_set_status_multiple_chunk_filters_set_warning(as_exp, mocker):
         for job in job_list_.get_job_list()
         if job.status == Status.COMPLETED and job.chunk == 1
     ]
+
     assert len(completed_jobs) == 9
 
     warning_messages = [

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -113,6 +113,72 @@ def test_set_status(as_exp, slurm_server, reset_target):
         assert len(completed_jobs) == len(job_list_.get_job_list())
 
 
+def test_set_status_combined_filters(as_exp):
+    """Test setstatus when multiple filters are used, selected jobs must match the intersection of the filters."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    # reset all the jobs to waiting
+    reset(as_exp, "WAITING")
+
+    # define filters to match only one job
+    target_job = f"{as_exp.expid}_20200101_fc0_1_1_LOCALJOB"
+    no_matching_job = f"{as_exp.expid}_20200101_fc0_1_1_PSJOB"
+    filter_list = f"{target_job} {no_matching_job}"
+
+    job_list = do_setstatus(
+        as_exp,
+        fl=filter_list,
+        fc="[20200101 [ fc0 [1] ] ]",  # force the intersection to be the target job
+        ft="LOCALJOB",
+        target="COMPLETED",
+    )
+
+    completed_jobs = [
+        job.name for job in job_list.get_job_list() if job.status == Status.COMPLETED
+    ]
+
+    assert target_job in completed_jobs
+    assert no_matching_job not in completed_jobs
+    assert len(completed_jobs) == 1
+
+
+def test_set_status_multiple_chunk_filters_set_warning(as_exp, mocker):
+    """Test that a warning is raised when multiple chunk filters are used, as they do the same."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        fc="[20200101 [ fc0 [1] ] ]",
+        fct="[20200101 [ fc0 [1] ] ],LOCALJOB",
+        ftcs="[20200101 [ fc0 [1] ] ],LOCALJOB [2]",
+        target="COMPLETED",
+    )
+
+    # -fc precedence over the other chunk filters
+    completed_jobs = [
+        job.name
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.chunk == 1
+    ]
+    assert len(completed_jobs) == 9
+
+    warning_messages = [
+        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
+    ]
+    assert any(
+        "Multiple chunk filters provided" in message for message in warning_messages
+    )
+
+
 @pytest.mark.parametrize(
     "ftcs_filter, expected_jobs",
     [

--- a/test/unit/test_commands.py
+++ b/test/unit/test_commands.py
@@ -64,3 +64,33 @@ def test_exceptions_raised(exception: BaseException, raised: BaseException, stat
         assert status
         status_returned, _ = Autosubmit.parse_args()
         assert status_returned == status
+
+
+def test_setstatus_accepts_combined_filters(mocker):
+    """Test that the combined ``setstatus`` filters should parse correctly."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "autosubmit",
+            "setstatus",
+            "a000",
+            "-fl",
+            "a000_20200101_fc0_1_1_LOCALJOB",
+            "-fc",
+            "[20200101 [ fc0 [1] ] ]",
+            "-ft",
+            "LOCALJOB",
+            "-fs",
+            "WAITING",
+            "-t",
+            "READY",
+        ],
+    )
+    status, args = Autosubmit.parse_args()
+
+    assert status == 0
+    assert args.command == "setstatus"
+    assert args.list == "a000_20200101_fc0_1_1_LOCALJOB"
+    assert args.filter_chunks == "[20200101 [ fc0 [1] ] ]"
+    assert args.filter_type == "LOCALJOB"
+    assert args.filter_status == "WAITING"


### PR DESCRIPTION
Closes #1250

**Things done:** 
- Modified the ```parse_args()``` method in ```autosubmit.py``` to accept multiple arguments for subparser setstatus. Deleted restriction of just one filter. Added [Deprecation] substring in helpers of -ftc and -ftcs.
- In ```set_status``` method, added warnings when user selects multiple filters related to chunks (will be treated with priority) and when a deprecated filter is selected.
- Updated all the os.path to Path
- When multiple filters selected, intersect the job names of the filtered jobs to obtain the final jobs to change status. Filters now work as ```AND``` operations (could implement ```OR``` in future versions, depending on the needs)
- Updated documentation for setstatus command
- Added integration tests in test_set_status
- No unit tests created for set_status, no implementation seen and very difficult to set it up (need to mock a lot of things)

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
