### PR TITLE
feat: update wallclock truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Accept local/intranet email addresses in validation #1471
 - Set PROJECT_TYPE, PROJECT_DESTINATION and CUSTOM_CONFIG for experiments without minimal configuration #2864
 - Added priority and retro-compatibility for etc/autosubmitrc over etc/.autosubmitrc #2312
+- Updated Slurm wallclock truncation, allowing users to use e.g., 01:00:00 correctly #2059
 
 **Enhancements:**
 

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -655,11 +655,11 @@ class AutosubmitConfig(object):
         """
         for job in data_fixed.get("JOBS", {}):
             wallclock = data_fixed["JOBS"][job].get("WALLCLOCK", "")
-            if wallclock and re.match(r'^\d{2}:\d{2}:\d{2}$', wallclock):
+            if wallclock and re.match(r'^\d{1,2}:\d{2}:\d{2}$', wallclock):
                 # Truncate SS to "HH:MM"
                 Log.warning(
                     f"Wallclock {wallclock} is in HH:MM:SS format. Autosubmit does not support the seconds. Truncating to HH:MM")
-                data_fixed["JOBS"][job]["WALLCLOCK"] = wallclock[:5]
+                data_fixed["JOBS"][job]["WALLCLOCK"] = ":".join(wallclock.split(":")[:2])
 
     @staticmethod
     def _normalize_dependencies(dependencies: Union[str, dict]) -> dict:

--- a/test/unit/config/test_normalize_variables.py
+++ b/test/unit/config/test_normalize_variables.py
@@ -414,6 +414,50 @@ from autosubmit.log.log import AutosubmitCritical
             True,
             id="wallclock"
         ),
+        pytest.param(
+            {
+                "JOBS": {
+                    "job1": {
+                        "FILE": "FILE1",
+                        "WALLCLOCK": "1:00:00"
+                    }
+                }
+            },
+            {
+                'JOBS': {
+                    'JOB1': {
+                        'FILE': 'FILE1',
+                        'ADDITIONAL_FILES': [],
+                        'DEPENDENCIES': {},
+                        'WALLCLOCK': "1:00",
+                    },
+                }
+            },
+            True,
+            id="wallclock_single_digit_hour"
+        ),
+        pytest.param(
+            {
+                "JOBS": {
+                    "job1": {
+                        "FILE": "FILE1",
+                        "WALLCLOCK": "9:30:45"
+                    }
+                }
+            },
+            {
+                'JOBS': {
+                    'JOB1': {
+                        'FILE': 'FILE1',
+                        'ADDITIONAL_FILES': [],
+                        'DEPENDENCIES': {},
+                        'WALLCLOCK': "9:30",
+                    },
+                }
+            },
+            True,
+            id="wallclock_single_digit_hour_non_zero_seconds"
+        ),
     ]
 )
 def test_normalize_variables(autosubmit_config, data, expected_data, must_exists):


### PR DESCRIPTION
Closes #2059 

This change:
- accepts single or double digit hours so that the slicing doesn’t pick up a `:` when hour is single digit
- instead of slicing, split by colon and always take the first two indices, hours and minutes, which is a little less fragile.
- add tests cases

(I know this one is old, but it’s listed as a Good First Issue and seemed small enough. Hope its still useful.)

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
