### PR TITLE
Enhancement: Detect inefficiencies in SIM jobs with CPMIPS thresholds - Part 3

### DIFF
--- a/autosubmit/metrics/__init__.py
+++ b/autosubmit/metrics/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Metrics for Autosubmit Jobs."""

--- a/autosubmit/metrics/cpmip_metrics.py
+++ b/autosubmit/metrics/cpmip_metrics.py
@@ -1,0 +1,538 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit. If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from autosubmit.log.log import Log
+
+
+@dataclass
+class CPMIPMetricsData:
+    """
+    Container for CPMIP metrics computation inputs.
+    
+    Holds the essential runtime and simulation metadata needed to compute CPMIP metrics.
+    This decouples metrics computation from job object structure.
+    
+    :param start_time: Unix timestamp (seconds) when the job started.
+    :type start_time: Optional[int]
+    :param end_time: Unix timestamp (seconds) when the job ended.
+    :type end_time: Optional[int]
+    :param run_years: Length of the simulation in years. Can be None.
+    :type run_years: Optional[float]
+    :param ncpus: Number of CPUs used by the job. Can be None if unavailable.
+    :type ncpus: Optional[int]
+    """
+    start_time: Optional[int] = None
+    end_time: Optional[int] = None
+    run_years: Optional[float] = None
+    ncpus: Optional[int] = None
+
+
+class CPMIPMetrics:
+    """Evaluates CPMIP performance metrics against configured thresholds."""
+
+    METRIC_NAME_ALIASES = {
+        "SYPD": ("SYPD", "simulated_years_per_day"),
+        "CORE_HOURS": ("CORE_HOURS", "core_hours"),
+        "CHSY": ("CHSY", "core_hours_per_simulated_year"),
+    }
+    _METRIC_NAME_LOOKUP = {
+        alias.strip().lower(): metric_name
+        for metric_name, aliases in METRIC_NAME_ALIASES.items()
+        for alias in aliases
+    }
+
+    _VALIDATION_SCHEMA = {
+        "start_time": {
+            "type": int,
+            "type_label": "an integer value",
+            "required": True,
+            "positive": False,
+        },
+        "end_time": {
+            "type": int,
+            "type_label": "an integer value",
+            "required": True,
+            "positive": False,
+        },
+        "run_years": {
+            "type": float,
+            "type_label": "a float value",
+            "required": False,
+            "positive": True,
+        },
+        "ncpus": {
+            "type": int,
+            "type_label": "an integer value",
+            "required": False,
+            "positive": True,
+        },
+    }
+
+    @staticmethod
+    def _validate_positive(
+        value: Union[int, float],
+        var_name: str,
+        error_message: Optional[str] = None,
+        allow_zero: bool = False,
+    ) -> None:
+        """
+        Validate that a value is positive, optionally allowing zero.
+
+        :param value: Value to validate.
+        :type value: Union[int, float]
+        :param var_name: Variable name for error messages.
+        :type var_name: str
+        :param error_message: Optional custom message for invalid values.
+        :type error_message: Optional[str]
+        :param allow_zero: Whether value can be equal to zero.
+        :type allow_zero: bool
+        :raises ValueError: If value is invalid for the configured positivity rule.
+        """
+        if allow_zero:
+            if value < 0:
+                raise ValueError(error_message or f"{var_name} must be >= 0")
+            return
+
+        if value <= 0:
+            raise ValueError(error_message or f"{var_name} must be > 0")
+
+    @staticmethod
+    def _validate_against_schema(value: Any, field_name: str, schema_rules: dict[str, Any]) -> Any:
+        """
+        Validate a value against schema rules and return normalized value.
+
+        :param value: Value to validate (can be None).
+        :type value: any
+        :param field_name: Field name for error messages.
+        :type field_name: str
+        :param schema_rules: Dictionary with validation rules (type, allowed_values, positive, etc.).
+        :type schema_rules: dict
+        :return: Normalized value (e.g., lowercased strings if case_insensitive=True).
+        :rtype: any
+        :raises TypeError: If type is invalid.
+        :raises ValueError: If value violates constraints.
+        """
+
+        if value is None:
+            if schema_rules.get("required", False):
+                raise ValueError(f"{field_name} is required")
+            return None
+
+
+        expected_type = schema_rules.get("type")
+        if expected_type and not isinstance(value, expected_type):
+            type_label = schema_rules.get("type_label", f"{expected_type.__name__}")
+            raise TypeError(f"{field_name} must be {type_label}")
+
+
+        if schema_rules.get("positive", False):
+            CPMIPMetrics._validate_positive(
+                value,
+                field_name,
+                error_message=f"{field_name} must be > 0",
+            )
+
+
+        allowed_values = schema_rules.get("allowed_values")
+        if allowed_values:
+            case_insensitive = schema_rules.get("case_insensitive", False)
+            check_value = value.strip().lower() if case_insensitive and isinstance(value, str) else value
+
+            if case_insensitive and isinstance(value, str):
+                allowed_lower = [v.lower() for v in allowed_values]
+                if check_value not in allowed_lower:
+                    raise ValueError(
+                        f"{field_name} must be one of {allowed_values}, got: {value}"
+                    )
+            else:
+                if value not in allowed_values:
+                    raise ValueError(
+                        f"{field_name} must be one of {allowed_values}, got: {value}"
+                    )
+
+        if schema_rules.get("case_insensitive", False) and isinstance(value, str):
+            return value.strip().lower()
+
+        return value
+
+    @staticmethod
+    def validate_metrics_data(data: CPMIPMetricsData) -> None:
+        """
+        Validate all fields of CPMIPMetricsData using the schema.
+
+        :param data: CPMIPMetricsData object to validate.
+        :type data: CPMIPMetricsData
+        :raises TypeError: If data is not a CPMIPMetricsData instance.
+        :raises ValueError: If any field violates schema constraints.
+        """
+        if not isinstance(data, CPMIPMetricsData):
+            raise TypeError("data must be a CPMIPMetricsData object")
+
+        for field_name, schema_rules in CPMIPMetrics._VALIDATION_SCHEMA.items():
+            field_value = getattr(data, field_name)
+            try:
+                normalized_value = CPMIPMetrics._validate_against_schema(field_value, field_name, schema_rules)
+                setattr(data, field_name, normalized_value)
+            except (TypeError, ValueError):
+                if schema_rules.get("required", False):
+                    raise
+                # Optional fields degrade to None so non-required metric paths can continue.
+                setattr(data, field_name, None)
+
+    @staticmethod
+    def _validate_timestamp_pair(start_time: Optional[int], end_time: Optional[int]) -> bool:
+        """
+        Validate start_time and end_time, ensuring end_time > start_time.
+
+        :param start_time: Unix timestamp (seconds) when job started.
+        :type start_time: Optional[int]
+        :param end_time: Unix timestamp (seconds) when job ended.
+        :type end_time: Optional[int]
+        :return: True when timestamps are valid for runtime computation, otherwise False.
+        :rtype: bool
+        """
+        if start_time is None or end_time is None:
+            Log.warning(
+                "Unable to compute CPMIP metrics due to invalid runtime metadata: "
+                "start_time and end_time are required"
+            )
+            return False
+
+        if end_time <= start_time:
+            Log.warning(
+                "Unable to compute CPMIP metrics due to invalid runtime metadata: "
+                "end_time must be greater than start_time"
+            )
+            return False
+
+        return True
+
+    @staticmethod
+    def _validate_threshold_config(metric_name: str, threshold_config: dict) -> dict:
+        """
+        Validate and normalize threshold configuration for a metric.
+
+        :param metric_name: Metric name from thresholds dict.
+        :type metric_name: str
+        :param threshold_config: Configuration dict with threshold, comparison, %_accepted_error.
+        :type threshold_config: dict
+        :return: Normalized config dict with parsed values.
+        :rtype: dict
+        :raises ValueError: If config is invalid or missing required keys.
+        :raises TypeError: If values have invalid types.
+        """
+        try:
+            normalized_config = {
+                str(key).strip().lower(): value
+                for key, value in threshold_config.items()
+            }
+
+            threshold = float(normalized_config["threshold"])
+            CPMIPMetrics._validate_positive(
+                threshold,
+                f"{metric_name} threshold",
+                error_message=f"{metric_name} threshold must be > 0",
+            )
+
+            comparison = str(normalized_config["comparison"]).strip().lower()
+
+            accepted_error = float(normalized_config["%_accepted_error"])
+            CPMIPMetrics._validate_positive(
+                accepted_error,
+                f"{metric_name} accepted error",
+                error_message=f"{metric_name} accepted error must be >= 0",
+                allow_zero=True,
+            )
+
+            if comparison not in ["greater_than", "less_than"]:
+                raise ValueError(
+                    f"Unsupported comparison operator: {comparison}"
+                )
+
+            return {
+                "threshold": threshold,
+                "comparison": comparison,
+                "accepted_error": accepted_error,
+            }
+        except (ValueError, TypeError, KeyError) as error:
+            raise ValueError(
+                f"Invalid threshold configuration for '{metric_name}': {error}"
+            ) from error
+
+    @staticmethod
+    def _simulated_years_per_day(runtime: float, simulated_years: float) -> float:
+        """
+        Compute Simulated Years Per Day from runtime and simulated years.
+
+        Assumes inputs are pre-validated. Called from _fetch_metrics() only.
+
+        :param runtime: Runtime of a Job in hours.
+        :type runtime: float
+        :param simulated_years: Simulated years.
+        :type simulated_years: float
+        :return: Simulated years per day.
+        :rtype: float
+        """
+        return simulated_years * 24.0 / runtime
+
+    @staticmethod
+    def _core_hours(runtime: float, ncpus: int) -> float:
+        """
+        Compute core-hours from runtime and CPU count.
+
+        Assumes inputs are pre-validated. Called from _fetch_metrics() and _core_hours_per_simulated_year() only.
+
+        :param runtime: Runtime of a Job in hours.
+        :type runtime: float
+        :param ncpus: Number of CPUs used by the job.
+        :type ncpus: int
+        :return: Core-hours.
+        :rtype: float
+        """
+        return ncpus * runtime
+
+    @staticmethod
+    def _core_hours_per_simulated_year(runtime: float, simulated_years: float, ncpus: int) -> float:
+        """
+        Compute Core-Hours per Simulated Year.
+
+        Assumes inputs are pre-validated. Called from _fetch_metrics() only.
+
+        :param runtime: Runtime of a Job in hours.
+        :type runtime: float
+        :param simulated_years: Simulated years.
+        :type simulated_years: float
+        :param ncpus: Number of CPUs used by the job.
+        :type ncpus: int
+        :return: Core-hours per simulated year.
+        :rtype: float
+        """
+        return CPMIPMetrics._core_hours(runtime, ncpus) / simulated_years
+
+    @staticmethod
+    def _get_runtime_hours(data: CPMIPMetricsData) -> float:
+        """
+        Extract runtime in hours from metrics data timestamps.
+
+        :param data: CPMIPMetricsData object with start/end times.
+        :type data: CPMIPMetricsData
+        :return: Runtime in hours.
+        :rtype: float
+        """
+        if data.start_time is None or data.end_time is None:
+            raise ValueError("start_time and end_time are required to compute runtime")
+
+        runtime_seconds = data.end_time - data.start_time
+        return runtime_seconds / 3600
+
+    @staticmethod
+    def _fetch_metrics(data: CPMIPMetricsData) -> dict[str, float]:
+        """
+        Build CPMIP metrics from runtime and simulation metadata.
+
+        :param data: CPMIPMetricsData object.
+        :type data: CPMIPMetricsData
+        :return: Dictionary with computed metrics. Empty dict when required metadata is missing or invalid.
+               If run_years metadata is missing/invalid, run_years-dependent metrics can fail while
+             runtime-dependent metrics (for example CORE_HOURS) can still be returned.
+        :rtype: dict[str, float]
+           :raises ValueError: If timestamp or run_years metadata is invalid.
+        :raises TypeError: If data types are invalid.
+        """
+
+        try:
+            CPMIPMetrics.validate_metrics_data(data)
+        except (ValueError, TypeError) as error:
+            Log.warning(f"Unable to compute CPMIP metrics due to invalid data: {error}")
+            return {}
+
+        if not CPMIPMetrics._validate_timestamp_pair(data.start_time, data.end_time):
+            return {}
+
+        runtime_hours = CPMIPMetrics._get_runtime_hours(data)
+        simulated_years = data.run_years
+
+        metrics: dict[str, float] = {}
+        ncpus = data.ncpus
+
+        if ncpus is None:
+            Log.warning("Skipping CORE_HOURS and CHSY metric computation because ncpus is missing")
+
+        if simulated_years is not None:
+            try:
+                metrics["SYPD"] = CPMIPMetrics._simulated_years_per_day(runtime_hours, simulated_years)
+            except (ValueError, TypeError) as error:
+                Log.warning(f"Unable to compute SYPD metric: {error}")
+
+        if ncpus is not None:
+            try:
+                metrics["CORE_HOURS"] = CPMIPMetrics._core_hours(runtime_hours, ncpus)
+            except (ValueError, TypeError) as error:
+                Log.warning(f"Unable to compute CORE_HOURS metric: {error}")
+
+        if ncpus is not None and simulated_years is not None and "CORE_HOURS" in metrics:
+            try:
+                metrics["CHSY"] = CPMIPMetrics._core_hours_per_simulated_year(
+                    runtime_hours,
+                    simulated_years,
+                    ncpus,
+                )
+            except (ValueError, TypeError) as error:
+                Log.warning(f"Unable to compute CHSY metric: {error}")
+
+        return metrics
+
+    @staticmethod
+    def _resolve_metric_for_evaluation(metric_name: str, metrics: dict) -> Optional[str]:
+        """
+        Resolve a metric alias to its canonical name and ensure it was computed.
+
+        :param metric_name: Metric alias provided by the threshold configuration.
+        :type metric_name: str
+        :param metrics: Dictionary of already computed metrics.
+        :type metrics: dict
+        :return: Canonical metric name if resolvable and present in computed metrics, otherwise None.
+        :rtype: Optional[str]
+        """
+        canonical_metric_name = CPMIPMetrics._METRIC_NAME_LOOKUP.get(metric_name.strip().lower())
+        if canonical_metric_name is None:
+            Log.warning(f"Ignoring unknown CPMIP metric alias: {metric_name}")
+            return None
+
+        if canonical_metric_name not in metrics:
+            Log.warning(
+                f"Skipping CPMIP metric '{metric_name}' ({canonical_metric_name}) because it was not computed"
+            )
+            return None
+
+        return canonical_metric_name
+
+    @staticmethod
+    def _extract_threshold_for_evaluation(metric_name: str, threshold_config: dict) -> Optional[dict]:
+        """
+        Validate threshold configuration and normalize it for evaluation.
+
+        :param metric_name: Metric name from the thresholds configuration.
+        :type metric_name: str
+        :param threshold_config: Raw threshold configuration dictionary.
+        :type threshold_config: dict
+        :return: Normalized threshold configuration dictionary, or None if invalid.
+        :rtype: Optional[dict]
+        """
+        try:
+            return CPMIPMetrics._validate_threshold_config(metric_name, threshold_config)
+        except ValueError as error:
+            Log.warning(f"Skipping CPMIP metric '{metric_name}' due to invalid threshold config: {error}")
+            return None
+
+    @staticmethod
+    def _compute_violation(
+        real_value: float,
+        threshold: float,
+        comparison: str,
+        accepted_error: float,
+    ) -> Optional[dict]:
+        """
+        Compute violation payload for a single metric.
+
+        Assumes comparison has already been validated by _validate_threshold_config.
+
+        :param real_value: Computed metric value.
+        :type real_value: float
+        :param threshold: Threshold value to compare against.
+        :type threshold: float
+        :param comparison: Comparison operator, either greater_than or less_than.
+        :type comparison: str
+        :param accepted_error: Accepted error percentage.
+        :type accepted_error: float
+        :return: Violation payload when out of bounds, otherwise None.
+        :rtype: Optional[dict]
+        """
+        tolerance_factor = accepted_error / 100.0
+        is_violation = False
+
+        if comparison == "greater_than":
+            lower_bound = threshold * (1 - tolerance_factor)
+            bound = lower_bound
+            if real_value < lower_bound:
+                is_violation = True
+        else:  # comparison == "less_than"
+            upper_bound = threshold * (1 + tolerance_factor)
+            bound = upper_bound
+            if real_value > upper_bound:
+                is_violation = True
+
+        if not is_violation:
+            return None
+
+        return {
+            "threshold": threshold,
+            "accepted_error": accepted_error,
+            "comparison": comparison,
+            "bound": bound,
+            "real_value": real_value,
+        }
+
+    @staticmethod
+    def evaluate(data: CPMIPMetricsData, thresholds: dict[str, dict]) -> dict:
+        """
+        Evaluate metrics against threshold definitions.
+
+        :param data: CPMIPMetricsData object used to fetch computed metrics.
+        :type data: CPMIPMetricsData
+        :param thresholds: Threshold configuration by metric name.
+        :type thresholds: dict[str, dict]
+        :return: Violations by metric name.
+        :rtype: dict[str, dict]
+        """
+        if not isinstance(thresholds, dict):
+            raise TypeError("thresholds must be a dictionary")
+
+        if not thresholds:
+            return {}
+
+        metrics = CPMIPMetrics._fetch_metrics(data)
+        if not metrics:
+            return {}
+
+        violations = {}
+
+        for metric_name, threshold_config in thresholds.items():
+            if not isinstance(metric_name, str):
+                continue
+
+            canonical_metric_name = CPMIPMetrics._resolve_metric_for_evaluation(metric_name, metrics)
+            if canonical_metric_name is None:
+                continue
+
+            config = CPMIPMetrics._extract_threshold_for_evaluation(metric_name, threshold_config)
+            if config is None:
+                continue
+
+            violation = CPMIPMetrics._compute_violation(
+                real_value=metrics[canonical_metric_name],
+                threshold=config["threshold"],
+                comparison=config["comparison"],
+                accepted_error=config["accepted_error"],
+            )
+            if violation is not None:
+                violations[canonical_metric_name] = violation
+
+        return violations

--- a/test/unit/test_cpmip_metrics.py
+++ b/test/unit/test_cpmip_metrics.py
@@ -1,0 +1,859 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit. If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, cast
+
+import pytest
+
+from autosubmit.metrics.cpmip_metrics import CPMIPMetrics, CPMIPMetricsData
+
+
+@pytest.fixture
+def metrics_data() -> CPMIPMetricsData:
+    return CPMIPMetricsData(
+        start_time=1000,
+        end_time=2000,
+        run_years=1.0,
+        ncpus=64,
+    )
+
+
+def test_evaluate_returns_empty_when_thresholds_is_empty(metrics_data):
+    """Test that evaluation returns no violations when no thresholds are provided."""
+
+    violations = CPMIPMetrics.evaluate(metrics_data, {})
+
+    assert violations == {}
+
+
+@pytest.mark.parametrize(
+    "metric_name,threshold,comparison,accepted_error,real_value,expected_bound",
+    [
+        ("SYPD", 5.0, "greater_than", 10, 3.9, 4.5),
+        ("CORE_HOURS", 10.0, "less_than", 5, 10.6, 10.5),
+    ],
+    ids=["sypd_greater_than_violation", "core_hours_less_than_violation"],
+)
+def test_evaluate_violation_cases(
+    mocker,
+    metrics_data,
+    metric_name,
+    threshold,
+    comparison,
+    accepted_error,
+    real_value,
+    expected_bound,
+):
+    """Test that evaluation detects violations outside the accepted tolerance."""
+
+    thresholds = {
+        metric_name: {
+            "THRESHOLD": threshold,
+            "COMPARISON": comparison,
+            "%_ACCEPTED_ERROR": accepted_error,
+        }
+    }
+    mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._fetch_metrics",
+        return_value={metric_name: real_value},
+    )
+
+    violations = CPMIPMetrics.evaluate(metrics_data, thresholds)
+
+    assert metric_name in violations
+    assert violations[metric_name]["threshold"] == threshold
+    assert violations[metric_name]["accepted_error"] == accepted_error
+    assert violations[metric_name]["comparison"] == comparison
+    assert violations[metric_name]["bound"] == pytest.approx(expected_bound)
+    assert violations[metric_name]["real_value"] == real_value
+
+
+@pytest.mark.parametrize(
+    "metric_name,threshold,comparison,accepted_error,real_value",
+    [
+        # lower bound = 5.0 * (1 - 0.10) = 4.5
+        ("SYPD", 5.0, "greater_than", 10, 4.5),
+        # upper bound = 10.0 * (1 + 0.10) = 11.0
+        ("CORE_HOURS", 10.0, "less_than", 10, 11.0),
+    ],
+    ids=["sypd_on_lower_bound", "core_hours_on_upper_bound"],
+)
+def test_evaluate_boundary_is_not_violation(
+    mocker,
+    metrics_data,
+    metric_name,
+    threshold,
+    comparison,
+    accepted_error,
+    real_value,
+):
+    """Test that values exactly on the tolerance boundary are accepted."""
+
+    thresholds = {
+        metric_name: {
+            "THRESHOLD": threshold,
+            "COMPARISON": comparison,
+            "%_ACCEPTED_ERROR": accepted_error,
+        }
+    }
+    mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._fetch_metrics",
+        return_value={metric_name: real_value},
+    )
+
+    violations = CPMIPMetrics.evaluate(metrics_data, thresholds)
+
+    assert violations == {}
+
+
+@pytest.mark.parametrize(
+    "sypd_name,core_hours_name,chsy_name",
+    [
+        ("simulated_years_per_day", "core_hours", "core_hours_per_simulated_year"),
+        ("SYPD", "CORE_HOURS", "CHSY"),
+        ("SIMULATED_YEARS_PER_DAY", "CORE_HOURS", "CORE_HOURS_PER_SIMULATED_YEAR"),
+        ("sypd", "core_hours", "chsy"),
+        ("SiMuLaTeD_YeArS_pEr_DaY", "CoRe_HoUrS", "CoRe_HoUrS_pEr_SiMuLaTeD_yEaR"),
+        ("SyPd", "CoRe_HoUrS", "ChSy"),
+    ],
+    ids=[
+        "snake_case_threshold_names",
+        "abbreviation_threshold_names",
+        "snake_case_upper_threshold_names",
+        "abbreviation_lower_threshold_names",
+        "snake_case_mixed_threshold_names",
+        "abbreviation_mixed_threshold_names",
+    ],
+)
+def test_evaluate_accepts_metric_alias_threshold_names(
+    mocker,
+    metrics_data,
+    sypd_name,
+    core_hours_name,
+    chsy_name,
+):
+    """Test that threshold metric aliases resolve to canonical metric names."""
+
+    thresholds = {
+        sypd_name: {
+            "THRESHOLD": 5.0,
+            "COMPARISON": "greater_than",
+            "%_ACCEPTED_ERROR": 10,
+        },
+        core_hours_name: {
+            "THRESHOLD": 100.0,
+            "COMPARISON": "greater_than",
+            "%_ACCEPTED_ERROR": 10,
+        },
+        chsy_name: {
+            "THRESHOLD": 1000.0,
+            "COMPARISON": "greater_than",
+            "%_ACCEPTED_ERROR": 10,
+        },
+    }
+    mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._fetch_metrics",
+        return_value={"SYPD": 3.9, "CORE_HOURS": 2880.0, "CHSY": 5760.0},
+    )
+
+    violations = CPMIPMetrics.evaluate(metrics_data, thresholds)
+
+    assert list(violations.keys()) == ["SYPD"]
+
+
+def test_evaluate_mixed_metrics_only_returns_violations(mocker, metrics_data):
+    """Test that only the violating metric is returned when inputs are mixed."""
+
+    thresholds = {
+        "SYPD": {
+            "THRESHOLD": 5.0,
+            "COMPARISON": "greater_than",
+            "%_ACCEPTED_ERROR": 10,
+        },
+        "LATENCY": {
+            "THRESHOLD": 10.0,
+            "COMPARISON": "less_than",
+            "%_ACCEPTED_ERROR": 5,
+        },
+    }
+    mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._fetch_metrics",
+        return_value={"SYPD": 3.9, "LATENCY": 10.4},
+    )
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    violations = CPMIPMetrics.evaluate(metrics_data, thresholds)
+
+    assert list(violations.keys()) == ["SYPD"]
+    log_mock.assert_called_once()
+    assert "Ignoring unknown CPMIP metric alias: LATENCY" in str(log_mock.call_args)
+
+
+@pytest.mark.parametrize(
+    "threshold_key,comparison_key,accepted_error_key",
+    [
+        ("threshold", "comparison", "%_accepted_error"),
+        ("ThReShOlD", "CoMpArIsOn", "%_AcCePtEd_ErRoR"),
+    ],
+    ids=["lowercase_threshold_config_keys", "mixed_case_threshold_config_keys"],
+)
+def test_evaluate_accepts_threshold_config_keys_case_insensitive(
+    mocker,
+    metrics_data,
+    threshold_key,
+    comparison_key,
+    accepted_error_key,
+):
+    """Test that threshold config variable names are case-insensitive."""
+
+    thresholds = {
+        "SYPD": {
+            threshold_key: 5.0,
+            comparison_key: "greater_than",
+            accepted_error_key: 10,
+        }
+    }
+    mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._fetch_metrics",
+        return_value={"SYPD": 3.9},
+    )
+
+    violations = CPMIPMetrics.evaluate(metrics_data, thresholds)
+
+    assert "SYPD" in violations
+    assert violations["SYPD"]["threshold"] == 5.0
+    assert violations["SYPD"]["accepted_error"] == 10
+    assert violations["SYPD"]["comparison"] == "greater_than"
+
+
+@pytest.mark.parametrize(
+    "thresholds,fetched_metrics,expected_log_calls",
+    [
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": 10,
+                }
+            },
+            {},
+            [],
+        ),
+        (
+            {
+                "CHSY": {
+                    "THRESHOLD": 1000,
+                    "COMPARISON": "less_than",
+                    "%_ACCEPTED_ERROR": 10,
+                }
+            },
+            {"SYPD": 1.5},
+            ["Skipping CPMIP metric 'CHSY' (CHSY) because it was not computed"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "greater_than",
+                }
+            },
+            {"SYPD": 3.0},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "equal_to",
+                    "%_ACCEPTED_ERROR": 0,
+                }
+            },
+            {"SYPD": 3.0},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": 0,
+                }
+            },
+            {"SYPD": 5.0},
+            [],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": "not-a-number",
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": 10,
+                }
+            },
+            {"SYPD": 3.9},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 0,
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": 10,
+                }
+            },
+            {"SYPD": 3.9},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": -1.0,
+                    "COMPARISON": "less_than",
+                    "%_ACCEPTED_ERROR": 10,
+                }
+            },
+            {"SYPD": 3.9},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": "invalid",
+                }
+            },
+            {"SYPD": 3.9},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": -10,
+                }
+            },
+            {"SYPD": 3.9},
+            ["Skipping CPMIP metric 'SYPD' due to invalid threshold config"],
+        ),
+        (
+            {
+                "SYPD": {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "less_than",
+                    "%_ACCEPTED_ERROR": 0,
+                }
+            },
+            {"SYPD": 3.9},
+            [],
+        ),
+        (
+            {
+                1: {
+                    "THRESHOLD": 5.0,
+                    "COMPARISON": "greater_than",
+                    "%_ACCEPTED_ERROR": 10,
+                }
+            },
+            {"SYPD": 3.9},
+            [],
+        ),
+    ],
+    ids=[
+        "metrics_fetch_returns_empty",
+        "metric_not_present_in_results",
+        "malformed_threshold_config",
+        "unsupported_comparison",
+        "zero_accepted_error_valid",
+        "invalid_threshold_type",
+        "zero_threshold",
+        "negative_threshold",
+        "invalid_accepted_error_type",
+        "negative_accepted_error",
+        "accepted_error_zero",
+        "non_string_metric_name",
+    ],
+)
+def test_evaluate_non_violation_paths(mocker, metrics_data, thresholds, fetched_metrics, expected_log_calls):
+    """Test that malformed or non-matching inputs do not produce violations and generate expected logs."""
+
+    mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._fetch_metrics",
+        return_value=fetched_metrics,
+    )
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    violations = CPMIPMetrics.evaluate(metrics_data, thresholds)
+
+    assert violations == {}
+    
+    assert log_mock.call_count == len(expected_log_calls)
+    
+    if expected_log_calls:
+        for expected_log in expected_log_calls:
+            calls_made = [str(call) for call in log_mock.call_args_list]
+            assert any(expected_log in call for call in calls_made), f"Expected log message not found: {expected_log}. Actual calls: {calls_made}"
+
+
+def test_evaluate_end_to_end_computes_values_and_returns_expected_violation(mocker):
+    """End-to-end evaluation should compute metrics from raw data and report only real violations."""
+
+    data = CPMIPMetricsData(
+        start_time=0,
+        end_time=43200,
+        run_years=1.0,
+        ncpus=64,
+    )
+    thresholds = {
+        "SYPD": {
+            "THRESHOLD": 3.0,
+            "COMPARISON": "greater_than",
+            "%_ACCEPTED_ERROR": 0,
+        },
+        "CORE_HOURS": {
+            "THRESHOLD": 800.0,
+            "COMPARISON": "less_than",
+            "%_ACCEPTED_ERROR": 0,
+        },
+        "CHSY": {
+            "THRESHOLD": 5000.0,
+            "COMPARISON": "less_than",
+            "%_ACCEPTED_ERROR": 0,
+        },
+    }
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    violations = CPMIPMetrics.evaluate(data, thresholds)
+
+    assert list(violations.keys()) == ["SYPD"]
+    assert violations["SYPD"]["comparison"] == "greater_than"
+    assert violations["SYPD"]["threshold"] == pytest.approx(3.0)
+    assert violations["SYPD"]["accepted_error"] == pytest.approx(0.0)
+    assert violations["SYPD"]["bound"] == pytest.approx(3.0)
+    assert violations["SYPD"]["real_value"] == pytest.approx(2.0)
+    log_mock.assert_not_called()
+
+
+
+
+@pytest.mark.parametrize(
+    "start_time,end_time",
+    [(44200, 1000), (2000, 2000)],
+    ids=["runtime_end_before_start", "runtime_end_equal_start"],
+)
+def test_fetch_metrics_returns_empty_when_runtime_validation_fails(mocker, start_time, end_time):
+    """Test that invalid runtime timestamps stop metric computation before runtime extraction."""
+
+    data = CPMIPMetricsData(
+        start_time=start_time,
+        end_time=end_time,
+        run_years=1.0,
+        ncpus=64,
+    )
+
+    runtime_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._get_runtime_hours",
+    )
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    metrics = CPMIPMetrics._fetch_metrics(data)
+
+    runtime_mock.assert_not_called()
+    assert metrics == {}
+    log_mock.assert_called_once()
+    assert "Unable to compute CPMIP metrics due to invalid runtime metadata" in str(log_mock.call_args)
+
+
+@pytest.mark.parametrize(
+    "ncpus,chsy_return_value,expected_metrics,expected_chsy_call,expected_log_calls",
+    [
+        (240, 5760.0, {"SYPD": 1.0, "CORE_HOURS": 2880.0, "CHSY": 5760.0}, (12.0, 1.0, 240), []),
+        (None, 2880.0, {"SYPD": 1.0}, None, ["Skipping CORE_HOURS and CHSY metric computation because ncpus is missing"]),
+    ],
+    ids=["with_ncpus_computes_ch_and_chsy", "without_ncpus_returns_only_sypd"],
+)
+def test_fetch_metrics_with_and_without_ncpus(
+    mocker,
+    ncpus,
+    chsy_return_value,
+    expected_metrics,
+    expected_chsy_call,
+    expected_log_calls,
+):
+    """Test that fetch_metrics includes CHSY only when ncpus is available and logs appropriately."""
+
+    data = CPMIPMetricsData(
+        start_time=1000,
+        end_time=44200,
+        run_years=1.0,
+        ncpus=ncpus,
+    )
+
+    sypd_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._simulated_years_per_day",
+        return_value=1.0,
+    )
+    core_hours_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._core_hours",
+        return_value=2880.0,
+    )
+    chsy_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._core_hours_per_simulated_year",
+        return_value=chsy_return_value,
+    )
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    metrics = CPMIPMetrics._fetch_metrics(data)
+
+    sypd_mock.assert_called_once_with(12.0, 1.0)
+
+    if expected_chsy_call is None:
+        core_hours_mock.assert_not_called()
+        chsy_mock.assert_not_called()
+    else:
+        core_hours_mock.assert_called_once_with(12.0, 240)
+        chsy_mock.assert_called_once_with(*expected_chsy_call)
+
+    assert metrics == expected_metrics
+    
+    assert log_mock.call_count == len(expected_log_calls)
+    if expected_log_calls:
+        for expected_log in expected_log_calls:
+            calls_made = [str(call) for call in log_mock.call_args_list]
+            assert any(expected_log in call for call in calls_made), f"Expected log message not found: {expected_log}"
+
+def test_fetch_metrics_continues_when_run_years_is_missing(mocker):
+    """Missing run_years should skip simulated-years-based metrics and still compute CORE_HOURS."""
+
+    data = CPMIPMetricsData(
+        start_time=1000,
+        end_time=44200,
+        run_years=None,
+        ncpus=64,
+    )
+
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    metrics = CPMIPMetrics._fetch_metrics(data)
+
+    assert metrics == {"CORE_HOURS": 768.0}
+    log_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "chsy_error",
+    [ValueError("invalid chsy"), TypeError("invalid chsy type")],
+    ids=["chsy_value_error", "chsy_type_error"],
+)
+def test_fetch_metrics_returns_only_sypd_and_ch_when_chsy_computation_fails(mocker, chsy_error):
+    """Test that CHSY failures still return SYPD and CORE_HOURS and log warning."""
+
+    data = CPMIPMetricsData(
+        start_time=1000,
+        end_time=44200,
+        run_years=1.0,
+        ncpus=64,
+    )
+
+    runtime_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._get_runtime_hours",
+        return_value=12.0,
+    )
+    sypd_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._simulated_years_per_day",
+        return_value=1.0,
+    )
+    core_hours_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._core_hours",
+        return_value=2880.0,
+    )
+    chsy_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._core_hours_per_simulated_year",
+        side_effect=chsy_error,
+    )
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    metrics = CPMIPMetrics._fetch_metrics(data)
+
+    runtime_mock.assert_called_once_with(data)
+    sypd_mock.assert_called_once_with(12.0, 1.0)
+    core_hours_mock.assert_called_once_with(12.0, 64)
+    chsy_mock.assert_called_once_with(12.0, 1.0, 64)
+    assert metrics == {"SYPD": 1.0, "CORE_HOURS": 2880.0}
+    
+    log_mock.assert_called_once()
+    assert "Unable to compute CHSY metric" in str(log_mock.call_args)
+
+
+@pytest.mark.parametrize(
+    "core_hours_error",
+    [ValueError("invalid core hours"), TypeError("invalid core hours type")],
+    ids=["core_hours_value_error", "core_hours_type_error"],
+)
+def test_fetch_metrics_returns_only_sypd_when_core_hours_computation_fails(mocker, core_hours_error):
+    """Test that CORE_HOURS failures still return SYPD and log warning."""
+
+    data = CPMIPMetricsData(
+        start_time=1000,
+        end_time=44200,
+        run_years=1.0,
+        ncpus=64,
+    )
+
+    runtime_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._get_runtime_hours",
+        return_value=12.0,
+    )
+    sypd_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._simulated_years_per_day",
+        return_value=1.0,
+    )
+    core_hours_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._core_hours",
+        side_effect=core_hours_error,
+    )
+    chsy_mock = mocker.patch(
+        "autosubmit.metrics.cpmip_metrics.CPMIPMetrics._core_hours_per_simulated_year",
+    )
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    metrics = CPMIPMetrics._fetch_metrics(data)
+
+    runtime_mock.assert_called_once_with(data)
+    sypd_mock.assert_called_once_with(12.0, 1.0)
+    core_hours_mock.assert_called_once_with(12.0, 64)
+    chsy_mock.assert_not_called()
+    assert metrics == {"SYPD": 1.0}
+    
+    log_mock.assert_called_once()
+    assert "Unable to compute CORE_HOURS metric" in str(log_mock.call_args)
+
+
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        CPMIPMetricsData(start_time=1000, end_time=2000, run_years=1.0, ncpus=64),
+        CPMIPMetricsData(start_time=1000, end_time=2000, run_years=1.0, ncpus=None),
+        CPMIPMetricsData(start_time=1000, end_time=2000, run_years=None, ncpus=64),
+    ],
+    ids=[
+        "all_fields_valid",
+        "optional_ncpus_none",
+        "optional_run_years_none",
+    ],
+)
+def test_validate_metrics_data_success_paths(data):
+    """Validate metrics data success paths across supported field combinations."""
+
+    CPMIPMetrics.validate_metrics_data(data)
+
+
+@pytest.mark.parametrize(
+    "data,expected_exception,error_message",
+    [
+        (
+            CPMIPMetricsData(start_time=None, end_time=2000, run_years=1.0, ncpus=64),
+            ValueError,
+            "start_time is required",
+        ),
+        (
+            CPMIPMetricsData(start_time=1000, end_time=None, run_years=1.0, ncpus=64),
+            ValueError,
+            "end_time is required",
+        ),
+        (
+            CPMIPMetricsData(start_time=cast(Any, "1000"), end_time=2000, run_years=1.0, ncpus=64),
+            TypeError,
+            "start_time must be an integer value",
+        ),
+        (
+            CPMIPMetricsData(start_time=1000, end_time=cast(Any, 2000.5), run_years=1.0, ncpus=64),
+            TypeError,
+            "end_time must be an integer value",
+        ),
+    ],
+    ids=[
+        "missing_required_start_time",
+        "missing_required_end_time",
+        "invalid_start_time_type",
+        "invalid_end_time_type",
+    ],
+)
+def test_validate_metrics_data_unsuccessful_paths(data, expected_exception, error_message):
+    """Validate metrics data failure paths across all validated input fields."""
+
+    with pytest.raises(expected_exception, match=error_message):
+        CPMIPMetrics.validate_metrics_data(data)
+
+@pytest.mark.parametrize(
+    "data,expected_field",
+    [
+        (
+            CPMIPMetricsData(start_time=1000, end_time=2000, run_years=cast(Any, "1"), ncpus=64),
+            "run_years",
+        ),
+        (
+            CPMIPMetricsData(start_time=1000, end_time=2000, run_years=0, ncpus=64),
+            "run_years",
+        ),
+        (
+            CPMIPMetricsData(start_time=1000, end_time=2000, run_years=1, ncpus=64),
+            "run_years",
+        ),
+        (
+            CPMIPMetricsData(start_time=1000, end_time=2000, run_years=1.0, ncpus=cast(Any, "64")),
+            "ncpus",
+        ),
+        (
+            CPMIPMetricsData(start_time=1000, end_time=2000, run_years=1.0, ncpus=0),
+            "ncpus",
+        ),
+    ],
+    ids=[
+        "invalid_run_years_type_degrades",
+        "invalid_run_years_non_positive_degrades",
+        "invalid_run_years_integer_degrades",
+        "invalid_ncpus_type_degrades",
+        "invalid_ncpus_non_positive_degrades",
+    ],
+)
+def test_validate_metrics_data_optional_invalid_fields_degrade_to_none(data, expected_field):
+    """Optional invalid fields are normalized to None instead of raising."""
+
+    CPMIPMetrics.validate_metrics_data(data)
+
+    assert getattr(data, expected_field) is None
+
+
+def test_validate_against_schema_allowed_values_case_sensitive_error_path():
+    """Non-case-insensitive allowed_values should reject values outside the literal list."""
+
+    schema_rules = {
+        "type": str,
+        "type_label": "a string",
+        "required": False,
+        "allowed_values": ["A", "B"],
+        "case_insensitive": False,
+    }
+
+    with pytest.raises(ValueError, match="must be one of"):
+        CPMIPMetrics._validate_against_schema("C", "dummy_field", schema_rules)
+
+
+@pytest.mark.parametrize(
+    "metric_name,threshold_config",
+    [
+        ("SYPD", {"threshold": 5.0, "comparison": "greater_than", "%_accepted_error": 10}),
+        ("CORE_HOURS", {"threshold": 100.0, "comparison": "less_than", "%_accepted_error": 5}),
+        ("CHSY", {"threshold": 500.0, "comparison": "greater_than", "%_accepted_error": 0}),
+    ],
+    ids=["sypd_valid_threshold", "core_hours_valid_threshold", "chsy_valid_threshold"],
+)
+def test_validate_threshold_config_success_paths_for_all_metrics(metric_name, threshold_config):
+    """Validate threshold-config success path for all supported metric names."""
+
+    config = CPMIPMetrics._validate_threshold_config(metric_name, threshold_config)
+
+    assert config["threshold"] == float(threshold_config["threshold"])
+    assert config["comparison"] == threshold_config["comparison"]
+    assert config["accepted_error"] == float(threshold_config["%_accepted_error"])
+
+
+@pytest.mark.parametrize(
+    "metric_name,threshold_config,error_message",
+    [
+        ("SYPD", {"threshold": 5.0, "comparison": "equal_to", "%_accepted_error": 10}, "Unsupported comparison operator"),
+        ("CORE_HOURS", {"threshold": "invalid", "comparison": "greater_than", "%_accepted_error": 10}, "Invalid threshold configuration"),
+        ("CHSY", {"threshold": 5.0, "comparison": "greater_than"}, "Invalid threshold configuration"),
+    ],
+    ids=["sypd_invalid_comparison", "core_hours_invalid_threshold_type", "chsy_missing_accepted_error"],
+)
+def test_validate_threshold_config_unsuccessful_paths_for_all_metrics(metric_name, threshold_config, error_message):
+    """Validate threshold-config failure path for all supported metric names."""
+
+    with pytest.raises(ValueError, match=error_message):
+        CPMIPMetrics._validate_threshold_config(metric_name, threshold_config)
+
+@pytest.mark.parametrize(
+    "start_time,end_time,error_message",
+    [
+        (5, 4, "end_time must be greater than start_time"),
+        (5, 5, "end_time must be greater than start_time"),
+    ],
+    ids=[
+        "timestamp_order_invalid_less",
+        "timestamp_order_invalid",
+    ],
+)
+def test_validate_timestamp_pair_error_paths(mocker, start_time, end_time, error_message):
+    """Cover timestamp validator error branches with one parametrized test."""
+
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    assert CPMIPMetrics._validate_timestamp_pair(start_time, end_time) is False
+    log_mock.assert_called_once()
+    assert error_message in str(log_mock.call_args)
+
+
+def test_validate_timestamp_pair_success_path():
+    """Valid timestamp pair should return True."""
+
+    assert CPMIPMetrics._validate_timestamp_pair(1, 2) is True
+
+
+@pytest.mark.parametrize(
+    "metric_function,args,expected",
+    [
+        (CPMIPMetrics._simulated_years_per_day, (12.0, 1.0), 2.0),
+        (CPMIPMetrics._core_hours, (12.0, 120), 1440.0),
+        (CPMIPMetrics._core_hours_per_simulated_year, (12.0, 1.0, 120), 1440.0),
+    ],
+    ids=[
+        "sypd_formula",
+        "core_hours_formula",
+        "chsy_formula",
+    ],
+)
+def test_private_formula_helpers(metric_function, args, expected):
+    """Validate private metric formula helpers in a compact parametrized test."""
+
+    assert metric_function(*args) == pytest.approx(expected)
+
+
+def test_fetch_metrics_returns_empty_when_data_object_invalid(mocker):
+    """Invalid data objects are rejected at validation and produce an empty metrics dict."""
+
+    log_mock = mocker.patch("autosubmit.metrics.cpmip_metrics.Log.warning")
+
+    metrics = CPMIPMetrics._fetch_metrics(cast(Any, {"invalid": "data"}))
+
+    assert metrics == {}
+    log_mock.assert_called_once()
+    assert "Unable to compute CPMIP metrics due to invalid data" in str(log_mock.call_args)
+    assert "data must be a CPMIPMetricsData object" in str(log_mock.call_args)
+
+
+@pytest.mark.parametrize("thresholds", [None, [], "invalid", 1], ids=["none", "list", "string", "int"])
+def test_evaluate_raises_when_thresholds_is_not_dict(metrics_data, thresholds):
+    """Evaluate must reject non-dict thresholds."""
+
+    with pytest.raises(TypeError, match="thresholds must be a dictionary"):
+        CPMIPMetrics.evaluate(metrics_data, thresholds)


### PR DESCRIPTION
Hi AS team!

This is the third part of a large [PR](https://github.com/MissterP/autosubmit/pull/1) with the objective to implement the detection of inefficiencies once the SIM job is completed (or section indicated) using CPMIPS and thresholds. If a threshold is violated, it will send a notification to the user indicated in the config. 

Last PR: #2918

For example, if you have 50 chunks of SIM jobs. An early detection could be observed in the first 2 chunks.

This third part consists in the computation of the CPMIPS and selection of violated metrics. 

**Check List**

- [X] I have read `CONTRIBUTING.md`.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`. (No need)
- [X] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`). (no bug)