### PR TITLE
Allow users to filter sections by splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Changed Yaml load mode from 'safe' to 'rt' #2851
 - Add issues URL to error message #2888
 - Allow multiple filters in `setstatus` command #1250
+- Allow filtering by section and split in the `ft` command #2910
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4598,12 +4598,6 @@ class Autosubmit:
             entry = entry.strip()
             if not entry:
                 continue
-            if re.search(r"\s+\[", entry):
-                raise AutosubmitCritical(
-                    "Malformed section filter: space between section name and split block.",
-                    7011,
-                    "\n\tEach entry should be in the format: SECTION or SECTION [1 2 5-8].",
-                )
             entries.append(entry)
         return entries
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4522,7 +4522,6 @@ class Autosubmit:
             valid_sections = {str(section).upper() for section in as_conf.jobs_data}
             for raw_section in Autosubmit._split_section_filter_entries(filter_section):
                 section = raw_section.strip()
-                print(f"Validating section entry: '{section}'")
                 if not section:
                     continue
                 # regex expression match
@@ -4536,14 +4535,11 @@ class Autosubmit:
                 )
                 # evaluate section format
                 if not match:
-                    print(f"Section entry '{section}' is malformed.")
                     malformed_sections.append(section)
                     continue
 
                 section_name = match.group(1).upper()
                 splits = match.group(2)
-                print(f"Extracted section name: '{section_name}'")
-                print(f"Extracted splits: '{splits}'")
                 # evaluate section name
                 if section_name not in valid_sections and section_name != "ANY":
                     section_not_found_error = True

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4623,7 +4623,6 @@ class Autosubmit:
 
         for section in [section.strip() for section in section_split_formula.split(",") if section.strip()]:
             section_name = section.strip().split("[")[0].strip().upper()
-            split_part = section.strip().split("[")[1].strip() if "[" in section and "]" in section else None
             if valid_sections is not None and section_name not in valid_sections and section_name != "ANY":
                 validation_message += f"\n\tSpecified section not found: {section_name}."
             

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4521,6 +4521,7 @@ class Autosubmit:
         else:
             valid_sections = {str(section).upper() for section in as_conf.jobs_data}
             for raw_section in Autosubmit._split_section_filter_entries(filter_section):
+                print(f"Validating section entry: '{raw_section}'")
                 section = raw_section.strip()
                 if not section:
                     continue
@@ -4579,7 +4580,8 @@ class Autosubmit:
     def _split_section_filter_entries(filter_section: str) -> list[str]:
         """Split ``-ft`` filter into section entries preserving split blocks.
         Entries are space-separated section names, optionally followed by
-        a bracketed split block. Spaces inside brackets are not separators:
+        a bracketed split block. 
+        Examples of valid entries:
         LOCALJOB PSJOB
         LOCALJOB [1 2] PSJOB [3-5]
         LOCALJOB [1 2] PSJOB
@@ -4590,7 +4592,7 @@ class Autosubmit:
             return []
 
         entries = []
-        current: list[str] = []
+        current = []
         level = 0
         i = 0
         while i < len(text):
@@ -4884,32 +4886,16 @@ class Autosubmit:
         if all_empty:
             raise AutosubmitCritical("At least one filter must be provided and must be not empty when using -fs, -ft, -fc, -ftc or -ftcs.", 7014)
 
-
     @staticmethod
     def _split_match(j: Job, split_list: list[str]) -> bool:
-        """Check if job split matches a split filter.
-        
-        A job matches if:
-        - No split filter was provided (split_list is empty)
-        - Split filter contains 'ANY'
-        - Job has splits AND its split is in the filter list
-        - Job has no splits (split < 0) and no split filter was provided
-        """
-        # If no split filter, match all jobs
-        if not split_list:
-            return True
-        # If split filter contains ANY, match all jobs
-        if "ANY" in split_list:
-            return True
-        # If job has no splits (split < 0), it shouldn't match a specific split filter
-        if j.split < 0:
-            return False
-        # If job has only one split (not actually split), match only if split_list is empty or ANY
-        # This is already handled above, so if we're here, no match for non-split jobs
-        if not j.splits or int(j.splits) < 2:
-            return False
-        # Job has multiple splits, check if it matches the filter
-        return str(j.split) in split_list
+        """Check if job split matches"""
+        return (
+            "ANY" in split_list
+            or not j.splits
+            or int(j.splits) < 2
+            or not split_list
+            or str(j.split) in split_list
+        )
 
     @staticmethod
     def _filter_sections_splits(filter_section_splits: str, jobs: list[Job]) -> list[Job]:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4844,14 +4844,12 @@ class Autosubmit:
         return str(j.split) in split_list
 
     @staticmethod
-    def _expand_values(
-        raw_value: str, known_values: list[str]
-    ) -> set[str]:
+    def _expand_values(raw_value: str, known_values: list[str]) -> set[str]:
         """Expand ranges, colon, dash, space-separated values.
 
         'ANY' expands to known_values if given.
         :param raw_value: string with the values to expand
-        :param known_values: list of known values to expand 'ANY' to
+        :param known_values: list of known valuses to expand 'ANY' to
         :return: set of expanded values
         """
         if raw_value is None:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4505,7 +4505,7 @@ class Autosubmit:
         Expected format for each section entry: SECTION or SECTION [1 2 5-8]
 
         :param as_conf: Autosubmit configuration object
-        :param filter_section: string with the sections separated by blank space
+        :param filter_section: string with the sections separated by comma
         """
         malformed_error = False  # incorrectly formatted
         malformed_sections = []
@@ -4569,7 +4569,7 @@ class Autosubmit:
                         + ", ".join(unique_not_found)
                         + "."
                         + "\n\tProcess stopped. Review the format of the provided input."
