### PR TITLE
Table in docs setstatus section to explain the diff flags

### DIFF
--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -162,7 +162,7 @@ How to change the job status
 This procedure allows you to modify the status of your jobs.
 
 .. warning:: Beware that Autosubmit must be stopped to use ``setstatus``.
-    Otherwise a running instance of Autosubmit, at some point, will overwrite any change you may have done.
+    Otherwise a running instance of Autosubmit, at some point, will overwrite any changes you may have done.
 
 You must execute:
 ::
@@ -177,17 +177,17 @@ By default, plots are **not** generated when changing status. To generate plots 
 
 Where:
 
-+------+----------------------------------------------+----------------------------------------------+
++--------+----------------------------------------------+----------------------------------------------+
 | FILTER | Meaning                                      | Example of VALUE_TO_FILTER                   |
-+======+==============================================+==============================================+
-| -fl    | filter by job name                           | ``-fl a000_20101101_fc3_21_SIM"``            |
-+------+----------------------------------------------+----------------------------------------------+
++========+==============================================+==============================================+
+| -fl    | filter by job name                           | ``-fl "a000_20101101_fc3_21_SIM"``           |
++--------+----------------------------------------------+----------------------------------------------+
 | -fs    | filter by job status                         | ``-fs FAILED``                               |
-+------+----------------------------------------------+----------------------------------------------+
-| -ft    | filter by job type (and optionally split)    | ``-ft TRANSFER``                             |
-+------+----------------------------------------------+----------------------------------------------+
++--------+----------------------------------------------+----------------------------------------------+
+| -ft    | filter by job type  (and optionally split)   | ``-ft TRANSFER``                             |
++--------+----------------------------------------------+----------------------------------------------+
 | -fc    | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
