### PR TITLE
Make current datetime timezone aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Allow filtering by section and split in the `ft` command #2910
 - Improved profiler adding tracing and stopping capabilities  #2933
 - Commands `setstatus, create and recovery` do not display tre plot by default #1347
+- Creation and modification dates are now timezone-aware in the `job_data` table #2943
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/history/utils.py
+++ b/autosubmit/history/utils.py
@@ -17,10 +17,11 @@
 
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Union
 
-DATETIME_FORMAT = '%Y-%m-%d-%H:%M:%S'
+LOCAL_TZ = datetime.now(timezone.utc).astimezone().tzinfo
+DATETIME_FORMAT = '%Y-%m-%d-%H:%M:%S%z'
 
 
 def get_fields_as_comma_str(model):
@@ -43,13 +44,13 @@ def calculate_run_time_in_seconds(start_time: float, finish_time: float) -> int:
 
 
 def get_current_datetime() -> str:
-    """Returns the current time in format '%Y-%m-%d-%H:%M:%S'."""
-    return datetime.today().strftime(DATETIME_FORMAT)
+    """Returns the current time in format '%Y-%m-%d-%H:%M:%S%z'."""
+    return datetime.now(LOCAL_TZ).strftime(DATETIME_FORMAT)
 
 
 def get_current_datetime_if_none(argument: Any) -> Union[str, None]:
     # type : (Any) -> Union[Any, str]
-    """ Returns the current time in format '%Y-%m-%d-%H:%M:%S' if the supplied argument is None, else return argument. """
+    """ Returns the current time in format '%Y-%m-%d-%H:%M:%S%z' if the supplied argument is None, else return argument. """
     if argument is None:
         return get_current_datetime()
     else:

--- a/autosubmit/history/utils.py
+++ b/autosubmit/history/utils.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from typing import Any, Union
 
 LOCAL_TZ = datetime.now(timezone.utc).astimezone().tzinfo
-DATETIME_FORMAT = '%Y-%m-%d-%H:%M:%S%z'
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
 
 
 def get_fields_as_comma_str(model):
@@ -44,13 +44,13 @@ def calculate_run_time_in_seconds(start_time: float, finish_time: float) -> int:
 
 
 def get_current_datetime() -> str:
-    """Returns the current time in format '%Y-%m-%d-%H:%M:%S%z'."""
+    """Returns the current time in format '%Y-%m-%dT%H:%M:%S%z'."""
     return datetime.now(LOCAL_TZ).strftime(DATETIME_FORMAT)
 
 
 def get_current_datetime_if_none(argument: Any) -> Union[str, None]:
     # type : (Any) -> Union[Any, str]
-    """ Returns the current time in format '%Y-%m-%d-%H:%M:%S%z' if the supplied argument is None, else return argument. """
+    """ Returns the current time in format '%Y-%m-%dT%H:%M:%S%z' if the supplied argument is None, else return argument. """
     if argument is None:
         return get_current_datetime()
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "psutil<=7.2.2",
     "py3dotplus==1.1.0",
     "numpy<3",
-    "rocrate==0.*",
+    "rocrate==0.14",
     "configparser",
     "setproctitle",
     "invoke>=2.0",

--- a/test/unit/test_history.py
+++ b/test/unit/test_history.py
@@ -18,6 +18,8 @@
 from collections import namedtuple
 
 import os
+import re
+from autosubmit.history.utils import get_current_datetime
 import pytest
 import time
 import traceback
@@ -38,6 +40,13 @@ BasicConfig.read()
 JOBDATA_DIR = BasicConfig.JOBDATA_DIR
 LOCAL_ROOT_DIR = BasicConfig.LOCAL_ROOT_DIR
 job = namedtuple("Job", ["name", "date", "member", "status_str", "children"])
+
+
+def test_get_current_datetime():
+    current_datetime = get_current_datetime()
+    assert isinstance(current_datetime, str)
+    pattern = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$"
+    assert re.match(pattern, current_datetime) is not None
 
 
 @pytest.mark.skip()


### PR DESCRIPTION
Really small PR to save the creation/modified times of the `job_data` table with timezone-aware datetimes.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