-                        + "\n\tRemember that this option expects section names separated by a blank space as input, and optionally split lists between brackets."
+                        + "\n\tRemember that this option expects section names separated by comma as input, and optionally splits between brackets."
                     )
                 raise AutosubmitCritical(
                     "Error in the supplied input for -ft.",
@@ -4588,7 +4588,7 @@ class Autosubmit:
         LOCALJOB [1:2], PSJOB
         LOCALJOB [1]
 
-        :param filter_section: string with the sections separated by blank space
+        :param filter_section: string with the sections separated by comma
         :return: list of section entries
         """
         text = filter_section.strip()
@@ -4637,7 +4637,7 @@ class Autosubmit:
                                           str(as_conf.expid) + ". \n\tProcess stopped. Review the format of the provided input. Comparison is case sensitive." + \
                                           "\n\tRemember that this option expects job names separated by a blank space as input."
             raise AutosubmitCritical(
-                "Error in the supplied input for -ft.", 7011, job_validation_message)
+                "Error in the supplied input for -fl.", 7011, job_validation_message)
 
     @staticmethod
     def _validate_status(job_list, filter_status):
@@ -4863,14 +4863,19 @@ class Autosubmit:
 
     @staticmethod
     def _split_match(j: Job, split_list: list[str]) -> bool:
-        """Check if job split matches"""
-        return (
-            "ANY" in split_list
-            or not j.splits
-            or int(j.splits) < 2
-            or not split_list
-            or str(j.split) in split_list
-        )
+        """Check if a job matches a split filter.
+
+        If no split filter is provided (or ``ANY``), all jobs match.
+        When specific splits are provided, only real split jobs (``splits >= 2``)
+        can match.
+        """
+        if not split_list or "ANY" in split_list:
+            return True
+
+        if not j.splits or int(j.splits) < 2:
+            return False
+
+        return str(j.split) in split_list
 
     @staticmethod
     def _filter_sections_splits(filter_section_splits: str, jobs: list[Job]) -> list[Job]:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4467,10 +4467,6 @@ class Autosubmit:
                     Log.info("Local project destination already exists, will not sync project files.")
 
         return True
-
-    ###############################
-    ## SETSTATUS METHODS
-    ###############################
     
     @staticmethod
     def change_status(final, final_status, job, save):

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -590,7 +590,8 @@ class Autosubmit:
                 "-ft",
                 "--filter_type",
                 type=str,
-                help="Select the job type to filter the list of jobs",
+                help='Select the job type and split to filter the list of jobs. Default split = "Any". '
+                'LIST = "LOCALJOB [5-10]"',
             )
             subparser.add_argument(
                 "-ftc",
@@ -4500,35 +4501,128 @@ class Autosubmit:
 
     @staticmethod
     def _validate_section(as_conf, filter_section):
-        section_validation_error = False
-        section_error = False
-        section_not_foundList = list()
-        section_validation_message = "\n## Section Validation Message ##"
-        countStart = filter_section.count('[')
-        countEnd = filter_section.count(']')
-        if countStart > 1 or countEnd > 1:
-            section_validation_error = True
-            section_validation_message += "\n\tList of sections has a format error. Perhaps you were trying to use -fc instead."
-        if section_validation_error is False:
-            if len(str(filter_section).strip()) > 0:
-                if len(filter_section.split()) > 0:
-                    jobSections = as_conf.jobs_data
-                    for section in filter_section.split():
-                        # print(section)
-                        # Provided section is not an existing section, or it is not the keyword 'Any'
-                        if section not in jobSections and (section != "Any"):
-                            section_error = True
-                            section_not_foundList.append(section)
-            else:
-                section_validation_error = True
-                section_validation_message += "\n\tEmpty input. No changes performed."
-        if section_validation_error is True or section_error is True:
-            if section_error is True:
-                section_validation_message += "\n\tSpecified section(s) : [" + str(section_not_foundList) + " not found" \
-                                                                                                            ".\n\tProcess stopped. Review the format of the provided input. Comparison is case sensitive." + \
-                                              "\n\tRemember that this option expects section names separated by a blank space as input."
+        """Validates the section filter input.
 
-            raise AutosubmitCritical("Error in the supplied input for -ft.", 7011, section_validation_message)
+        :param as_conf: Autosubmit configuration object
+        :param filter_section: section filter input provided by the user
+        """
+        malformed_error = False  # incorrectly formatted
+        malformed_sections = []
+        section_not_found_error = (
+            False  # correctly formatted but does not match any existing section
+        )
+        section_not_found_list = []
+        section_validation_message = "\n## Section Validation Message ##"
+
+        if len(str(filter_section).strip()) == 0:
+            malformed_error = True
+            section_validation_message += "\n\tEmpty input. No changes performed."
+        else:
+            valid_sections = {str(section).upper() for section in as_conf.jobs_data}
+            for raw_section in Autosubmit._split_section_filter_entries(filter_section):
+                section = raw_section.strip()
+                if not section:
+                    continue
+                # regex expression match
+                # evaluate two groups in the section
+                # SECTION: string with uppercase letters, digits, _ . - or the keyword 'ANY'
+                # SPLIT: optional list of sections between brackets, separated by blank space
+                match = re.match(
+                    r"^([A-Z0-9_.-]+|ANY)(?:\s*\[(.*?)\])?$", section, re.IGNORECASE
+                )
+                if not match:
+                    malformed_sections.append(section)
+                    continue
+
+                section_name = match.group(1).upper()
+                splits = match.group(2)
+
+                if section_name not in valid_sections and section_name != "ANY":
+                    section_not_found_error = True
+                    section_not_found_list.append(section_name)
+
+                if splits is not None:
+                    section_validation_message = (
+                        Autosubmit._validate_section_split_formula(
+                            f"{section_name} [{splits}]", section_validation_message
+                        )
+                    )
+
+            if malformed_sections:
+                malformed_error = True
+                section_validation_message += (
+                    "\n\tMalformed section/split entries in -ft: "
+                    + ", ".join(malformed_sections)
+                    + "."
+                )
+                section_validation_message += "\n\tEach entry should be in the format: SECTION or SECTION [1 2 5-8]."
+
+            if malformed_error or section_not_found_error:
+                if section_not_found_error:
+                    unique_not_found = sorted(set(section_not_found_list))
+                    section_validation_message += (
+                        "\n\tSpecified section(s) not found in this experiment: "
+                        + ", ".join(unique_not_found)
+                        + "."
+                        + "\n\tProcess stopped. Review the format of the provided input."
+                        + "\n\tRemember that this option expects section names separated by a blank space as input, and optionally split lists between brackets."
+                    )
+                raise AutosubmitCritical(
+                    "Error in the supplied input for -ft.",
+                    7011,
+                    section_validation_message,
+                )
+    
+    @staticmethod
+    def _split_section_filter_entries(filter_section: str) -> list[str]:
+        """Split ``-ft`` filter into section entries preserving split blocks.
+        Entries are space-separated section names, optionally followed by
+        a bracketed split block. Spaces inside brackets are not separators:
+        LOCALJOB PSJOB
+        LOCALJOB [1 2] PSJOB [3-5]
+        LOCALJOB [1 2] PSJOB
+        LOCALJOB [1]
+        """
+        text = filter_section.strip()
+        if not text:
+            return []
+
+        entries = []
+        current: list[str] = []
+        level = 0
+        i = 0
+        while i < len(text):
+            ch = text[i]
+            if ch == "[":
+                level += 1
+                current.append(ch)
+            elif ch == "]":
+                level = max(0, level - 1)
+                current.append(ch)
+            elif ch == " " and level == 0:
+                # peek ahead, skip spaces, check if next char is '['
+                j = i + 1
+                while j < len(text) and text[j] == " ":
+                    j += 1
+                if j < len(text) and text[j] == "[":
+                    # space between section name and its bracket block, keep together
+                    current.append(ch)
+                else:
+                    # space between two entries, flush current
+                    entry = "".join(current).strip()
+                    if entry:
+                        entries.append(entry)
+                    current = []
+            else:
+                current.append(ch)
+            i += 1
+
+        tail = "".join(current).strip()
+        if tail:
+            entries.append(tail)
+
+        return entries
+
 
     @staticmethod
     def _validate_list(as_conf, job_list, filter_list):
@@ -4659,19 +4753,24 @@ class Autosubmit:
         return validation_message
 
     @staticmethod
-    def _validate_section_split_formula(section_split_formula: str, validation_message: str) -> str:
+    def _validate_section_split_formula(section_split_formula: str, validation_message: str, valid_sections: Optional[set[str]] = None) -> str:
         """Validate section/split formula syntax.
 
         Expects to receive the second part of the -ftcs filter. ex: SIM [ Any ], SIM2 [1 2], SIM3.
 
         :param section_split_formula: section_split_formula string.
         :param validation_message: Message to append validation errors to.
+        :param valid_sections: Set of valid section names.
         """
 
         if not section_split_formula:
             return validation_message
 
         for section in [section.strip() for section in section_split_formula.split(",") if section.strip()]:
+            section_name = section.strip().split("[")[0].strip().upper()
+            if valid_sections is not None and section_name not in valid_sections and section_name != "ANY":
+                validation_message += f"\n\tSpecified section not found: {section_name}."
+            
             if '[' not in section and ']' not in section:
                 if len(section.split()) > 1:
                     validation_message += f"\n\tMalformed section/split entry: {section}. "
@@ -4700,7 +4799,7 @@ class Autosubmit:
         return validation_message
 
     @staticmethod
-    def _validate_chunk_section_split(filter_string: str) -> None:
+    def _validate_chunk_section_split(filter_string: str, valid_sections: Optional[set[str]] = None) -> None:
         """Validate a chunk/section/split filter string for commands using -fc/-ftc/-ftcs.
 
         Validate that the filter string contains a chunk formula and, optionally,
@@ -4738,7 +4837,7 @@ class Autosubmit:
         section_split_formula = ",".join(filter_string_parts[1:]) if len(filter_string_parts) > 1 else ''
 
         validation_message = Autosubmit._validate_chunk_formula(chunk_formula, validation_message)
-        validation_message = Autosubmit._validate_section_split_formula(section_split_formula, validation_message)
+        validation_message = Autosubmit._validate_section_split_formula(section_split_formula, validation_message, valid_sections=valid_sections)
 
         if validation_message != "## -fc // -ftc // -ftcs Validation Message ##":
             raise AutosubmitCritical("Error in the supplied input for -fc // -ftc // -ftcs.", 7011, validation_message)
@@ -4776,7 +4875,8 @@ class Autosubmit:
             all_empty = False
 
         if filter_chunk_section_split:
-            Autosubmit._validate_chunk_section_split(filter_chunk_section_split)
+            valid_sections = {str(section).upper() for section in as_conf.jobs_data}
+            Autosubmit._validate_chunk_section_split(filter_chunk_section_split, valid_sections=valid_sections)
             all_empty = False
 
         if all_empty:
@@ -4785,8 +4885,29 @@ class Autosubmit:
 
     @staticmethod
     def _split_match(j: Job, split_list: list[str]) -> bool:
-        """Check if job split matches"""
-        return "ANY" in split_list or not j.splits or int(j.splits) < 2 or not split_list or str(j.split) in split_list
+        """Check if job split matches a split filter.
+        
+        A job matches if:
+        - No split filter was provided (split_list is empty)
+        - Split filter contains 'ANY'
+        - Job has splits AND its split is in the filter list
+        - Job has no splits (split < 0) and no split filter was provided
+        """
+        # If no split filter, match all jobs
+        if not split_list:
+            return True
+        # If split filter contains ANY, match all jobs
+        if "ANY" in split_list:
+            return True
+        # If job has no splits (split < 0), it shouldn't match a specific split filter
+        if j.split < 0:
+            return False
+        # If job has only one split (not actually split), match only if split_list is empty or ANY
+        # This is already handled above, so if we're here, no match for non-split jobs
+        if not j.splits or int(j.splits) < 2:
+            return False
+        # Job has multiple splits, check if it matches the filter
+        return str(j.split) in split_list
 
     @staticmethod
     def _filter_sections_splits(filter_section_splits: str, jobs: list[Job]) -> list[Job]:
@@ -5034,9 +5155,10 @@ class Autosubmit:
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
-                    ft = filter_section.split()
-                    if not (len(ft) == 1 and ft[0].upper() == 'ANY'):
-                        selected_job_names &= {job.name for job in all_jobs if job.section in ft}
+                    ft_entries = [section.upper() for section in Autosubmit._split_section_filter_entries(filter_section)]
+                    if not (len(ft_entries) == 1 and ft_entries[0].upper() == 'ANY'):
+                        section_filtered_jobs = Autosubmit._filter_sections_splits(ft_entries, all_jobs)
+                        selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4498,20 +4498,24 @@ class Autosubmit:
 
     @staticmethod
     def _validate_section(as_conf: AutosubmitConfig, filter_section: str) -> None:
-        """Validates the section filter input.
-        Expected format for each section entry: SECTION or SECTION [1 2 5-8]
+        """Validate the ``-ft`` section filter.
+
+        Each entry must be an exact section name, optionally followed by a split
+        selector in brackets. The filter is comma-separated and supports ``ANY``
+        as a wildcard value.
 
         :param as_conf: Autosubmit configuration object
         :param filter_section: string with the sections separated by comma
         """
         section_validation_message = "\n## Section Validation Message ##"
+        section_entries = Autosubmit._split_section_filter_entries(filter_section)
 
-        if len(str(filter_section).strip()) == 0:
+        if not section_entries:
             section_validation_message += "\n\tEmpty input. No changes performed."
         else:
             valid_sections = {str(section).upper() for section in as_conf.jobs_data}
             section_validation_message = Autosubmit._validate_section_split_formula(
-                filter_section, section_validation_message, valid_sections
+                ", ".join(section_entries), section_validation_message, valid_sections
             )
 
         if section_validation_message != "\n## Section Validation Message ##":
@@ -4860,7 +4864,7 @@ class Autosubmit:
             else:
                 section_matching_jobs.extend([j for j in jobs if j.section == section_name and Autosubmit._split_match(j, job_splits)])
 
-            section_matching_jobs = list(set(section_matching_jobs))
+            section_matching_jobs = list(dict.fromkeys(section_matching_jobs))
 
             # All jobs matched, no need to continue
             if len(section_matching_jobs) == len(jobs):
@@ -4870,7 +4874,10 @@ class Autosubmit:
 
     @staticmethod
     def _filter_chunks(filter_chunk_str: str, job_list: "JobList", matching_jobs: list[Job]) -> list[Job]:
-        """Filter jobs by chunks.
+        """Filter jobs by exact date, member and chunk matches.
+
+        ``ANY`` acts as a wildcard for the corresponding field. Jobs that do not
+        have a value for a required field are excluded.
 
         :param filter_chunk_str: filter chunks
         :param job_list: JobList object
@@ -4878,53 +4885,58 @@ class Autosubmit:
 
         :return: list of jobs matching the filter
         """
-        final_list = []
         data = json.loads(Autosubmit._create_json(filter_chunk_str))
-        # Mapping so it is easier to understand
         dates = 'sds'
         members = 'ms'
         chunks = 'cs'
         date = 'sd'
         member = 'm'
 
-        selected_dates: set = set()
-        selected_members: set = set()
+        def normalize_date(value) -> str:
+            return date2str(value).upper() if value is not None else ""
 
-        # Prune first to reduce the amount of jobs that the chunk filter (last one) has to interate with
-        # Here we want a reduced list of jobs that matches any date or member selected and remove the rest.
-        for date_json in data[dates]:
-            if "ANY" == str(date_json[date]).upper():
-                selected_dates = set(date2str(d).upper() for d in job_list._date_list)
-            else:
-                selected_dates.add(date_json[date].upper())
-            for member_json in date_json[members]:
-                if "ANY" == str(member_json[member]).upper():
-                    selected_members = set(m.upper() for m in job_list._member_list)
+        def expand_values(raw_value, known_values: list[str]) -> set[str] | None:
+            value = str(raw_value).strip().upper()
+            if not value or value == "ANY":
+                return None
+            expanded_values: set[str] = set()
+            for token in value.split():
+                if token.find("-") != -1:
+                    start, end = token.split("-", 1)
+                    expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
+                elif token.find(":") != -1:
+                    start, end = token.split(":", 1)
+                    expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
                 else:
-                    selected_members.add(member_json[member].upper())
+                    expanded_values.add(token)
+            if not expanded_values and known_values:
+                return {str(value).upper() for value in known_values}
+            return expanded_values
 
-        matching_jobs = [job for job in matching_jobs if
-                         (not job.date or date2str(job.date).upper() in selected_dates) and
-                         (not job.member or job.member.upper() in selected_members)]
-
-        # Now, build final list according to the structure in data
+        selected_jobs: list[Job] = []
         for date_json in data[dates]:
-            if "ANY" == str(date_json[date]).upper():
-                selected_dates = set(date2str(d).upper() for d in job_list._date_list)
-            else:
-                selected_dates = {date_json[date].upper()}
+            selected_dates = expand_values(date_json[date], [normalize_date(d) for d in job_list._date_list])
             for member_json in date_json[members]:
-                if "ANY" == str(member_json[member]).upper():
-                    selected_members = set([m.upper() for m in job_list._member_list])
-                else:
-                    selected_members = {member_json[member].upper()}
+                selected_members = expand_values(member_json[member], [str(m).upper() for m in job_list._member_list])
+                for chunk_json in member_json[chunks]:
+                    selected_chunks = expand_values(chunk_json, [str(c).upper() for c in job_list._chunk_list])
+                    for job in matching_jobs:
+                        if job.date is None or job.member is None or job.chunk is None:
+                            continue
 
-                selected_chunks = member_json[chunks] if "ANY" != str(member_json[chunks][-1]).upper() else [str(chunks) for chunks in job_list._chunk_list]
-                final_list.extend([job for job in matching_jobs if
-                                   (not job.date or date2str(job.date).upper() in selected_dates) and
-                                   (not job.member or job.member.upper() in selected_members) and
-                                   (not job.chunk or job.synchronize or str(job.chunk) in selected_chunks)])
-        return final_list
+                        job_date = normalize_date(job.date)
+                        job_member = str(job.member).upper()
+                        job_chunk = str(job.chunk).upper()
+
+                        if selected_dates is not None and job_date not in selected_dates:
+                            continue
+                        if selected_members is not None and job_member not in selected_members:
+                            continue
+                        if selected_chunks is not None and job_chunk not in selected_chunks:
+                            continue
+                        selected_jobs.append(job)
+
+        return list(dict.fromkeys(selected_jobs))
 
     @staticmethod
     def filter_jobs_by_chunks_splits(job_list: "JobList", filter_chunks: str) -> list[Job]:
@@ -4949,7 +4961,7 @@ class Autosubmit:
 
         final_list = Autosubmit._filter_chunks(fc, job_list, matching_jobs)
 
-        return list(set(final_list))
+        return list(dict.fromkeys(final_list))
 
     @staticmethod
     def set_status(expid: str, noplot: bool, save: bool, final: str, filter_list: str, filter_chunks: str,

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -549,10 +549,7 @@ class Autosubmit:
                     "COMPLETED",
                     "WAITING",
                     "SUSPENDED",
-                    "FAILED",
                     "UNKNOWN",
-                    "QUEUING",
-                    "RUNNING",
                     "HELD",
                 ),
                 required=True,
@@ -4507,75 +4504,22 @@ class Autosubmit:
         :param as_conf: Autosubmit configuration object
         :param filter_section: string with the sections separated by comma
         """
-        malformed_error = False  # incorrectly formatted
-        malformed_sections = []
-        section_not_found_error = (
-            False  # correctly formatted but does not match any existing section
-        )
-        section_not_found_list = []
         section_validation_message = "\n## Section Validation Message ##"
 
         if len(str(filter_section).strip()) == 0:
-            malformed_error = True
             section_validation_message += "\n\tEmpty input. No changes performed."
         else:
             valid_sections = {str(section).upper() for section in as_conf.jobs_data}
-            for raw_section in Autosubmit._split_section_filter_entries(filter_section):
-                section = raw_section.strip()
-                if not section:
-                    continue
-                # regex expression match
-                # evaluate two parts in the section
-                # SECTION NAME: string with uppercase letters, digits, _ . - or the keyword 'ANY'
-                # SPLIT: optional, only one pair of brackets allowed
-                match = re.match(
-                    r"^([A-Z0-9_.-]+|ANY)(?:\s*\[\s*((?:ANY)|(?:[0-9]+(?:[-:][0-9]+)?(?:\s+[0-9]+(?:[-:][0-9]+)?)*))\s*\])?$",
-                    section,
-                    re.IGNORECASE,
-                )
-                # evaluate section format
-                if not match:
-                    malformed_sections.append(section)
-                    continue
+            section_validation_message = Autosubmit._validate_section_split_formula(
+                filter_section, section_validation_message, valid_sections
+            )
 
-                section_name = match.group(1).upper()
-                splits = match.group(2)
-                # evaluate section name
-                if section_name not in valid_sections and section_name != "ANY":
-                    section_not_found_error = True
-                    section_not_found_list.append(section_name)
-                # evaluate section splits
-                if splits is not None:
-                    section_validation_message = (
-                        Autosubmit._validate_section_split_formula(
-                            f"{section_name} [{splits}]", section_validation_message
-                        )
-                    )
-
-            if malformed_sections:
-                malformed_error = True
-                section_validation_message += (
-                    "\n\tMalformed section/split entries in -ft: "
-                    + ", ".join(malformed_sections)
-                    + "."
-                )
-                section_validation_message += "\n\tEach entry should be in the format: SECTION or SECTION [1 2 5-8]."
-
-            if malformed_error or section_not_found_error:
-                if section_not_found_error:
-                    unique_not_found = sorted(set(section_not_found_list))
-                    section_validation_message += (
-                        "\n\tSpecified section(s) not found in this experiment: "
-                        + ", ".join(unique_not_found)
-                        + "."
-                        + "\n\tProcess stopped. Review the format of the provided input."
-                        + "\n\tRemember that this option expects section names separated by comma as input, and optionally splits between brackets."
-                    )
-                raise AutosubmitCritical(
-                    "Error in the supplied input for -ft.",
-                    7011,
-                    section_validation_message,
-                )
+        if section_validation_message != "\n## Section Validation Message ##":
+            raise AutosubmitCritical(
+                "Error in the supplied input for -ft.",
+                7011,
+                section_validation_message,
+            )
 
     @staticmethod
     def _split_section_filter_entries(filter_section: str) -> list[str]:
@@ -4879,6 +4823,7 @@ class Autosubmit:
 
     @staticmethod
     def _filter_sections_splits(filter_section_splits: str, jobs: list[Job]) -> list[Job]:
+        # TODO: I suspect that filter_section_splits is a list of sections with their splits, not a string
         """Filter jobs by sections and splits.
         :param filter_section_splits: filter sections and splits
         :param jobs: list of jobs
@@ -5123,10 +5068,8 @@ class Autosubmit:
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
-                    ft_entries = [section.upper() for section in Autosubmit._split_section_filter_entries(filter_section)]
-                    if not (len(ft_entries) == 1 and ft_entries[0].upper() == 'ANY'):
-                        section_filtered_jobs = Autosubmit._filter_sections_splits(ft_entries, all_jobs)
-                        selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}
+                    section_filtered_jobs = Autosubmit._filter_sections_splits(filter_section, all_jobs)
+                    selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4567,7 +4567,7 @@ class Autosubmit:
                 if len(filter_list.split()) > 0:
                     for sentJob in filter_list.split():
                         # Provided job does not exist, or it is not the keyword 'Any'
