### PR TITLE
Enhancement: Detect inefficiencies in SIM jobs with CPMIPS thresholds - Part 2

### DIFF
--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -87,7 +87,7 @@ EXCLUDED = ["_platform", "_children", "_parents", "submitter"]
             'chunk_first': 'True if the current chunk is the first, false otherwise.',
             'chunk_last': 'True if the current chunk is the last, false otherwise.',
             'run_days': 'Chunk length in days.',
-            'notify_on': 'Determine the job statuses you want to be notified.'
+            'notify_on': 'Determine the job statuses you want to be notified.',
         },
         'config': {
             'config.autosubmit_version': 'Current version of Autosubmit.',
@@ -148,7 +148,7 @@ class Job(object):
         'delete_when_edgeless', 'het', 'updated_log',
         'submit_time_timestamp', 'start_time_timestamp', 'finish_time_timestamp',
         '_script', '_log_recovery_retries', 'ready_date', 'wrapper_name',
-        'is_wrapper', '_wallclock_in_seconds', '_notify_on', '_processors_per_node',
+        'is_wrapper', '_wallclock_in_seconds', '_notify_on', '_cpmip_thresholds', '_chunk_size', '_chunk_size_unit', '_processors_per_node',
         'ec_queue', 'platform_name', '_serial_platform',
         'submitter', '_shape', '_x11', '_x11_options', '_hyperthreading',
         '_scratch_free_space', '_delay_retrials', '_custom_directives',
@@ -282,6 +282,9 @@ class Job(object):
         self.is_wrapper = False
         self._wallclock_in_seconds = None
         self._notify_on = None
+        self._cpmip_thresholds = {}
+        self._chunk_size = None
+        self._chunk_size_unit = None
         self._processors_per_node = None
         self.ec_queue = None
         self.platform_name = None
@@ -342,6 +345,9 @@ class Job(object):
         self.is_wrapper = False
         self._wallclock_in_seconds = None
         self._notify_on = None
+        self._cpmip_thresholds = {}
+        self._chunk_size = None
+        self._chunk_size_unit = None
         self._processors_per_node = None
         self._shape = None
         self._x11 = False
@@ -690,6 +696,36 @@ class Job(object):
     @notify_on.setter
     def notify_on(self, value):
         self._notify_on = value
+
+    @property
+    @autosubmit_parameter(name='cpmip_thresholds')
+    def cpmip_thresholds(self):
+        """Thresholds for CPMIP metrics."""
+        return self._cpmip_thresholds
+
+    @cpmip_thresholds.setter
+    def cpmip_thresholds(self, value):
+        self._cpmip_thresholds = value
+
+    @property
+    @autosubmit_parameter(name='chunk_size')
+    def chunk_size(self):
+        """Chunk size used to compute CPMIP metrics."""
+        return self._chunk_size
+
+    @chunk_size.setter
+    def chunk_size(self, value):
+        self._chunk_size = value
+
+    @property
+    @autosubmit_parameter(name='chunk_size_unit')
+    def chunk_size_unit(self):
+        """Chunk size unit used to compute CPMIP metrics."""
+        return self._chunk_size_unit
+
+    @chunk_size_unit.setter
+    def chunk_size_unit(self, value):
+        self._chunk_size_unit = value
 
     @property
     @autosubmit_parameter(name='validate_template')
@@ -1984,6 +2020,11 @@ class Job(object):
         self.ext_tailer_path = as_conf.jobs_data.get(self.section, {}).get('EXTENDED_TAILER_PATH', None)
         if self.platform_name:
             self.platform_name = self.platform_name.upper()
+        self.cpmip_thresholds = as_conf.jobs_data.get(self.section, {}).get("CPMIP_THRESHOLDS", {})
+        self.chunk_size = as_conf.jobs_data.get(self.section, {}).get("CHUNKSIZE", as_conf.get_chunk_size())
+        self.chunk_size_unit = str(as_conf.jobs_data.get(self.section, {}).get(
+            "CHUNKSIZEUNIT", as_conf.get_chunk_size_unit()
+        )).lower()
 
     def update_check_variables(self, as_conf: AutosubmitConfig) -> None:
         job_data = as_conf.jobs_data.get(self.section, {})

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -87,7 +87,7 @@ EXCLUDED = ["_platform", "_children", "_parents", "submitter"]
             'chunk_first': 'True if the current chunk is the first, false otherwise.',
             'chunk_last': 'True if the current chunk is the last, false otherwise.',
             'run_days': 'Chunk length in days.',
-            'notify_on': 'Determine the job statuses you want to be notified.',
+            'notify_on': 'Determine the job statuses you want to be notified.'
         },
         'config': {
             'config.autosubmit_version': 'Current version of Autosubmit.',

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -282,9 +282,11 @@ class Job(object):
         self.is_wrapper = False
         self._wallclock_in_seconds = None
         self._notify_on = None
-        self._cpmip_thresholds = {}
-        self._chunk_size = None
-        self._chunk_size_unit = None
+        # The three variables under this message are related to the #PR2918 that is a development
+        # focused on adding the key information for computing the simulated years for the CPMIPS metrics.
+        self._cpmip_thresholds = {} 
+        self._chunk_size = None 
+        self._chunk_size_unit = None 
         self._processors_per_node = None
         self.ec_queue = None
         self.platform_name = None
@@ -2020,11 +2022,9 @@ class Job(object):
         self.ext_tailer_path = as_conf.jobs_data.get(self.section, {}).get('EXTENDED_TAILER_PATH', None)
         if self.platform_name:
             self.platform_name = self.platform_name.upper()
-        self.cpmip_thresholds = as_conf.jobs_data.get(self.section, {}).get("CPMIP_THRESHOLDS", {})
-        self.chunk_size = as_conf.jobs_data.get(self.section, {}).get("CHUNKSIZE", as_conf.get_chunk_size())
-        self.chunk_size_unit = str(as_conf.jobs_data.get(self.section, {}).get(
-            "CHUNKSIZEUNIT", as_conf.get_chunk_size_unit()
-        )).lower()
+        self._cpmip_thresholds = as_conf.jobs_data.get(self.section, {}).get("CPMIP_THRESHOLDS", {})
+        self._chunk_size = as_conf.get_chunk_size()
+        self._chunk_size_unit = as_conf.get_chunk_size_unit().lower()
 
     def update_check_variables(self, as_conf: AutosubmitConfig) -> None:
         job_data = as_conf.jobs_data.get(self.section, {})

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -1108,11 +1108,12 @@ def test_recover_last_log_name(tmpdir, test_with_logfiles, file_timestamp_greate
     assert job.local_logs[1] == str(expected_local_logs[1])
 
 
-@pytest.mark.parametrize('experiment_data, attributes_to_check', [(
+@pytest.mark.parametrize('experiment_data, attributes_to_check', [
+    (
         {
             'JOBS': {
                 'RANDOM-SECTION': {
-                    'FILE': "test.sh",
+                    'FILE': 'test.sh',
                     'PLATFORM': 'DUMMY_PLATFORM',
                     'NOTIFY_ON': 'COMPLETED',
                 },
@@ -1127,12 +1128,100 @@ def test_recover_last_log_name(tmpdir, test_with_logfiles, file_timestamp_greate
             'LOCAL_ROOT_DIR': 'dummy_rootdir',
         },
         {'notify_on': ['COMPLETED']}
-)])
+    ),
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'CPMIP_THRESHOLDS': {
+                        'SYPD': {
+                            'THRESHOLD': 5.0,
+                            'COMPARISON': 'greater_than',
+                            '%_ACCEPTED_ERROR': 10,
+                        }
+                    },
+                },
+            },
+        },
+        {
+            'cpmip_thresholds': {
+                'SYPD': {
+                    'THRESHOLD': 5.0,
+                    'COMPARISON': 'greater_than',
+                    '%_ACCEPTED_ERROR': 10,
+                }
+            }
+        }
+    ),
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                },
+            },
+        },
+        {'cpmip_thresholds': {}}
+    ),
+    (
+        {
+            'EXPERIMENT': {
+                'CHUNKSIZE': 3,
+                'CHUNKSIZEUNIT': 'MONTH',
+            },
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                },
+            },
+        },
+        {'chunk_size': 3, 'chunk_size_unit': 'month'}
+    ),
+    (
+        {
+            'EXPERIMENT': {
+                'CHUNKSIZE': 1,
+                'CHUNKSIZEUNIT': 'day',
+            },
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'CHUNKSIZE': 12,
+                    'CHUNKSIZEUNIT': 'HOUR',
+                },
+            },
+        },
+        {'chunk_size': 12, 'chunk_size_unit': 'hour'}
+    ),
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                },
+            },
+        },
+        {'chunk_size': 1, 'chunk_size_unit': ''}
+    ),
+], ids=[
+    'notify_on_attribute',
+    'cpmip_thresholds_from_config',
+    'empty_cpmip_thresholds_when_missing',
+    'chunk_metadata_from_experiment_defaults',
+    'chunk_metadata_with_job_overrides',
+    'chunk_metadata_when_missing',
+])
 def test_update_parameters_attributes(autosubmit_config, experiment_data, attributes_to_check):
     job, _, _ = create_job_and_update_parameters(autosubmit_config, experiment_data)
