### PR TITLE
Inclusion of seconds within monitor class to avoid files or plot overwrite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug fixes:**
 
+- Fixed generate_output and generate_output_txt in Monitor to include seconds in the output filename timestamp, preventing files from being overwritten when generated within the same minute #1159 #1368
 - Fix for energy data that was not being stored for the last job of the batch #2657 #2418
 - Reduce the frequency with which energy data was not being stored for the last job of the batch #2657 #2418
 - Fixed issue with experiments running on LOCAL platform without a defined LOCAL entry in platforms.yml config file #1131

--- a/autosubmit/monitor/monitor.py
+++ b/autosubmit/monitor/monitor.py
@@ -486,7 +486,7 @@ class Monitor:
         try:
             Log.info('Plotting...')
             now = time.localtime()
-            output_date = time.strftime("%Y%m%d_%H%M", now)
+            output_date = time.strftime("%Y%m%d_%H%M%S", now)
             plot_file_name = f'{expid}_{output_date}.{output_format}'
             output_file = Path(BasicConfig.LOCAL_ROOT_DIR, expid, "plot", plot_file_name)
 
@@ -551,7 +551,7 @@ class Monitor:
         Log.info('Writing status txt...')
 
         now = time.localtime()
-        output_date = time.strftime("%Y%m%d_%H%M", now)
+        output_date = time.strftime("%Y%m%d_%H%M%S", now)
 
         status_dir = Path(BasicConfig.LOCAL_ROOT_DIR, expid, "status")
         if not status_dir.exists():

--- a/test/integration/monitor/test_monitor.py
+++ b/test/integration/monitor/test_monitor.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, SubprocessError
 from typing import Optional
 
+import time
 import pytest
 
 from autosubmit.config.yamlparser import YAMLParserFactory
@@ -99,6 +100,23 @@ def test_generate_output(
             )
     else:
         mock_display_file = mocker.patch('autosubmit.monitor.monitor._display_file')
+
+        call_count = 0
+        original_localtime = time.localtime
+
+        
+        def fake_localtime():
+            nonlocal call_count
+            call_count += 1
+            t = list(original_localtime())
+            t[5] = call_count
+            return time.struct_time(t)
+
+        # Patch time.localtime to return a different second on each call,
+        # ensuring distinct filenames even when calls happen within the same second.
+        
+        mocker.patch('autosubmit.monitor.monitor.time.localtime', side_effect=fake_localtime)
+
         if display_error:
             mock_display_file.side_effect = display_error
 
@@ -111,8 +129,17 @@ def test_generate_output(
             groups=None,
             job_list_object=job_list
         )
+        monitor.generate_output(
+            expid=exp.expid,
+            joblist=job_list.get_job_list(),
+            path=str(exp_path / f'tmp/LOG_{exp.expid}'),
+            output_format=output_format,
+            show=show,
+            groups=None,
+            job_list_object=job_list
+        )
+        # Call generate_output twice to verify that the second call does not
 
-        assert mock_display_file.called == show
         if display_error:
             assert mocked_log.printlog.call_count > 0
             logged_message = mocked_log.printlog.call_args_list[-1].args[0]
@@ -124,11 +151,12 @@ def test_generate_output(
             plots_dir = Path(exp_path, 'plot')
         plots = list(plots_dir.iterdir())
 
-        assert len(plots) == 1
-        assert plots[0].name.endswith(output_format)
+        # Both calls must have produced a separate file.
+        assert len(plots) == 2, "Second call must not overwrite the first"
+        assert all(p.name.endswith(output_format) for p in plots)
 
         # TODO: txt is creating an empty file, whereas the other formats create
         #       something that tells the user what are the jobs in the workflow.
         #       So txt format gives less information to the user, thus the 0 size.
         if output_format != 'txt':
-            assert plots[0].stat().st_size > 0
+            assert all(p.stat().st_size > 0 for p in plots)


### PR DESCRIPTION
Fixes the issue with plot overwrite with updates in monitor class on functions generate_output and generate_output_txt to also have seconds on the file name generation #1159 

Fixes output date for files on monitor to have seconds hence will not overwrite files generated in the same minute #1368 

Have not added or changed tests cause the tests only check that the output file exists and has the correct extension — they don't assert on the timestamp portion of the filename — so they remain valid after adding %S to the format string.

**Check List**

- [X] I have read `CONTRIBUTING.md`.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [X] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).