-                        if sentJob not in jobs and (sentJob != "Any"):
+                        if sentJob not in jobs and (sentJob.upper() != "ANY"):
                             job_error = True
                             job_not_foundList.append(sentJob)
             else:
@@ -4822,8 +4822,7 @@ class Autosubmit:
         return str(j.split) in split_list
 
     @staticmethod
-    def _filter_sections_splits(filter_section_splits: str, jobs: list[Job]) -> list[Job]:
-        # TODO: I suspect that filter_section_splits is a list of sections with their splits, not a string
+    def _filter_sections_splits(filter_section_splits: list[str], jobs: list[Job]) -> list[Job]:
         """Filter jobs by sections and splits.
         :param filter_section_splits: filter sections and splits
         :param jobs: list of jobs
@@ -5068,8 +5067,10 @@ class Autosubmit:
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
-                    section_filtered_jobs = Autosubmit._filter_sections_splits(filter_section, all_jobs)
-                    selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}
+                    ft_entries = [section.upper() for section in Autosubmit._split_section_filter_entries(filter_section)]
+                    if not (len(ft_entries) == 1 and ft_entries[0] == 'ANY'):
+                        section_filtered_jobs = Autosubmit._filter_sections_splits(ft_entries, all_jobs)
+                        selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4468,6 +4468,10 @@ class Autosubmit:
 
         return True
 
+    ###############################
+    ## SETSTATUS METHODS
+    ###############################
+    
     @staticmethod
     def change_status(final, final_status, job, save):
         """Set job status to final.
@@ -4502,13 +4506,13 @@ class Autosubmit:
 
         Each entry must be an exact section name, optionally followed by a split
         selector in brackets. The filter is comma-separated and supports ``ANY``
-        as a wildcard value.
+        as a wildcard.
 
         :param as_conf: Autosubmit configuration object
         :param filter_section: string with the sections separated by comma
         """
         section_validation_message = "\n## Section Validation Message ##"
-        section_entries = Autosubmit._split_section_filter_entries(filter_section)
+        section_entries = Autosubmit._separate_section_entries(filter_section)
 
         if not section_entries:
             section_validation_message += "\n\tEmpty input. No changes performed."
@@ -4526,33 +4530,16 @@ class Autosubmit:
             )
 
     @staticmethod
-    def _split_section_filter_entries(filter_section: str) -> list[str]:
-        """Split ``-ft`` filter into sections preserving split blocks.
-        Sections are section names, optionally followed by a split bracket.
-        The separation between sections is a comma.
-        Examples of valid entries:
-        LOCALJOB, PSJOB
-        LOCALJOB [1 2], PSJOB [3-5]
-        LOCALJOB [1:2], PSJOB
-        LOCALJOB [1]
-
-        :param filter_section: string with the sections separated by comma
-        :return: list of section entries
-        """
-        text = filter_section.strip()
-        if not text:
-            return []
-
-        entries = []
-        for entry in text.split(","):
-            entry = entry.strip()
-            if not entry:
-                continue
-            entries.append(entry)
-        return entries
-
-    @staticmethod
     def _validate_list(as_conf, job_list, filter_list):
+        """
+        Validate the ``-fl`` job filter.
+
+        Each entry must be an exact job name. The filter is space-separated and supports ``ANY`` as a wildcard.
+
+        :param as_conf: Autosubmit configuration object
+        :param job_list: JobList object containing the jobs to validate against
+        :param filter_list: string with the jobs separated by space
+        """
         job_validation_error = False
         job_error = False
         job_not_foundList = list()
@@ -4589,6 +4576,14 @@ class Autosubmit:
 
     @staticmethod
     def _validate_status(job_list, filter_status):
+        """
+        Validate the ``-fs`` status filter.
+
+        Each entry must be an exact status name. The filter is space-separated and supports ``ANY`` as a wildcard.
+
+        :param job_list: JobList object containing the jobs to validate against.
+        :param filter_status: string with the statuses separated by space
+        """
         status_validation_error = False
         status_validation_message = "\n## Status Validation Message ##"
         # Trying to identify chunk formula
@@ -4622,9 +4617,9 @@ class Autosubmit:
 
         [ 19900101 [ fc0 [ Any ] fc1 [1 2] ] 19950101 [ fc0 [1-10] ] ]
 
-
         :param chunk_formula: Chunk formula string.
         :param validation_message: Message to append validation errors to.
+        :return: Updated validation message with any errors found.
         """
 
         if not chunk_formula:
@@ -4688,6 +4683,7 @@ class Autosubmit:
         :param section_split_formula: section_split_formula string.
         :param validation_message: Message to append validation errors to.
         :param valid_sections: Set of valid section names.
