### PR TITLE
Allow definining jobs.yml RUNNING parameter as 'ONCE' uppercase without throwing autosubmit critical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added priority and retro-compatibility for etc/autosubmitrc over etc/.autosubmitrc #2312
 - Updated Slurm wallclock truncation, allowing users to use e.g., 01:00:00 correctly #2059
 - Fixed exception trace in AutosubmitCritical and AutosubmitError not being displayed to the user #2109
+- Fix `Jobs.running` to case-insensitive #2916
 
 **Enhancements:**
 

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1968,7 +1968,7 @@ class Job(object):
             self.splits = as_conf.jobs_data.get(self.section, {}).get("SPLITS", None)
         self.delete_when_edgeless = as_conf.jobs_data.get(self.section, {}).get("DELETE_WHEN_EDGELESS", True)
         self.dependencies = str(as_conf.jobs_data.get(self.section, {}).get("DEPENDENCIES", ""))
-        self.running = as_conf.jobs_data.get(self.section, {}).get("RUNNING", "once")
+        self.running = str(as_conf.jobs_data.get(self.section, {}).get("RUNNING", "once")).lower()
         self.platform_name = as_conf.jobs_data.get(self.section, {}).get("PLATFORM",
                                                                          as_conf.experiment_data.get("DEFAULT", {}).get(
                                                                              "HPCARCH", None))

--- a/docs/source/userguide/defining_workflows/code/jobs_splits.yml
+++ b/docs/source/userguide/defining_workflows/code/jobs_splits.yml
@@ -1,22 +1,22 @@
 JOBS:
   INI:
     SCRIPT: 'sleep 0'
-    RUNNING: ONCE
+    RUNNING: once
 
   SIM:
     SCRIPT: 'sleep 0'
     DEPENDENCIES: INI SIM-1
-    RUNNING: ONCE
+    RUNNING: once
 
   ASIM:
     SCRIPT: 'sleep 0'
     DEPENDENCIES: SIM
-    RUNNING: ONCE
+    RUNNING: once
     SPLITS: 3
 
   POST:
     SCRIPT: 'sleep 0'
-    RUNNING: ONCE
+    RUNNING: once
     DEPENDENCIES:
       ASIM:
         SPLITS_FROM:

--- a/docs/source/userguide/defining_workflows/index.rst
+++ b/docs/source/userguide/defining_workflows/index.rst
@@ -530,22 +530,22 @@ There is also an special character '*' that can be used to specify that the spli
     JOBS:
       INI:
         FILE: INI.sh
-        RUNNING: ONCE
+        RUNNING: once
 
       SIM:
         FILE: SIM.sh
         DEPENDENCIES: INI SIM-1
-        RUNNING: ONCE
+        RUNNING: once
 
       ASIM:
         FILE: ASIM.sh
         DEPENDENCIES: SIM
-        RUNNING: ONCE
+        RUNNING: once
         SPLITS: 3
 
       POST:
         FILE: POST.sh
-        RUNNING: ONCE
+        RUNNING: once
         DEPENDENCIES:
           ASIM:
             SPLITS_FROM:

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -2228,18 +2228,13 @@ def test_retrieve_logfiles(local, mocker, output):
     job.retrieve_logfiles()
     assert job.log_recovered
 
+
 def test_case_insensitive_running_parameter(autosubmit_config):
     """Test that the ``running`` parameter is case-insensitive."""
-    as_conf = autosubmit_config(_EXPID, {
-        'JOBS': {
-            'A': {
-                'FILE': 'a',
-                'PLATFORM': 'local',
-                'RUNNING': 'ONCE'
-            }
-        }
-    })
-    job = Job(_EXPID, '1', status=Status.WAITING, priority=0, loaded_data=None)
-    job.section = 'A'
+    as_conf = autosubmit_config(
+        _EXPID, {"JOBS": {"A": {"FILE": "a", "PLATFORM": "local", "RUNNING": "ONCE"}}}
+    )
+    job = Job(_EXPID, "1", status=Status.WAITING, priority=0, loaded_data=None)
+    job.section = "A"
     job.update_dict_parameters(as_conf)
-    assert job.running == 'once'
+    assert job.running == "once"

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -2227,3 +2227,19 @@ def test_retrieve_logfiles(local, mocker, output):
     job.platform.check_file_exists = mocker.MagicMock(return_value=True)
     job.retrieve_logfiles()
     assert job.log_recovered
+
+def test_case_insensitive_running_parameter(autosubmit_config):
+    """Test that the ``running`` parameter is case-insensitive."""
+    as_conf = autosubmit_config(_EXPID, {
+        'JOBS': {
+            'A': {
+                'FILE': 'a',
+                'PLATFORM': 'local',
+                'RUNNING': 'ONCE'
+            }
+        }
+    })
+    job = Job(_EXPID, '1', status=Status.WAITING, priority=0, loaded_data=None)
+    job.section = 'A'
+    job.update_dict_parameters(as_conf)
+    assert job.running == 'once'


### PR DESCRIPTION
Closes #2916 

Normalized `self.running` attribute in Job so that is case-insensitive to `once` vs `ONCE`.
Prevents throwing an AutosubmitCritical error when RUNNING: ONCE.
Changed config files in the documentation to always use lowercase. e.g. `RUNNING: once`

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