-+------+----------------------------------------------+----------------------------------------------+
++--------+----------------------------------------------+----------------------------------------------+
 
 If multiple filters are provided (``-f{ l | s | t | c }``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will have their status changed.
 

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -167,7 +167,7 @@ This procedure allows you to modify the status of your jobs.
 You must execute:
 ::
 
-    autosubmit setstatus <EXPID> -f{ l | s | t | c } <VALUE_TO_FILTER> -t <STATUS_FINAL> -s
+    autosubmit setstatus <EXPID> -<FILTER> <VALUE_TO_FILTER> -t <STATUS_FINAL> -s
 
 By default, plots are **not** generated when changing status. To generate plots showing the updated job statuses, use the ``-plt`` or ``--plot`` option.
 
@@ -178,19 +178,15 @@ By default, plots are **not** generated when changing status. To generate plots 
 Where:
 
 +------+----------------------------------------------+----------------------------------------------+
-| Flag | Meaning                                      | Example                                      |
+| FILTER | Meaning                                      | Example of VALUE_TO_FILTER                   |
 +======+==============================================+==============================================+
-| -fl  | filter by job name                           | ``-fl a000_20101101_fc3_21_SIM"``            |
+| -fl    | filter by job name                           | ``-fl a000_20101101_fc3_21_SIM"``            |
 +------+----------------------------------------------+----------------------------------------------+
-| -fs  | filter by job status                         | ``-fs FAILED``                               |
+| -fs    | filter by job status                         | ``-fs FAILED``                               |
 +------+----------------------------------------------+----------------------------------------------+
-| -ft  | filter by job type (and optionally split)    | ``-ft TRANSFER``                             |
+| -ft    | filter by job type (and optionally split)    | ``-ft TRANSFER``                             |
 +------+----------------------------------------------+----------------------------------------------+
-| -fc  | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
-+------+----------------------------------------------+----------------------------------------------+
-| -t   | target status                                | ``-t READY``                                 |
-+------+----------------------------------------------+----------------------------------------------+
-| -s   | save changes                                 | ``-s``                                       |
+| -fc    | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
 +------+----------------------------------------------+----------------------------------------------+
 
 If multiple filters are provided (``-f{ l | s | t | c }``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will have their status changed.

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -173,7 +173,7 @@ By default, plots are **not** generated when changing status. To generate plots 
 
 ::
 
-    autosubmit setstatus <EXPID> -f{ l | s | t | c } <VALUE_TO_FILTER> -t <STATUS_FINAL> -s -plt
+    autosubmit setstatus <EXPID> <FILTER> <VALUE_TO_FILTER> -t <STATUS_FINAL> -s -plt
 
 Where:
 
@@ -189,12 +189,12 @@ Where:
 | -fc    | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
 +--------+----------------------------------------------+----------------------------------------------+
 
-If multiple filters are provided (``-f{ l | s | t | c }``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will have their status changed.
+If multiple filters are provided (``-fl, fs, ft, fc``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will have their status changed.
 
 Mandatory arguments:
 
 * ``<EXPID>``: experiment identifier
-* ``-f{ l | s | t | c } <VALUE_TO_FILTER>``: at least one filter is required to select jobs (see below for filter options)
+* ``<FILTER> <VALUE_TO_FILTER>``: at least one filter is required to select jobs (see below for filter options)
 * ``-t STATUS_FINAL``: target status (``READY``, ``COMPLETED``, ``WAITING``, ``SUSPENDED``, ``HELD``, ``UNKNOWN``)
 
 Optional filter arguments (combine multiple for granular selection):

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -180,11 +180,11 @@ Where:
 +------+----------------------------------------------+----------------------------------------------+
 | Flag | Meaning                                      | Example                                      |
 +======+==============================================+==============================================+
-| -fl  | filter by section (and optionally split)     | ``-fl "19601101_fc3_21_sim ..."``            |
+| -fl  | filter by job name                           | ``-fl a000_20101101_fc3_21_SIM"``            |
 +------+----------------------------------------------+----------------------------------------------+
 | -fs  | filter by job status                         | ``-fs FAILED``                               |
 +------+----------------------------------------------+----------------------------------------------+
-| -ft  | filter by job type                           | ``-ft TRANSFER``                             |
+| -ft  | filter by job type (and optionally split)    | ``-ft TRANSFER``                             |
 +------+----------------------------------------------+----------------------------------------------+
 | -fc  | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
 +------+----------------------------------------------+----------------------------------------------+
@@ -207,7 +207,7 @@ Optional filter arguments (combine multiple for granular selection):
 
 ::
 
-    autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_sim <EXPID>_20111101_fc4_26_sim" -t READY -s
+    autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_SIM <EXPID>_20111101_fc4_26_SIM" -t READY -s
 
 * ``-fc``: chunk/section/split filter (JSON-like format, takes precedence over legacy filters)
 
@@ -266,7 +266,7 @@ Filter Examples
 Single filter, by job list:
 ::
 
-    autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_sim <EXPID>_20111101_fc4_26_sim" -t READY -s
+    autosubmit setstatus <EXPID> -fl "<EXPID>_20101101_fc3_21_SIM <EXPID>_20111101_fc4_26_SIM" -t READY -s
 
 Single filter, by chunk/section/split:
 ::
@@ -389,8 +389,8 @@ Example:
 
 .. code-block:: ini
 
-    <EXPID>_20101101_fc3_21_sim    READY
-    <EXPID>_20111101_fc4_26_sim    READY
+    <EXPID>_20101101_fc3_21_SIM    READY
+    <EXPID>_20111101_fc4_26_SIM    READY
 
 If Autosubmit finds the above file, it will process it. You can check that the processing was OK at a given date and time,
 if you see that the file name has changed to:

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -167,7 +167,7 @@ This procedure allows you to modify the status of your jobs.
 You must execute:
 ::
 
-    autosubmit setstatus <EXPID> -<FILTER> <VALUE_TO_FILTER> -t <STATUS_FINAL> -s
+    autosubmit setstatus <EXPID> <FILTER> <VALUE_TO_FILTER> -t <STATUS_FINAL> -s
 
 By default, plots are **not** generated when changing status. To generate plots showing the updated job statuses, use the ``-plt`` or ``--plot`` option.
 

--- a/docs/source/userguide/manage/index.rst
+++ b/docs/source/userguide/manage/index.rst
@@ -175,6 +175,23 @@ By default, plots are **not** generated when changing status. To generate plots 
 
     autosubmit setstatus <EXPID> -f{ l | s | t | c } <VALUE_TO_FILTER> -t <STATUS_FINAL> -s -plt
 
+Where:
+
++------+----------------------------------------------+----------------------------------------------+
+| Flag | Meaning                                      | Example                                      |
++======+==============================================+==============================================+
+| -fl  | filter by section (and optionally split)     | ``-fl "19601101_fc3_21_sim ..."``            |
++------+----------------------------------------------+----------------------------------------------+
+| -fs  | filter by job status                         | ``-fs FAILED``                               |
++------+----------------------------------------------+----------------------------------------------+
+| -ft  | filter by job type                           | ``-ft TRANSFER``                             |
++------+----------------------------------------------+----------------------------------------------+
+| -fc  | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
++------+----------------------------------------------+----------------------------------------------+
+| -t   | target status                                | ``-t READY``                                 |
++------+----------------------------------------------+----------------------------------------------+
+| -s   | save changes                                 | ``-s``                                       |
++------+----------------------------------------------+----------------------------------------------+
 
 If multiple filters are provided (``-f{ l | s | t | c }``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will have their status changed.
 


### PR DESCRIPTION
Closes #2928

**Things done**
- Added table in docs/source/userguide/manage/section setstatus to explain each flag in the command.
- Modified how the initial command is presented in the docs, easier to understand
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