+        :return: Updated validation message with any errors found.
         """
 
         if not section_split_formula:
@@ -4808,6 +4804,25 @@ class Autosubmit:
 
         if all_empty:
             raise AutosubmitCritical("At least one filter must be provided and must be not empty when using -fs, -ft, -fc, -ftc or -ftcs.", 7014)
+    
+    @staticmethod
+    def _separate_section_entries(filter_entries: str) -> list[str]:
+        """Separate section entries with optional splits separated by comma into a list.
+
+        :param filter_entries: string with the entries separated by comma
+        :return: list of entries
+        """
+        text = filter_entries.strip()
+        if not text:
+            return []
+
+        entries = []
+        for entry in text.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            entries.append(entry.upper())
+        return entries
 
     @staticmethod
     def _split_match(j: Job, split_list: list[str]) -> bool:
@@ -4816,6 +4831,9 @@ class Autosubmit:
         If no split filter is provided (or ``ANY``), all jobs match.
         When specific splits are provided, only real split jobs (``splits >= 2``)
         can match.
+        :param j: Job object to check.
+        :param split_list: list of splits to match against.
+        :return: True if the job matches the split filter, False otherwise.
         """
         if not split_list or "ANY" in split_list:
             return True
@@ -4826,44 +4844,73 @@ class Autosubmit:
         return str(j.split) in split_list
 
     @staticmethod
-    def _filter_sections_splits(filter_section_splits: list[str], jobs: list[Job]) -> list[Job]:
+    def _expand_values(
+        raw_value: str | None, known_values: list[str] | None = None
+    ) -> set[str]:
+        """Expand ranges, colon, dash, space-separated values.
+
+        'ANY' expands to known_values if given.
+        :param raw_value: string with the values to expand
+        :param known_values: list of known values to expand 'ANY' to
+        :return: set of expanded values
+        """
+        if raw_value is None:
+            return set(known_values) if known_values else set()
+
+        value = str(raw_value).strip().upper()
+        if not value or value == "ANY":
+            return set(known_values) if known_values else set()
+
+        expanded_values: set[str] = set()
+        for token in value.split():
+            if "-" in token or ":" in token:
+                sep = "-" if "-" in token else ":"
+                start, end = token.split(sep, 1)
+                expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
+            else:
+                expanded_values.add(token)
+        return expanded_values
+
+    @staticmethod
+    def _filter_sections_splits(
+        filter_section_splits: list[str], jobs: list[Job]
+    ) -> list[Job]:
         """Filter jobs by sections and splits.
         :param filter_section_splits: filter sections and splits
         :param jobs: list of jobs
         :return: list of jobs matching the filter
         """
         section_matching_jobs: list[Job] = []
+        all_splits = list(
+            {
+                str(job.split).upper()
+                for job in jobs
+                if job.splits and int(job.splits) >= 2 and job.split is not None
+            }
+        )
+        
         for section in filter_section_splits:
             section_name = section.strip().split("[")[0].strip()
-            job_splits = []
+
             if "[" in section and "]" in section:
                 job_splits_str = section.strip().split("[")[1].strip(" ]")
                 # splits: can be: [ 1:15 ] [ 1-15 ] [ 1 2 3 4 5 6 ] [ Any ]
-                if "ANY" in job_splits_str.upper() or not job_splits_str.strip():
-                    job_splits = ["ANY"]
-                else:
-                    for job_split in job_splits_str.split():
-                        job_split = job_split.strip()
-                        start = None
-                        end = None
-                        if job_split.find("-") != -1:
-                            start = job_split.split("-")[0]
-                            end = job_split.split("-")[1]
-                        elif job_split.find(":") != -1:
-                            start = job_split.split(":")[0]
-                            end = job_split.split(":")[1]
-                        if start and end:
-                            job_splits += [str(i) for i in range(int(start), int(end) + 1)]
-                        else:
-                            job_splits.append(str(job_split))
-            if not job_splits:
-                job_splits = ["ANY"]
-
-            if section_name == "ANY":
-                section_matching_jobs.extend([j for j in jobs if Autosubmit._split_match(j, job_splits)])
+                job_splits = Autosubmit._expand_values(job_splits_str, all_splits)
             else:
-                section_matching_jobs.extend([j for j in jobs if j.section == section_name and Autosubmit._split_match(j, job_splits)])
-
+                job_splits = set(all_splits)
+            # Filter jobs by section and split
+            if section_name.upper() == "ANY":
+                filtered_jobs = [j for j in jobs if Autosubmit._split_match(j, job_splits)]
+            else:
+                filtered_jobs = [
+                    j
+                    for j in jobs
+                    if j.section.upper() == section_name.upper()
+                    and Autosubmit._split_match(j, job_splits)
+                ]
+            
+            section_matching_jobs.extend(filtered_jobs)
+            # Deduplicate
             section_matching_jobs = list(dict.fromkeys(section_matching_jobs))
 
             # All jobs matched, no need to continue
@@ -4873,7 +4920,9 @@ class Autosubmit:
         return section_matching_jobs
 
     @staticmethod
-    def _filter_chunks(filter_chunk_str: str, job_list: "JobList", matching_jobs: list[Job]) -> list[Job]:
+    def _filter_chunks(
+        filter_chunk_str: str, job_list: "JobList", matching_jobs: list[Job]
+    ) -> list[Job]:
         """Filter jobs by exact date, member and chunk matches.
 
         ``ANY`` acts as a wildcard for the corresponding field. Jobs that do not
@@ -4885,61 +4934,71 @@ class Autosubmit:
 
         :return: list of jobs matching the filter
         """
+        final_list = []
         data = json.loads(Autosubmit._create_json(filter_chunk_str))
-        dates = 'sds'
-        members = 'ms'
-        chunks = 'cs'
-        date = 'sd'
-        member = 'm'
 
-        def normalize_date(value) -> str:
-            return date2str(value).upper() if value is not None else ""
+        dates = "sds"
+        members = "ms"
+        chunks = "cs"
+        date = "sd"
+        member = "m"
 
-        def expand_values(raw_value, known_values: list[str]) -> set[str] | None:
-            value = str(raw_value).strip().upper()
-            if not value or value == "ANY":
-                return None
-            expanded_values: set[str] = set()
-            for token in value.split():
-                if token.find("-") != -1:
-                    start, end = token.split("-", 1)
-                    expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
-                elif token.find(":") != -1:
-                    start, end = token.split(":", 1)
-                    expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
-                else:
-                    expanded_values.add(token)
-            if not expanded_values and known_values:
-                return {str(value).upper() for value in known_values}
-            return expanded_values
+        # Precompute normalized dates, members and chunks
+        normalized_jobs = []
+        for job in matching_jobs:
+            if job.date is None or job.member is None or job.chunk is None:
+                continue
+            normalized_jobs.append(
+                (
+                    job,
+                    date2str(job.date).upper(),
+                    str(job.member).upper(),
+                    str(job.chunk).upper(),
+                )
+            )
 
-        selected_jobs: list[Job] = []
+        all_dates = [date2str(d).upper() for d in job_list._date_list]
+        all_members = [str(m).upper() for m in job_list._member_list]
+        all_chunks = [str(c).upper() for c in job_list._chunk_list]
+
+        selected_dates: set[str] = set()
+        selected_members: set[str] = set()
+
+        # Prune first to reduce the amount of jobs that the chunk filter (last one) has to interate with
+        # Here we want a reduced list of jobs that matches any date or member selected and remove the rest.
         for date_json in data[dates]:
-            selected_dates = expand_values(date_json[date], [normalize_date(d) for d in job_list._date_list])
+            selected_dates.update(Autosubmit._expand_values(date_json[date], all_dates))
             for member_json in date_json[members]:
-                selected_members = expand_values(member_json[member], [str(m).upper() for m in job_list._member_list])
-                for chunk_json in member_json[chunks]:
-                    selected_chunks = expand_values(chunk_json, [str(c).upper() for c in job_list._chunk_list])
-                    for job in matching_jobs:
-                        if job.date is None or job.member is None or job.chunk is None:
-                            continue
+                selected_members.update(Autosubmit._expand_values(member_json[member], all_members))
 
-                        job_date = normalize_date(job.date)
-                        job_member = str(job.member).upper()
-                        job_chunk = str(job.chunk).upper()
+        pruned_jobs = [
+            job_tuple
+            for job_tuple in normalized_jobs
+            if job_tuple[1] in selected_dates and job_tuple[2] in selected_members
+        ]
 
-                        if selected_dates is not None and job_date not in selected_dates:
-                            continue
-                        if selected_members is not None and job_member not in selected_members:
-                            continue
-                        if selected_chunks is not None and job_chunk not in selected_chunks:
-                            continue
-                        selected_jobs.append(job)
+        # Now, build final list according to the structure in data
+        for date_json in data[dates]:
+            date_values = Autosubmit._expand_values(date_json[date], all_dates)
+            for member_json in date_json[members]:
+                member_values = Autosubmit._expand_values(
+                    member_json[member], all_members
+                )
+                for chunk_value in member_json[chunks]:
+                    chunk_values = Autosubmit._expand_values(chunk_value, all_chunks)
+                    for job_tuple in pruned_jobs:
+                        job, job_date, job_member, job_chunk = job_tuple
+                        if (
+                            job_date in date_values
+                            and job_member in member_values
+                            and job_chunk in chunk_values
+                        ):
+                            final_list.append(job)
 
-        return list(dict.fromkeys(selected_jobs))
-
+        return list(set(final_list))
+    
     @staticmethod
-    def filter_jobs_by_chunks_splits(job_list: "JobList", filter_chunks: str) -> list[Job]:
+    def _filter_jobs_by_chunks_splits(job_list: "JobList", filter_chunks: str) -> list[Job]:
         """Select jobs from *job_list* according to *filter_chunks* specification.
 
         Expected format:
@@ -4961,7 +5020,7 @@ class Autosubmit:
 
         final_list = Autosubmit._filter_chunks(fc, job_list, matching_jobs)
 
-        return list(dict.fromkeys(final_list))
+        return list(set(final_list))
 
     @staticmethod
     def set_status(expid: str, noplot: bool, save: bool, final: str, filter_list: str, filter_chunks: str,
@@ -5079,14 +5138,14 @@ class Autosubmit:
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
-                    ft_entries = [section.upper() for section in Autosubmit._split_section_filter_entries(filter_section)]
+                    ft_entries = [section for section in Autosubmit._separate_section_entries(filter_section)]
                     if not (len(ft_entries) == 1 and ft_entries[0] == 'ANY'):
                         section_filtered_jobs = Autosubmit._filter_sections_splits(ft_entries, all_jobs)
                         selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()
-                    chunk_filtered_jobs = Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)
+                    chunk_filtered_jobs = Autosubmit._filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)
                     selected_job_names &={job.name for job in chunk_filtered_jobs}
                     Log.info(f"Chunk filtering took {time.time() - start:.2f} seconds.")
 
@@ -5099,15 +5158,9 @@ class Autosubmit:
 
                 if filter_list:
                     jobs = filter_list.split()
-                    expidJoblist = defaultdict(int)
-                    for x in jobs:
-                        expidJoblist[str(x[0:4])] += 1
-                    if str(expid) in expidJoblist:
-                        wrongExpid = len(jobs) - expidJoblist[expid]
-                    if wrongExpid > 0:
-                        Log.warning(f"There are {wrongExpid} job.name with an invalid Expid")
                     if not (len(jobs) == 1 and jobs[0].upper() == 'ANY'):
                         selected_job_names &= {job.name for job in all_jobs if job.name in jobs}
+
                 # preserve job list ordering
                 final_list = [job for job in all_jobs if job.name in selected_job_names]
                 # Time to change status

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -591,7 +591,7 @@ class Autosubmit:
                 "--filter_type",
                 type=str,
                 help='Select the job type and split to filter the list of jobs. Default split = "Any". '
-                'LIST = "LOCALJOB [5-10]"',
+                'LIST = "LOCALJOB [5-10] SIM"',
             )
             subparser.add_argument(
                 "-ftc",
@@ -4502,9 +4502,10 @@ class Autosubmit:
     @staticmethod
     def _validate_section(as_conf, filter_section):
         """Validates the section filter input.
