### PR TITLE
fix: log trace at CRITICAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Set PROJECT_TYPE, PROJECT_DESTINATION and CUSTOM_CONFIG for experiments without minimal configuration #2864
 - Added priority and retro-compatibility for etc/autosubmitrc over etc/.autosubmitrc #2312
 - Updated Slurm wallclock truncation, allowing users to use e.g., 01:00:00 correctly #2059
+- Fixed exception trace in AutosubmitCritical and AutosubmitError not being displayed to the user #2109
 
 **Enhancements:**
 

--- a/autosubmit/scripts/autosubmit.py
+++ b/autosubmit/scripts/autosubmit.py
@@ -48,10 +48,8 @@ def delete_lock_file(base_path: str = Log.file_path, lock_file: str = 'autosubmi
 def exit_from_error(e: BaseException) -> int:
     """Called by ``Autosubmit`` when an exception is raised during a command execution.
 
-    Prints the exception in ``DEBUG`` level.
-
     Prints the exception in ``CRITICAL`` if is it an ``AutosubmitCritical`` or an
-    ``AutosubmitError`` exception.
+    ``AutosubmitError`` exception, including any trace attached to the exception.
 
     Exceptions raised by ``porta-locker` library print a message informing the user
     about the locked experiment. Other exceptions raised cause the lock to be deleted.
@@ -82,7 +80,7 @@ def exit_from_error(e: BaseException) -> int:
     if is_autosubmit_error:
         e: Union[AutosubmitError, AutosubmitCritical] = e
         if e.trace:
-            Log.debug("Trace: {0}", str(e.trace))
+            Log.critical("Trace: {0}", str(e.trace))
         Log.critical("{1} [eCode={0}]", e.code, e.message)
         err_code = e.code
 

--- a/test/unit/test_lockfile.py
+++ b/test/unit/test_lockfile.py
@@ -63,7 +63,7 @@ _TEST_EXCEPTION.trace = 'a trace'
         (ValueError, 0, 2, True),
         (BaseLockException, 0, 1, False),
         (AutosubmitCritical, 0, 2, True),
-        (_TEST_EXCEPTION, 1, 2, True),
+        (_TEST_EXCEPTION, 0, 3, True),
         (AutosubmitError, 0, 2, True)
     ],
     ids=[


### PR DESCRIPTION
Closes #2109 

When an `AutosubmitCritical` or `AutosubmitError` exception carries a `.trace`, `exit_from_error` was logging it with Log.debug(…) and the trace output was silently swallowed due to the log level being lower than the console default. This change sets the log level to critical so that the trace info is logged to the console.

Updated the corresponding test to expect 0 debug calls and 3 critical calls when an exception with a trace is handled.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
