### PR TITLE
Fix ugly and incorrect logs in ASLOGS directory of experiments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   command line if you want this) #2879
 - Allow to set AS variables as lowercase/uppercase (,,/^^) #2504
 - Slurm tests in CICD are using a new container by @giovtorres #2871
+- Fixed main-loop iteration message handling singular/plural and reducing number of line breaks #2969
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2088,10 +2088,10 @@ class Autosubmit:
         :return: common parameters for the iteration
         """
         total_jobs = len(job_list.get_job_list())
-        Log.info(f"\n\n{(total_jobs - len(job_list.get_completed()))} of {total_jobs} jobs remaining "
+        Log.info(f"{(total_jobs - len(job_list.get_completed()))} of {total_jobs} jobs remaining "
                  f"({time.strftime('%H:%M')})")
         if len(job_list.get_failed()) > 0:
-            Log.info(f"{len(job_list.get_failed())} jobs has been  failed ({time.strftime('%H:%M')})")
+            Log.info(f"{len(job_list.get_failed())} jobs have failed ({time.strftime('%H:%M')})")
         safetysleeptime = as_conf.get_safetysleeptime()
         default_retrials = as_conf.get_retrials()
         check_wrapper_jobs_sleeptime = as_conf.get_wrapper_check_time()

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2080,7 +2080,7 @@ class Autosubmit:
             return job_list, submitter, None, None, as_conf, list(platforms_to_test), packages_persistence, True
 
     @staticmethod
-    def get_iteration_info(as_conf, job_list):
+    def get_iteration_info(as_conf, job_list) -> tuple[int, int, int, bool]:
         """Prints the current iteration information.
 
         :param as_conf: autosubmit configuration object
@@ -2090,8 +2090,10 @@ class Autosubmit:
         total_jobs = len(job_list.get_job_list())
         Log.info(f"{(total_jobs - len(job_list.get_completed()))} of {total_jobs} jobs remaining "
                  f"({time.strftime('%H:%M')})")
-        if len(job_list.get_failed()) > 0:
-            Log.info(f"{len(job_list.get_failed())} jobs have failed ({time.strftime('%H:%M')})")
+        failed_jobs = len(job_list.get_failed())
+        if failed_jobs > 0:
+            failed_text = "job has failed" if failed_jobs == 1 else "jobs have failed"
+            Log.info(f"{len(job_list.get_failed())} {failed_text} ({time.strftime('%H:%M')})")
         safetysleeptime = as_conf.get_safetysleeptime()
         default_retrials = as_conf.get_retrials()
         check_wrapper_jobs_sleeptime = as_conf.get_wrapper_check_time()

--- a/test/unit/test_autosubmit.py
+++ b/test/unit/test_autosubmit.py
@@ -79,3 +79,52 @@ def test_database_backup_postgres(monkeypatch, autosubmit, mocker):
     mocked_log = mocker.patch('autosubmit.autosubmit.Log')
     autosubmit.database_backup('a000')
     assert mocked_log.debug.called
+
+
+@pytest.mark.parametrize(
+    'completed,failed',
+    [
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (1, 1),
+        (1, 2)
+    ]
+)
+def test_iteration_info(completed, failed, mocker):
+    """Test that we return and print the iteration info.
+
+    Autosubmit has a function that prints the information about the current main loop iteration.
+    This includes total and failed jobs, and other information about the current loop step.
+    """
+    total_jobs = completed + failed
+    job_list = mocker.MagicMock()
+    job_list.get_job_list.return_value = list(range(total_jobs))
+    job_list.get_completed.return_value = list(range(completed))
+    job_list.get_failed.return_value = list(range(failed))
+
+    expected_safety_time = 42
+    expected_default_retries = 22
+    expected_check_wrapper_time = 1984
+
+    as_conf = mocker.MagicMock()
+    as_conf.get_safetysleeptime.return_value = expected_safety_time
+    as_conf.get_retrials.return_value = expected_default_retries
+    as_conf.get_wrapper_check_time.return_value = expected_check_wrapper_time
+
+    mocked_log = mocker.patch('autosubmit.autosubmit.Log')
+
+    total, safety_time, default_retries, check_wrapper_time = Autosubmit.get_iteration_info(as_conf, job_list)
+
+    assert expected_default_retries == default_retries
+    assert expected_check_wrapper_time == check_wrapper_time
+    assert expected_safety_time == safety_time
+
+    log_info_called = mocked_log.info.call_count
+    expected_info_called = 2 if failed > 0 else 1
+    assert log_info_called == expected_info_called
+
+    if failed > 0:
+        failed_text = "job has" if failed == 1 else "jobs have"
+        assert failed_text in mocked_log.info.call_args_list[1][0][0]
+


### PR DESCRIPTION
I got tired of reading ASLOGS/ run.log entries like this:


2026-04-20 10:07:34,871 Loading HPC parameters...
2026-04-20 10:07:34,938

38826 of 131101 jobs remaining (10:07)
2026-04-20 10:07:35,063 14 jobs has been  failed (10:07) 2026-04-20 10:07:35,063 Sleep: 10

- Remove the extra double newlines.
- Fix the "jobs has been  " to "jobs have " to make the message legible in English.

No change in logic, just formatting the output.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