+        Expected format for each section entry: SECTION or SECTION [1 2 5-8]
 
         :param as_conf: Autosubmit configuration object
-        :param filter_section: section filter input provided by the user
+        :param filter_section: string with the sections separated by blank space
         """
         malformed_error = False  # incorrectly formatted
         malformed_sections = []

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4441,7 +4441,12 @@ class Autosubmit:
         as a wildcard.
 
         :param as_conf: Autosubmit configuration object
+        :type as_conf: AutosubmitConfig
         :param filter_section: string with the sections separated by comma
+        :type filter_section: str
+        :return None if the filter is valid
+        :rtype: None
+        :raises AutosubmitCritical: if the filter is invalid, with a message describing the errors found
         """
         section_validation_message = "\n## Section Validation Message ##"
         section_entries = separate_section_entries(filter_section)
@@ -4469,8 +4474,14 @@ class Autosubmit:
         Each entry must be an exact job name. The filter is space-separated and supports ``ANY`` as a wildcard.
 
         :param as_conf: Autosubmit configuration object
+        :type as_conf: AutosubmitConfig
         :param job_list: JobList object containing the jobs to validate against
+        :type job_list: JobList
         :param filter_list: string with the jobs separated by space
+        :type filter_list: str
+        :return None if the filter is valid
+        :rtype: None
+        :raises AutosubmitCritical: if the filter is invalid, with a message describing the errors found
         """
         job_validation_error = False
         job_error = False
@@ -4513,8 +4524,13 @@ class Autosubmit:
 
         Each entry must be an exact status name. The filter is space-separated and supports ``ANY`` as a wildcard.
 
-        :param job_list: JobList object containing the jobs to validate against.
+        :param job_list: JobList object containing the jobs to validate against
+        :type job_list: JobList
         :param filter_status: string with the statuses separated by space
+        :type filter_status: str
+        :return None if the filter is valid
+        :rtype: None
+        :raises AutosubmitCritical: if the filter is invalid, with a message describing the errors found
         """
         status_validation_error = False
         status_validation_message = "\n## Status Validation Message ##"
@@ -4550,8 +4566,11 @@ class Autosubmit:
         [ 19900101 [ fc0 [ Any ] fc1 [1 2] ] 19950101 [ fc0 [1-10] ] ]
 
         :param chunk_formula: Chunk formula string.
+        :type chunk_formula: str
         :param validation_message: Message to append validation errors to.
+        :type validation_message: str
         :return: Updated validation message with any errors found.
+        :rtype: str
         """
 
         if not chunk_formula:
@@ -4613,9 +4632,13 @@ class Autosubmit:
         Expects to receive the second part of the -ftcs filter. ex: SIM [ Any ], SIM2 [1 2], SIM3.
 
         :param section_split_formula: section_split_formula string.
+        :type section_split_formula: str
         :param validation_message: Message to append validation errors to.
+        :type validation_message: str
         :param valid_sections: Set of valid section names.
+        :type valid_sections: Optional[set[str]]
         :return: Updated validation message with any errors found.
+        :rtype: str
         """
 
         if not section_split_formula:
@@ -4660,16 +4683,17 @@ class Autosubmit:
         Validate that the filter string contains a chunk formula and, optionally,
         a comma-separated list of section names. Section names are checked
         case-insensitively against the keys in ``as_conf.jobs_data``.
-
         Splits are also optional and must be included in the Section part of the formula.
-
         [ chunk_splits_formula, section1 [splits], section2 [splits], ... ]
-
         Example:
-
         [ 19900101 [ fc0 [ Any ] fc1 [1 2] ] 19950101 [ fc0 [1-10] ], SIM [ Any ], SIM2 [1 2] ]
 
         :param filter_string: Filter string with form '<chunk_split_formula>[,<SECTION>[<splits>],...]'.
+        :type filter_string: str
+        :param valid_sections: Set of valid section names for validation. If None, section names are not validated.
+        :type valid_sections: Optional[set[str]]
+        :return: None if the filter string is valid.
+        :rtype: None
         :raises AutosubmitCritical: If the input is malformed or references unknown sections.
         """
 
@@ -4709,11 +4733,19 @@ class Autosubmit:
         AutosubmitCritical (code 7014) if all filters are empty or whitespace-only.
 
         :param as_conf: Autosubmit configuration object.
+        :type as_conf: AutosubmitConfig
         :param job_list: JobList object containing jobs to validate against.
+        :type job_list: JobList
         :param filter_list: Job name list filter (``-fl``).
+        :type filter_list: Optional[str]
         :param filter_chunk_section_split: Chunk/section/split filter (``-fc``, ``-ftc``, ``-ftcs``).
+        :type filter_chunk_section_split: Optional[str]
         :param filter_status: Status filter (``-fs``).
+        :type filter_status: Optional[str]
         :param filter_section: Section filter (``-ft``).
+        :type filter_section: Optional[str]
+        :return: None if all provided filters are valid.
+        :rtype: None
         :raises AutosubmitCritical: If no non-empty filter is provided or if any validator fails.
         """
         all_empty = True
@@ -4744,9 +4776,13 @@ class Autosubmit:
         If no split filter is provided (or ``ANY``), all jobs match.
         When specific splits are provided, only real split jobs (``splits >= 2``)
         can match.
+
         :param j: Job object to check.
+        :type j: Job
         :param split_list: list of splits to match against.
+        :type split_list: list[str]
         :return: True if the job matches the split filter, False otherwise.
+        :rtype: bool
         """
         if not split_list or "ANY" in split_list:
             return True
@@ -4761,9 +4797,13 @@ class Autosubmit:
         filter_section_splits: list[str], jobs: list[Job]
     ) -> list[Job]:
         """Filter jobs by sections and splits.
+
         :param filter_section_splits: filter sections and splits
+        :type filter_section_splits: list[str]
         :param jobs: list of jobs
+        :type jobs: list[Job]
         :return: list of jobs matching the filter
+        :rtype: list[Job]
         """
         section_matching_jobs: list[Job] = []
         all_splits = list(
@@ -4841,10 +4881,13 @@ class Autosubmit:
         have a value for a required field are excluded.
 
         :param filter_chunk_str: filter chunks
+        :type filter_chunk_str: str
         :param job_list: JobList object
+        :type job_list: JobList
         :param matching_jobs: list of jobs to filter
-
+        :type matching_jobs: list[Job]
         :return: list of jobs matching the filter
+        :rtype: list[Job]
         """
         final_list = []
         data = json.loads(Autosubmit._create_json(filter_chunk_str))
@@ -4917,8 +4960,11 @@ class Autosubmit:
             - "[ DATE|Any [ MEMBER|Any [ CHUNKS|Any ] ... ] ... ], SECTION1|Any [SPLITS|Any], ..."
 
         :param job_list: JobList object
+        :type job_list: JobList
         :param filter_chunks: filter chunks
+        :type filter_chunks: str
         :return: list of jobs matching the filter
+        :rtype: list[Job]
         """
 
         filter_chunks = filter_chunks.upper()
@@ -4942,22 +4988,40 @@ class Autosubmit:
         """Set status of jobs.
 
         :param expid: experiment id
+        :type expid: str
         :param noplot: do not plot
+        :type noplot: bool
         :param save: save
+        :type save: bool
         :param final: final status
+        :type final: str
         :param filter_list: list of jobs
+        :type filter_list: str
         :param filter_chunks: filter chunks
+        :type filter_chunks: str
         :param filter_status: filter status
+        :type filter_status: str
         :param filter_section: filter section
+        :type filter_section: str
         :param filter_type_chunk: filter type chunk
+        :type filter_type_chunk: str
         :param filter_type_chunk_split: filter chunk split
+        :type filter_type_chunk_split: str
         :param hide: hide
+        :type hide: bool
         :param group_by: group by
+        :type group_by: Optional[str]
         :param expand: Whether to expand during job grouping or not.
+        :type expand: Optional[list]
         :param expand_status: The status to use when expanding.
+        :type expand_status: Optional[str]
         :param check_wrapper: check wrapper
+        :type check_wrapper: bool
         :param detail: detail
+        :type detail: bool
         :return: ``True`` if executed successfully.