-    for attr in attributes_to_check:
+    for attr, expected in attributes_to_check.items():
         assert hasattr(job, attr)
-        assert getattr(job, attr) == attributes_to_check[attr]
+        assert getattr(job, attr) == expected
 
 
 @pytest.mark.parametrize('custom_directives, test_type, result_by_lines', [

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -1183,23 +1183,6 @@ def test_recover_last_log_name(tmpdir, test_with_logfiles, file_timestamp_greate
     ),
     (
         {
-            'EXPERIMENT': {
-                'CHUNKSIZE': 1,
-                'CHUNKSIZEUNIT': 'day',
-            },
-            'JOBS': {
-                'RANDOM-SECTION': {
-                    'FILE': 'test.sh',
-                    'PLATFORM': 'DUMMY_PLATFORM',
-                    'CHUNKSIZE': 12,
-                    'CHUNKSIZEUNIT': 'HOUR',
-                },
-            },
-        },
-        {'chunk_size': 12, 'chunk_size_unit': 'hour'}
-    ),
-    (
-        {
             'JOBS': {
                 'RANDOM-SECTION': {
                     'FILE': 'test.sh',
@@ -1211,11 +1194,10 @@ def test_recover_last_log_name(tmpdir, test_with_logfiles, file_timestamp_greate
     ),
 ], ids=[
     'notify_on_attribute',
-    'cpmip_thresholds_from_config',
-    'empty_cpmip_thresholds_when_missing',
-    'chunk_metadata_from_experiment_defaults',
-    'chunk_metadata_with_job_overrides',
-    'chunk_metadata_when_missing',
+    'cpmip_thresholds_from_config', # Expected to be loaded when present in the config.
+    'empty_cpmip_thresholds_when_missing', # Expected to be empty when not present in the config.
+    'chunk_metadata_from_experiment_defaults', # Expected to be loaded from experiment config when present.
+    'chunk_metadata_when_missing', # Expected to have default values when chunk metadata is missing in the config
 ])
 def test_update_parameters_attributes(autosubmit_config, experiment_data, attributes_to_check):
     job, _, _ = create_job_and_update_parameters(autosubmit_config, experiment_data)

--- a/test/unit/test_split_job.py
+++ b/test/unit/test_split_job.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
 # This file is part of Autosubmit.
 #

--- a/test/unit/test_split_job.py
+++ b/test/unit/test_split_job.py
@@ -1,0 +1,197 @@
+# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+from datetime import datetime
+
+import pytest
+
+from autosubmit.job.job_list import JobList
+from autosubmit.job.job_list_persistence import JobListPersistencePkl
+from autosubmit.job.template import Language
+from autosubmit.platforms.psplatform import PsPlatform
+
+
+def _build_split_experiment_data(experiment_data):
+    split_experiment_data = copy.deepcopy(experiment_data)
+    split_job_data = split_experiment_data.setdefault('JOBS', {}).setdefault('RANDOM-SECTION', {})
+    split_job_data['RUNNING'] = 'chunk'
+
+    split_experiment_data.setdefault('PLATFORMS', {}).setdefault('dummy_platform', {'type': 'ps'})
+    split_experiment_data.setdefault('ROOTDIR', 'dummy_rootdir')
+    split_experiment_data.setdefault('LOCAL_TMP_DIR', 'dummy_tmpdir')
+    split_experiment_data.setdefault('LOCAL_ROOT_DIR', 'dummy_rootdir')
+
+    return split_experiment_data
+
+
+def _generate_and_get_split_job(autosubmit_config, experiment_data):
+    as_conf = autosubmit_config('t000', experiment_data)
+    as_conf.experiment_data = as_conf.deep_normalize(as_conf.experiment_data)
+    as_conf.experiment_data = as_conf.normalize_variables(as_conf.experiment_data, must_exists=True)
+    as_conf.experiment_data = as_conf.deep_read_loops(as_conf.experiment_data)
+    as_conf.experiment_data = as_conf.substitute_dynamic_variables(as_conf.experiment_data)
+    as_conf.experiment_data = as_conf.parse_data_loops(as_conf.experiment_data)
+
+    parameters = as_conf.load_parameters()
+    job_list_obj = JobList('t000', as_conf, as_conf.parser_factory, JobListPersistencePkl())
+    job_list_obj.generate(
+        as_conf=as_conf,
+        date_list=[datetime(2020, 1, 1)],
+        member_list=['fc0'],
+        num_chunks=1,
+        chunk_ini=1,
+        parameters=parameters,
+        date_format=None,
+        default_retrials=as_conf.get_retrials(),
+        default_job_type=Language.BASH,
+        wrapper_jobs={},
+        new=True,
+        run_only_members=[],
+        show_log=False,
+        create=True,
+    )
+
+    split_jobs = [
+        job for job in job_list_obj.get_job_list()
+        if job.section == 'RANDOM-SECTION' and isinstance(job.split, int) and job.split > 0
+    ]
+    assert split_jobs
+
+    for job in split_jobs:
+        job.platform = PsPlatform(expid='t000', name='DUMMY_PLATFORM', config=as_conf.experiment_data)
+        job.update_parameters(as_conf, set_attributes=True)
+    return split_jobs
+
+
+@pytest.mark.parametrize('experiment_data, attributes_to_check, configured_splits', [
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'NOTIFY_ON': 'COMPLETED',
+                    'SPLITS': 2,
+                },
+            },
+            'PLATFORMS': {
+                'dummy_platform': {
+                    'type': 'ps',
+                },
+            },
+            'ROOTDIR': 'dummy_rootdir',
+            'LOCAL_TMP_DIR': 'dummy_tmpdir',
+            'LOCAL_ROOT_DIR': 'dummy_rootdir',
+        },
+        {'notify_on': ['COMPLETED']},
+        2
+    ),
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'CPMIP_THRESHOLDS': {
+                        'SYPD': {
+                            'THRESHOLD': 5.0,
+                            'COMPARISON': 'greater_than',
+                            '%_ACCEPTED_ERROR': 10,
+                        }
+                    },
+                    'SPLITS': 3,
+                },
+            },
+        },
+        {
+            'cpmip_thresholds': {
+                'SYPD': {
+                    'THRESHOLD': 5.0,
+                    'COMPARISON': 'greater_than',
+                    '%_ACCEPTED_ERROR': 10,
+                }
+            }
+        },
+        3
+    ),
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'SPLITS': 1,
+                },
+            },
+        },
+        {'cpmip_thresholds': {}},
+        1
+    ),
+    (
+        {
+            'EXPERIMENT': {
+                'CHUNKSIZE': 3,
+                'CHUNKSIZEUNIT': 'MONTH',
+            },
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'SPLITS': 4,
+                },
+            },
+        },
+        {'chunk_size': 3, 'chunk_size_unit': 'month'},
+        4
+    ),
+    (
+        {
+            'JOBS': {
+                'RANDOM-SECTION': {
+                    'FILE': 'test.sh',
+                    'PLATFORM': 'DUMMY_PLATFORM',
+                    'SPLITS': 5,
+                },
+            },
+        },
+        {'chunk_size': 1, 'chunk_size_unit': ''},
+        5
+    ),
+], ids=[
+    'notify_on_attribute',
+    'cpmip_thresholds_from_config',
+    'empty_cpmip_thresholds_when_missing',
+    'chunk_metadata_from_experiment_defaults',
+    'chunk_metadata_when_missing',
+])
+def test_update_parameters_split_attributes(autosubmit_config, experiment_data, attributes_to_check, configured_splits):
+    split_experiment_data = _build_split_experiment_data(experiment_data)
+    split_jobs = _generate_and_get_split_job(autosubmit_config, split_experiment_data)
+
+    assert len(split_jobs) == configured_splits
+    assert sorted(int(job.split) for job in split_jobs) == list(range(1, configured_splits + 1))
+
+    for job in split_jobs:
+        assert job.split > 0
+        assert job.splits > 0
+        assert int(job.splits) == configured_splits
+        assert 1 <= int(job.split) <= configured_splits
+
+        for attr, expected in attributes_to_check.items():
+            assert hasattr(job, attr)
+            assert getattr(job, attr) == expected


### PR DESCRIPTION
Hi AS team!

This is the second part of a large [PR](https://github.com/MissterP/autosubmit/pull/1) with the objective to implement the detection of inefficiencies once the SIM job is completed (or section indicated) using CPMIPS and thresholds. If a threshold is violated, it will send a notification to the user indicated in the config. 

For example, if you have 50 chunks of SIM jobs. An early detection could be observed in the first 2 chunks.

This second part consists in the addition of new attributes in the Job class related to the computation for the CPMIPS. 

**Check List**

- [X] I have read `CONTRIBUTING.md`.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`. (No need)
- [X] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`). (no bug)