+        :rtype: bool
+        :raises AutosubmitCritical: if any of the filters is malformed or if no filter is provided, with a message describing the errors found.
         """
         if filter_status:
             filter_status = filter_status.upper()

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4524,23 +4524,24 @@ class Autosubmit:
                 if not section:
                     continue
                 # regex expression match
-                # evaluate two groups in the section
+                # evaluate two parts in the section
                 # SECTION: string with uppercase letters, digits, _ . - or the keyword 'ANY'
                 # SPLIT: optional list of sections between brackets, separated by blank space
                 match = re.match(
                     r"^([A-Z0-9_.-]+|ANY)(?:\s*\[(.*?)\])?$", section, re.IGNORECASE
                 )
+                # evaluate section format
                 if not match:
                     malformed_sections.append(section)
                     continue
 
                 section_name = match.group(1).upper()
                 splits = match.group(2)
-
+                # evaluate section name
                 if section_name not in valid_sections and section_name != "ANY":
                     section_not_found_error = True
                     section_not_found_list.append(section_name)
-
+                # evaluate section splits
                 if splits is not None:
                     section_validation_message = (
                         Autosubmit._validate_section_split_formula(

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -5074,7 +5074,8 @@ class Autosubmit:
 
                 if filter_chunks or filter_type_chunk or filter_type_chunk_split:
                     start = time.time()
-                    selected_job_names &={job.name for job in Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)}
+                    chunk_filtered_jobs = Autosubmit.filter_jobs_by_chunks_splits(job_list, filter_chunk_section_split)
+                    selected_job_names &={job.name for job in chunk_filtered_jobs}
                     Log.info(f"Chunk filtering took {time.time() - start:.2f} seconds.")
 
                 if filter_status:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4527,11 +4527,12 @@ class Autosubmit:
                     continue
                 # regex expression match
                 # evaluate two parts in the section
-                # SECTION: string with uppercase letters, digits, _ . - or the keyword 'ANY'
-                # SPLIT: optional only one pair of brackets
+                # SECTION NAME: string with uppercase letters, digits, _ . - or the keyword 'ANY'
+                # SPLIT: optional, only one pair of brackets allowed
                 match = re.match(
-                    r"^([A-Z0-9_.-]+|ANY)(?:\s*\[\s*([0-9]+(?:[-:][0-9]+)?(?:\s+[0-9]+(?:[-:][0-9]+)?)*)\s*\])?$",
-                    section,re.IGNORECASE
+                    r"^([A-Z0-9_.-]+|ANY)(?:\s*\[\s*((?:ANY)|(?:[0-9]+(?:[-:][0-9]+)?(?:\s+[0-9]+(?:[-:][0-9]+)?)*))\s*\])?$",
+                    section,
+                    re.IGNORECASE,
                 )
                 # evaluate section format
                 if not match:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -79,7 +79,7 @@ from autosubmit.notifications.notifier import Notifier
 from autosubmit.platforms.paramiko_platform import ParamikoPlatform
 from autosubmit.platforms.paramiko_submitter import ParamikoSubmitter
 from autosubmit.platforms.platform import Platform
-from autosubmit.utils import as_conf_default_values
+from autosubmit.utils import as_conf_default_values, separate_section_entries, expand_values
 
 
 if TYPE_CHECKING:
@@ -1276,70 +1276,6 @@ class Autosubmit:
             # replace only the parameter
             content = re.sub(rf'({parameter}:).*', rf'\1 "{new_value}"', content)
         return content
-
-    @staticmethod
-    def as_conf_default_values(exp_id:str, hpc:str = "local", minimal_configuration:bool = False, git_repo:str = "",
-                               git_branch:str = "main", git_as_conf:str = "") -> None:
-        """Replace default values in as_conf files.
-
-        :param exp_id: experiment id
-        :param hpc: platform
-        :param minimal_configuration: minimal configuration
-        :param git_repo: path to project git repository
-        :param git_branch: main branch
-        :param git_as_conf: path to as_conf file in git repository
-        :return: None
-        """
-        # the var hpc was hardcoded in the header of the function
-
-        # open and replace values
-        for as_conf_file in Path(BasicConfig.LOCAL_ROOT_DIR, f"{exp_id}/conf").iterdir():
-            if as_conf_file.name.endswith(".yml") or as_conf_file.name.endswith(".yaml"):
-                with open(as_conf_file, 'r+') as f:
-                    # Copied files could not have default names.
-                    content = f.read()
-                    search = re.search('AUTOSUBMIT_VERSION: .*', content, re.MULTILINE)
-                    if search is not None:
-                        content = content.replace(search.group(0), f"AUTOSUBMIT_VERSION: \""
-                                                                   f"{Autosubmit.autosubmit_version}\"")
-                    search = re.search('NOTIFICATIONS: .*', content, re.MULTILINE)
-                    if search is not None:
-                        content = content.replace(search.group(0), "NOTIFICATIONS: False")
-                    search = re.search('TO: .*', content, re.MULTILINE)
-                    if search is not None:
-                        content = content.replace(search.group(0), "TO: \"\"")
-                    content = Autosubmit.replace_parameter_inside_section(content, "EXPID", exp_id, "DEFAULT")
-                    search = re.search('HPCARCH: .*', content, re.MULTILINE)
-                    if search is not None:
-                        x = search.group(0).split(":")
-                        # clean blank space, quotes and double quote
-                        aux = x[1].strip(' "\'')
-                        # hpc in config is empty && -H has a value-> write down hpc value
-                        if hpc != "":
-                            content = content.replace(search.group(0), f"HPCARCH: \"{hpc}\"")
-                        elif len(aux) > 0:
-                            content = content.replace(search.group(0), f"HPCARCH: \"{aux}\"")
-                        else:
-                            content = content.replace(search.group(0), "HPCARCH: \"local\"")
-                        # the other case is aux!=0 that we dont care about val(hpc) because its a copyExpId
-                    if minimal_configuration:
-                        search = re.search('CUSTOM_CONFIG: .*', content, re.MULTILINE)
-                        if search is not None:
-                            content = content.replace(search.group(0),
-                                                      "CUSTOM_CONFIG: \"%PROJDIR%/" + git_as_conf + "\"")
-                        search = re.search('PROJECT_ORIGIN: .*', content, re.MULTILINE)
-                        if search is not None:
-                            content = content.replace(search.group(0), f"PROJECT_ORIGIN: \"{git_repo}\"")
-                        search = re.search('PROJECT_PATH: .*', content, re.MULTILINE)
-                        if search is not None:
-                            content = content.replace(search.group(0), f"PROJECT_PATH: \"{git_repo}\"")
-                        search = re.search('PROJECT_BRANCH: .*', content, re.MULTILINE)
-                        if search is not None:
-                            content = content.replace(search.group(0), f"PROJECT_BRANCH: \"{git_branch}\"")
-
-                    f.seek(0)
-                    f.write(content)
-                    f.truncate()
 
     @staticmethod
     def expid(description, hpc="", copy_id='', dummy=False, minimal_configuration=False,
@@ -4508,7 +4444,7 @@ class Autosubmit:
         :param filter_section: string with the sections separated by comma
         """
         section_validation_message = "\n## Section Validation Message ##"
-        section_entries = Autosubmit._separate_section_entries(filter_section)
+        section_entries = separate_section_entries(filter_section)
 
         if not section_entries:
             section_validation_message += "\n\tEmpty input. No changes performed."
@@ -4687,6 +4623,7 @@ class Autosubmit:
 
         for section in [section.strip() for section in section_split_formula.split(",") if section.strip()]:
             section_name = section.strip().split("[")[0].strip().upper()
+            split_part = section.strip().split("[")[1].strip() if "[" in section and "]" in section else None
             if valid_sections is not None and section_name not in valid_sections and section_name != "ANY":
                 validation_message += f"\n\tSpecified section not found: {section_name}."
             
@@ -4800,25 +4737,6 @@ class Autosubmit:
 
         if all_empty:
             raise AutosubmitCritical("At least one filter must be provided and must be not empty when using -fs, -ft, -fc, -ftc or -ftcs.", 7014)
-    
-    @staticmethod
-    def _separate_section_entries(filter_entries: str) -> list[str]:
-        """Separate section entries with optional splits separated by comma into a list.
-
-        :param filter_entries: string with the entries separated by comma
-        :return: list of entries
-        """
-        text = filter_entries.strip()
-        if not text:
-            return []
-
-        entries = []
-        for entry in text.split(","):
-            entry = entry.strip()
-            if not entry:
-                continue
-            entries.append(entry.upper())
-        return entries
 
     @staticmethod
     def _split_match(j: Job, split_list: list[str]) -> bool:
@@ -4840,32 +4758,6 @@ class Autosubmit:
         return str(j.split) in split_list
 
     @staticmethod
-    def _expand_values(raw_value: str, known_values: list[str]) -> set[str]:
-        """Expand ranges, colon, dash, space-separated values.
-
-        'ANY' expands to known_values if given.
-        :param raw_value: string with the values to expand
-        :param known_values: list of known valuses to expand 'ANY' to
-        :return: set of expanded values
-        """
-        if raw_value is None:
-            return set(known_values) if known_values else set()
-
-        value = str(raw_value).strip().upper()
-        if not value or value == "ANY":
-            return set(known_values) if known_values else set()
-
-        expanded_values: set[str] = set()
-        for token in value.split():
-            if "-" in token or ":" in token:
-                sep = "-" if "-" in token else ":"
-                start, end = token.split(sep, 1)
-                expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
-            else:
-                expanded_values.add(token)
-        return expanded_values
-
-    @staticmethod
     def _filter_sections_splits(
         filter_section_splits: list[str], jobs: list[Job]
     ) -> list[Job]:
@@ -4885,21 +4777,48 @@ class Autosubmit:
         
         for section in filter_section_splits:
             section_name = section.strip().split("[")[0].strip()
+            section_name_upper = section_name.upper()
+            has_split_selector = "[" in section and "]" in section
+            job_splits_str = ""
 
-            if "[" in section and "]" in section:
+            if has_split_selector:
                 job_splits_str = section.strip().split("[")[1].strip(" ]")
                 # splits: can be: [ 1:15 ] [ 1-15 ] [ 1 2 3 4 5 6 ] [ Any ]
-                job_splits = Autosubmit._expand_values(job_splits_str, all_splits)
+                job_splits = expand_values(job_splits_str, all_splits)
             else:
                 job_splits = set(all_splits)
+
+            if (
+                has_split_selector
+                and job_splits_str.strip()
+                and job_splits_str.strip().upper() != "ANY"
+            ):
+                if section_name_upper == "ANY":
+                    available_section_splits = set(all_splits)
+                else:
+                    available_section_splits = {
+                        str(job.split).upper()
+                        for job in jobs
+                        if job.section.upper() == section_name_upper
+                        and job.splits
+                        and int(job.splits) >= 2
+                        and job.split is not None
+                    }
+
+                missing_splits = set(job_splits) - available_section_splits
+                if missing_splits:
+                    Log.warning(
+                        f"Some jobs do not exist in section '{section_name_upper}' with the requested splits."
+                    )
+
             # Filter jobs by section and split
-            if section_name.upper() == "ANY":
+            if section_name_upper == "ANY":
                 filtered_jobs = [j for j in jobs if Autosubmit._split_match(j, job_splits)]
             else:
                 filtered_jobs = [
                     j
                     for j in jobs
-                    if j.section.upper() == section_name.upper()
+                    if j.section.upper() == section_name_upper
                     and Autosubmit._split_match(j, job_splits)
                 ]
             
@@ -4961,9 +4880,9 @@ class Autosubmit:
         # Prune first to reduce the amount of jobs that the chunk filter (last one) has to interate with
         # Here we want a reduced list of jobs that matches any date or member selected and remove the rest.
         for date_json in data[dates]:
-            selected_dates.update(Autosubmit._expand_values(date_json[date], all_dates))
+            selected_dates.update(expand_values(date_json[date], all_dates))
             for member_json in date_json[members]:
-                selected_members.update(Autosubmit._expand_values(member_json[member], all_members))
+                selected_members.update(expand_values(member_json[member], all_members))
 
         pruned_jobs = [
             job_tuple
@@ -4973,13 +4892,13 @@ class Autosubmit:
 
         # Now, build final list according to the structure in data
         for date_json in data[dates]:
-            date_values = Autosubmit._expand_values(date_json[date], all_dates)
+            date_values = expand_values(date_json[date], all_dates)
             for member_json in date_json[members]:
-                member_values = Autosubmit._expand_values(
+                member_values = expand_values(
                     member_json[member], all_members
                 )
                 for chunk_value in member_json[chunks]:
-                    chunk_values = Autosubmit._expand_values(chunk_value, all_chunks)
+                    chunk_values = expand_values(chunk_value, all_chunks)
                     for job_tuple in pruned_jobs:
                         job, job_date, job_member, job_chunk = job_tuple
                         if (
@@ -5132,7 +5051,7 @@ class Autosubmit:
                 
                 final_status = Autosubmit._get_status(final)
                 if filter_section:
-                    ft_entries = [section for section in Autosubmit._separate_section_entries(filter_section)]
+                    ft_entries = [section for section in separate_section_entries(filter_section)]
                     if not (len(ft_entries) == 1 and ft_entries[0] == 'ANY'):
                         section_filtered_jobs = Autosubmit._filter_sections_splits(ft_entries, all_jobs)
                         selected_job_names &= {job.name for job in all_jobs if job in section_filtered_jobs}

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4522,22 +4522,27 @@ class Autosubmit:
             valid_sections = {str(section).upper() for section in as_conf.jobs_data}
             for raw_section in Autosubmit._split_section_filter_entries(filter_section):
                 section = raw_section.strip()
+                print(f"Validating section entry: '{section}'")
                 if not section:
                     continue
                 # regex expression match
                 # evaluate two parts in the section
                 # SECTION: string with uppercase letters, digits, _ . - or the keyword 'ANY'
-                # SPLIT: optional list of sections between brackets, separated by blank space
+                # SPLIT: optional only one pair of brackets
                 match = re.match(
-                    r"^([A-Z0-9_.-]+|ANY)(?:\s*\[(.*?)\])?$", section, re.IGNORECASE
+                    r"^([A-Z0-9_.-]+|ANY)(?:\s*\[\s*([0-9]+(?:[-:][0-9]+)?(?:\s+[0-9]+(?:[-:][0-9]+)?)*)\s*\])?$",
+                    section,re.IGNORECASE
                 )
                 # evaluate section format
                 if not match:
+                    print(f"Section entry '{section}' is malformed.")
                     malformed_sections.append(section)
                     continue
 
                 section_name = match.group(1).upper()
                 splits = match.group(2)
+                print(f"Extracted section name: '{section_name}'")
+                print(f"Extracted splits: '{splits}'")
                 # evaluate section name
                 if section_name not in valid_sections and section_name != "ANY":
                     section_not_found_error = True

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4521,7 +4521,6 @@ class Autosubmit:
         else:
             valid_sections = {str(section).upper() for section in as_conf.jobs_data}
             for raw_section in Autosubmit._split_section_filter_entries(filter_section):
-                print(f"Validating section entry: '{raw_section}'")
                 section = raw_section.strip()
                 if not section:
                     continue
@@ -4578,13 +4577,13 @@ class Autosubmit:
 
     @staticmethod
     def _split_section_filter_entries(filter_section: str) -> list[str]:
-        """Split ``-ft`` filter into section entries preserving split blocks.
-        Entries are section names, optionally followed by a bracketed split block.
+        """Split ``-ft`` filter into sections preserving split blocks.
+        Sections are section names, optionally followed by a split bracket.
         The separation between sections is a comma.
         Examples of valid entries:
-        LOCALJOB PSJOB
+        LOCALJOB, PSJOB
         LOCALJOB [1 2], PSJOB [3-5]
-        LOCALJOB [12] PSJOB
+        LOCALJOB [1:2], PSJOB
         LOCALJOB [1]
 
         :param filter_section: string with the sections separated by blank space

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4845,7 +4845,7 @@ class Autosubmit:
 
     @staticmethod
     def _expand_values(
-        raw_value: str | None, known_values: list[str] | None = None
+        raw_value: str, known_values: list[str]
     ) -> set[str]:
         """Expand ranges, colon, dash, space-separated values.
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4500,7 +4500,7 @@ class Autosubmit:
         Log.status("CHANGED: job: " + job.name + " status to: " + final)
 
     @staticmethod
-    def _validate_section(as_conf, filter_section):
+    def _validate_section(as_conf: AutosubmitConfig, filter_section: str) -> None:
         """Validates the section filter input.
         Expected format for each section entry: SECTION or SECTION [1 2 5-8]
 
@@ -4575,58 +4575,38 @@ class Autosubmit:
                     7011,
                     section_validation_message,
                 )
-    
+
     @staticmethod
     def _split_section_filter_entries(filter_section: str) -> list[str]:
         """Split ``-ft`` filter into section entries preserving split blocks.
-        Entries are space-separated section names, optionally followed by
-        a bracketed split block. 
+        Entries are section names, optionally followed by a bracketed split block.
+        The separation between sections is a comma.
         Examples of valid entries:
         LOCALJOB PSJOB
-        LOCALJOB [1 2] PSJOB [3-5]
-        LOCALJOB [1 2] PSJOB
+        LOCALJOB [1 2], PSJOB [3-5]
+        LOCALJOB [12] PSJOB
         LOCALJOB [1]
+
+        :param filter_section: string with the sections separated by blank space
+        :return: list of section entries
         """
         text = filter_section.strip()
         if not text:
             return []
 
         entries = []
-        current = []
-        level = 0
-        i = 0
-        while i < len(text):
-            ch = text[i]
-            if ch == "[":
-                level += 1
-                current.append(ch)
-            elif ch == "]":
-                level = max(0, level - 1)
-                current.append(ch)
-            elif ch == " " and level == 0:
-                # peek ahead, skip spaces, check if next char is '['
-                j = i + 1
-                while j < len(text) and text[j] == " ":
-                    j += 1
-                if j < len(text) and text[j] == "[":
-                    # space between section name and its bracket block, keep together
-                    current.append(ch)
-                else:
-                    # space between two entries, flush current
-                    entry = "".join(current).strip()
-                    if entry:
-                        entries.append(entry)
-                    current = []
-            else:
-                current.append(ch)
-            i += 1
-
-        tail = "".join(current).strip()
-        if tail:
-            entries.append(tail)
-
+        for entry in text.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            if re.search(r"\s+\[", entry):
+                raise AutosubmitCritical(
+                    "Malformed section filter: space between section name and split block.",
+                    7011,
+                    "\n\tEach entry should be in the format: SECTION or SECTION [1 2 5-8].",
+                )
+            entries.append(entry)
         return entries
-
 
     @staticmethod
     def _validate_list(as_conf, job_list, filter_list):

--- a/autosubmit/utils.py
+++ b/autosubmit/utils.py
@@ -77,3 +77,48 @@ def as_conf_default_values(autosubmit_version: str, exp_id: str, hpc: str = "", 
                     yaml_data['DEFAULT']['CUSTOM_CONFIG'] = f"%PROJDIR%/{git_as_conf}"
 
             yaml.dump(yaml_data, as_conf_file)
+
+def separate_section_entries(filter_entries: str) -> list[str]:
+    """Separate section entries with optional splits separated by comma into a list.
+
+    :param filter_entries: string with the entries separated by comma
+    :return: list of entries
+    """
+    text = filter_entries.strip()
+    if not text:
+        return []
+
+    entries = []
+    for entry in text.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        entries.append(entry.upper())
+    return entries
+
+def expand_values(raw_value: str, known_values: list[str]) -> set[str]:
+    """Expand ranges, colon, dash, space-separated values.
+
+    'ANY' expands to known_values if given.
+    :param raw_value: string with the values to expand
+    :param known_values: list of known valuses to expand 'ANY' to
+    :return: set of expanded values
+    """
+    set_known_values: set[str] = set(known_values) if known_values else set()
+
+    if raw_value is None:
+        return set_known_values
+
+    value = str(raw_value).strip().upper()
+    if not value or value == "ANY":
+        return set_known_values
+
+    expanded_values: set[str] = set()
+    for token in value.split():
+        if "-" in token or ":" in token:
+            sep = "-" if "-" in token else ":"
+            start, end = token.split(sep, 1)
+            expanded_values.update(str(i) for i in range(int(start), int(end) + 1))
+        else:
+            expanded_values.add(token)
+    return expanded_values

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -175,7 +175,7 @@ Mandatory arguments:
 
 * ``<EXPID>``: experiment identifier
 * ``-f{ l | s | t | c } <VALUE_TO_FILTER>``: at least one filter is required to select jobs (see below for filter options)
-* ``-t STATUS_FINAL``: target status (``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``FAILED``, ``UNKNOWN``)
+* ``-t STATUS_FINAL``: target status (``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``HELD``, ``UNKNOWN``)
 
 Optional filter arguments (combine multiple for granular selection):
 
@@ -191,17 +191,18 @@ Optional filter arguments (combine multiple for granular selection):
 
     autosubmit setstatus <EXPID> -fc "[ 19601101 [ fc1 [1] ] ]" -t READY -s
 
-* ``-fs``: space-separated job statuses. The available statuses are: ``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``FAILED``, and ``UNKNOWN``.
+* ``-fs``: space-separated job statuses. The available statuses are: ``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``HELD``, and ``UNKNOWN``.
 
 ::
 
     autosubmit setstatus <EXPID> -fs FAILED -t READY -s
 
-* ``-ft``: space-separated job types
+* ``-ft``: space-separated job types with optional split selection
 
 ::
 
     autosubmit setstatus <EXPID> -ft TRANSFER -t SUSPENDED -s
+    autosubmit setstatus <EXPID> -ft "TRANSFER[1 2]" -t SUSPENDED -s
 
 * ``-ftc``: **[DEPRECATED]** legacy chunk/type filter (use a combination of ``-fc`` and ``-ft`` instead).
 
@@ -257,6 +258,11 @@ Single filter, by job type:
 ::
 
     autosubmit setstatus <EXPID> -ft TRANSFER -t SUSPENDED -s
+
+Single filter, by job type and split:
+::
+
+    autosubmit setstatus <EXPID> -ft "TRANSFER[1:5]" -t SUSPENDED -s
 
 Multiple filters combined (AND logic, selects jobs matching ALL filters):
 ::

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -319,7 +319,7 @@ def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
     ],
 )
 def test_set_status_filter_type_with_splits(as_exp, ft_filter, expected_jobs):
-    """``-ft`` should support split selectors per section."""
+    """Test ``-ft`` with splits per section."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -312,10 +312,13 @@ def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
 @pytest.mark.parametrize(
     "ft_filter, expected_jobs",
     [
-        ("LOCALJOB [2]", 8),
+        ("LOCALJOB [2]", 16),
         ("LOCALJOB [2-3]", 16),
         ("LOCALJOB [2:3]", 16),
         ("LOCALJOB [ANY]", 24),
+        ("LOCALJOB [2], LOCALJOB [3]", 16),
+        ("SLURMJOB, PSJOB [2]", 16),
+        ("SLURMJOB [2], PSJOB", 16),
     ],
 )
 def test_set_status_filter_type_with_splits(as_exp, ft_filter, expected_jobs):
@@ -342,7 +345,7 @@ def test_set_status_filter_type_with_splits(as_exp, ft_filter, expected_jobs):
 
 
 def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp):
-    """Unknown sections in ``-ft`` must fail validation before changing any status."""
+    """Unknown sections in ``-ft`` raises AutosubmitCritical."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )
@@ -358,8 +361,46 @@ def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp):
         )
 
 
+def test_set_status_filter_type_empty_section_raises_validation_error(as_exp):
+    """Unknown sections in ``-ft`` raises AutosubmitCritical."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    # assert error message contains "Empty input. No changes performed."
+
+    reset(as_exp, "WAITING")
+
+    with pytest.raises(AutosubmitCritical) as validation_err:
+        do_setstatus(
+            as_exp,
+            ft=" ",
+            target="COMPLETED",
+        )
+
+    assert "Empty input. No changes performed." in str(validation_err.value)
+
+
+def test_set_status_filter_type_with_splits_invalid_split_raises_validation_error(as_exp):
+    """Invalid splits in ``-ft`` raises AutosubmitCritical."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    with pytest.raises(AutosubmitCritical):
+        do_setstatus(
+            as_exp,
+            ft="LOCALJOB [999]",
+            target="COMPLETED",
+        )
+
+
 def test_set_status_filter_chunks_invalid_section_raises_validation_error(as_exp):
-    """Unknown sections in ``-fc`` section/split suffix must fail validation."""
+    """Unknown sections in ``-fc`` section/split raises AutosubmitCritical."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )
@@ -376,7 +417,7 @@ def test_set_status_filter_chunks_invalid_section_raises_validation_error(as_exp
 
 
 def test_set_status_invalid_job_in_list_raises_validation_error(as_exp):
-    """Invalid job IDs in ``-fl`` must fail validation without bypassing validators."""
+    """Invalid job IDs ``-fl`` raises AutosubmitCritical."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -309,6 +309,72 @@ def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
     assert len(completed_jobs) == 9
 
 
+@pytest.mark.parametrize(
+    "ft_filter, expected_jobs",
+    [
+        ("LOCALJOB [2]", 8),
+        ("LOCALJOB [2-3]", 16),
+        ("LOCALJOB [2:3]", 16),
+        ("LOCALJOB [ANY]", 24),
+    ],
+)
+def test_set_status_filter_type_with_splits(as_exp, ft_filter, expected_jobs):
+    """``-ft`` should support split selectors per section."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        ft=ft_filter,
+        target="COMPLETED",
+    )
+
+    completed_jobs = [
+        job
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.section == "LOCALJOB"
+    ]
+    assert len(completed_jobs) == expected_jobs
+
+
+def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp):
+    """Unknown sections in ``-ft`` must fail validation before changing any status."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    with pytest.raises(AutosubmitCritical):
+        do_setstatus(
+            as_exp,
+            ft="DOES_NOT_EXIST [1]",
+            target="COMPLETED",
+        )
+
+
+def test_set_status_filter_chunks_invalid_section_raises_validation_error(as_exp):
+    """Unknown sections in ``-fc`` section/split suffix must fail validation."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    with pytest.raises(AutosubmitCritical):
+        do_setstatus(
+            as_exp,
+            fc="[20200101 [ fc0 [1] ] ],DOES_NOT_EXIST [1]",
+            target="COMPLETED",
+        )
+
+
 def test_set_status_invalid_job_in_list_raises_validation_error(as_exp):
     """Invalid job IDs in ``-fl`` must fail validation without bypassing validators."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -312,13 +312,13 @@ def test_set_status_section_any_with_chunk_filter_does_not_restrict(as_exp):
 @pytest.mark.parametrize(
     "ft_filter, expected_jobs",
     [
-        ("LOCALJOB [2]", 16),
+        ("LOCALJOB [2]", 8),
         ("LOCALJOB [2-3]", 16),
         ("LOCALJOB [2:3]", 16),
         ("LOCALJOB [ANY]", 24),
         ("LOCALJOB [2], LOCALJOB [3]", 16),
-        ("SLURMJOB, PSJOB [2]", 16),
-        ("SLURMJOB [2], PSJOB", 16),
+        ("SLURMJOB, PSJOB [2]", 0),
+        ("SLURMJOB [2], PSJOB", 0),
     ],
 )
 def test_set_status_filter_type_with_splits(as_exp, ft_filter, expected_jobs):
@@ -372,18 +372,16 @@ def test_set_status_filter_type_empty_section_raises_validation_error(as_exp):
 
     reset(as_exp, "WAITING")
 
-    with pytest.raises(AutosubmitCritical) as validation_err:
+    with pytest.raises(AutosubmitCritical):
         do_setstatus(
             as_exp,
             ft=" ",
             target="COMPLETED",
         )
 
-    assert "Empty input. No changes performed." in str(validation_err.value)
 
-
-def test_set_status_filter_type_with_splits_invalid_split_raises_validation_error(as_exp):
-    """Invalid splits in ``-ft`` raises AutosubmitCritical."""
+def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp):
+    """Invalid splits in ``-ft`` does not change any job status"""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )
@@ -391,12 +389,11 @@ def test_set_status_filter_type_with_splits_invalid_split_raises_validation_erro
 
     reset(as_exp, "WAITING")
 
-    with pytest.raises(AutosubmitCritical):
-        do_setstatus(
-            as_exp,
-            ft="LOCALJOB [999]",
-            target="COMPLETED",
-        )
+    do_setstatus(
+        as_exp,
+        ft="LOCALJOB [999]",
+        target="COMPLETED",
+    )
 
 
 def test_set_status_filter_chunks_invalid_section_raises_validation_error(as_exp):

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -399,8 +399,8 @@ def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp, 
         )
 
 
-def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp):
-    """Invalid splits in ``-ft`` does not change any job status"""
+def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp, mocker):
+    """Unknown split in ``-ft`` logs a warning and does not stop execution."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )
@@ -408,10 +408,59 @@ def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp):
 
     reset(as_exp, "WAITING")
 
-    do_setstatus(
+    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
+
+    job_list_ = do_setstatus(
         as_exp,
         ft="LOCALJOB [999]",
         target="COMPLETED",
+    )
+
+    completed_jobs = [
+        job for job in job_list_.get_job_list() if job.status == Status.COMPLETED
+    ]
+    assert len(completed_jobs) == 0
+
+    warning_messages = [
+        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
+    ]
+    assert any(
+        "Some jobs do not exist in section 'LOCALJOB' with the requested splits." in message
+        for message in warning_messages
+    )
+
+
+def test_set_status_filter_type_with_splits_partial_range_logs_missing_range(as_exp, mocker):
+    """Partially missing split ranges in ``-ft`` log a warning but still update valid splits."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        ft="LOCALJOB [1-999]",
+        target="COMPLETED",
+    )
+
+    completed_jobs = [
+        job
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED and job.section == "LOCALJOB"
+    ]
+    assert len(completed_jobs) == 24
+
+    warning_messages = [
+        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
+    ]
+    assert any(
+        "Some jobs do not exist in section 'LOCALJOB' with the requested splits."
+        in message
+        for message in warning_messages
     )
 
 

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -24,6 +24,7 @@ from autosubmit.job.job_common import Status
 import pytest
 
 from autosubmit.log.log import AutosubmitCritical
+from bscearth.utils.date import date2str
 
 
 @pytest.fixture(scope="function")
@@ -145,6 +146,34 @@ def test_set_status(as_exp, slurm_server, reset_target):
             if job.status == Status.COMPLETED
         ]
         assert len(completed_jobs) == len(job_list_.get_job_list())
+
+
+def test_set_status_filter_chunks_matches_exact_job_fields(as_exp):
+    """``-fc`` must only match the exact date/member/chunk combination."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    job_list_ = do_setstatus(
+        as_exp,
+        fc="[20200101 [ fc0 [1] ] ]",
+        target="COMPLETED",
+    )
+
+    completed_jobs = [
+        job
+        for job in job_list_.get_job_list()
+        if job.status == Status.COMPLETED
+    ]
+
+    assert len(completed_jobs) == 9
+    # datetime object
+    assert all(date2str(job.date) == "20200101" for job in completed_jobs)
+    assert all(job.member == "fc0" for job in completed_jobs)
+    assert all(job.chunk == 1 for job in completed_jobs)
 
 
 def test_set_status_combined_filters(as_exp):

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -398,8 +398,15 @@ def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp, 
             target="COMPLETED",
         )
 
-
-def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp, mocker):
+@pytest.mark.parametrize(
+    "ft_filter, expected_jobs",
+    [
+        ("LOCALJOB [999]", 0),
+        ("LOCALJOB [2-999]", 16),
+        ("LOCALJOB [2:999]", 16),
+    ],
+)
+def test_set_status_filter_type_with_splits_invalid_split_logs_warning(as_exp, mocker, ft_filter, expected_jobs):
     """Unknown split in ``-ft`` logs a warning and does not stop execution."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
@@ -412,54 +419,20 @@ def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp, mocker):
 
     job_list_ = do_setstatus(
         as_exp,
-        ft="LOCALJOB [999]",
+        ft=ft_filter,
         target="COMPLETED",
     )
 
     completed_jobs = [
         job for job in job_list_.get_job_list() if job.status == Status.COMPLETED
     ]
-    assert len(completed_jobs) == 0
+    assert len(completed_jobs) == expected_jobs
 
     warning_messages = [
         str(call.args[0]) for call in mocked_warning.call_args_list if call.args
     ]
     assert any(
         "Some jobs do not exist in section 'LOCALJOB' with the requested splits." in message
-        for message in warning_messages
-    )
-
-
-def test_set_status_filter_type_with_splits_partial_range_logs_missing_range(as_exp, mocker):
-    """Partially missing split ranges in ``-ft`` log a warning but still update valid splits."""
-    db_manager = SqlAlchemyExperimentHistoryDbManager(
-        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
-    )
-    db_manager.initialize()
-
-    reset(as_exp, "WAITING")
-
-    mocked_warning = mocker.patch("autosubmit.autosubmit.Log.warning")
-
-    job_list_ = do_setstatus(
-        as_exp,
-        ft="LOCALJOB [1-999]",
-        target="COMPLETED",
-    )
-
-    completed_jobs = [
-        job
-        for job in job_list_.get_job_list()
-        if job.status == Status.COMPLETED and job.section == "LOCALJOB"
-    ]
-    assert len(completed_jobs) == 24
-
-    warning_messages = [
-        str(call.args[0]) for call in mocked_warning.call_args_list if call.args
-    ]
-    assert any(
-        "Some jobs do not exist in section 'LOCALJOB' with the requested splits."
-        in message
         for message in warning_messages
     )
 

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -373,8 +373,17 @@ def test_set_status_filter_type_with_splits(as_exp, ft_filter, expected_jobs):
     assert len(completed_jobs) == expected_jobs
 
 
-def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp):
-    """Unknown sections in ``-ft`` raises AutosubmitCritical."""
+@pytest.mark.parametrize(
+    "ft_filter",
+    [
+        ("DOES NOT EXIST [1]"),
+        (" "),
+        ("LOCALJOB [[2:3]"),
+        ("LOCALJOB [ANY]]"),
+    ],
+)
+def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp, ft_filter):
+    """Invalid sections in ``-ft`` raises AutosubmitCritical."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )
@@ -385,26 +394,7 @@ def test_set_status_filter_type_invalid_section_raises_validation_error(as_exp):
     with pytest.raises(AutosubmitCritical):
         do_setstatus(
             as_exp,
-            ft="DOES_NOT_EXIST [1]",
-            target="COMPLETED",
-        )
-
-
-def test_set_status_filter_type_empty_section_raises_validation_error(as_exp):
-    """Unknown sections in ``-ft`` raises AutosubmitCritical."""
-    db_manager = SqlAlchemyExperimentHistoryDbManager(
-        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
-    )
-    db_manager.initialize()
-
-    # assert error message contains "Empty input. No changes performed."
-
-    reset(as_exp, "WAITING")
-
-    with pytest.raises(AutosubmitCritical):
-        do_setstatus(
-            as_exp,
-            ft=" ",
+            ft=ft_filter,
             target="COMPLETED",
         )
 
@@ -426,7 +416,7 @@ def test_set_status_filter_type_with_splits_invalid_split_noop(as_exp):
 
 
 def test_set_status_filter_chunks_invalid_section_raises_validation_error(as_exp):
-    """Unknown sections in ``-fc`` section/split raises AutosubmitCritical."""
+    """Unknown sections in ``-fc`` raises AutosubmitCritical."""
     db_manager = SqlAlchemyExperimentHistoryDbManager(
         as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
     )

--- a/test/unit/test_commands.py
+++ b/test/unit/test_commands.py
@@ -94,3 +94,24 @@ def test_setstatus_accepts_combined_filters(mocker):
     assert args.filter_chunks == "[20200101 [ fc0 [1] ] ]"
     assert args.filter_type == "LOCALJOB"
     assert args.filter_status == "WAITING"
+
+
+def test_setstatus_accepts_section_splits_in_ft(mocker):
+    """Test that ``setstatus`` accepts section/split syntax in ``-ft``."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "autosubmit",
+            "setstatus",
+            "a000",
+            "-ft",
+            "LOCALJOB [ 1 2 5-8 ]",
+            "-t",
+            "READY",
+        ],
+    )
+    status, args = Autosubmit.parse_args()
+
+    assert status == 0
+    assert args.command == "setstatus"
+    assert args.filter_type == "LOCALJOB [ 1 2 5-8 ]"


### PR DESCRIPTION
Closes #2910

**Things done**
- Modified `_validate_section` function. Now it validates sections expecting input: `SECTION_NAME [OPTIONAL_SPLITS]`. It raises AutosubmitCritical errors when: 1) input does not match the expected pattern for sections; 2) section name is not found in the list of sections specified in jobs.yaml; 3) splits of a section are not correctly formatted
-  setstatus command only let users set target job statuses to: `READY, COMPLETED, WAITING, SUSPENDED, UNKNOWN, HELD`.
- updated `_split_match` to only match those jobs where the splits exactly match. In previous code, if split did not match the job was selected anyways.
- created a helper function `_expand_values` to expand dashes, colons and ranges. Used by `_filter_sections_splits` and `_filter_chunks`
- rewritten `_filter_chunks` in order to select only those jobs where date, member and chunk exactly match with the one provided as input.
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
