### PR TITLE
2264 added  o txt option to as create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 **Enhancements:**
 
+- Normalized the flags across create / monitor to have the txt option #2264
 - Fix characters escaped in regexes #2526
 - Fixed RO-Crate validation issues with the latest `rocrate-validator`,
   now Autosubmit crates conform to RO-Crate 1.1, process 0.5, workflow run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 **Enhancements:**
 
-- Normalized the flags across create / monitor to have the txt option #2264
+- Added txt report generation using autosubmit create -o txt, similar to autosubmit monitor -o txt #2264"
 - Fix characters escaped in regexes #2526
 - Fixed RO-Crate validation issues with the latest `rocrate-validator`,
   now Autosubmit crates conform to RO-Crate 1.1, process 0.5, workflow run

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4435,6 +4435,7 @@ class Autosubmit:
                                 "Couldn't recover the Historical database, AS will continue without it, GUI may be affected")
                     if detail:
                         output = 'txt'
+                    if output == 'txt':
                         noplot = False
                     if not noplot:
                         from .monitor.monitor import Monitor

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -4433,6 +4433,9 @@ class Autosubmit:
                         except Exception:
                             Log.warning(
                                 "Couldn't recover the Historical database, AS will continue without it, GUI may be affected")
+                    if detail:
+                        output = 'txt'
+                        noplot = False
                     if not noplot:
                         from .monitor.monitor import Monitor
                         if group_by:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -532,7 +532,7 @@ class Autosubmit:
                                    help='hides plot window')
             subparser.add_argument('-d', '--detail', action='store_true',
                                    default=False, help='Show Job List view in terminal')
-            subparser.add_argument('-o', '--output', choices=('pdf', 'png', 'ps', 'svg'),
+            subparser.add_argument('-o', '--output', choices=('pdf', 'png', 'ps', 'svg', 'txt'),
                                    help='chooses type of output for generated plot')  # Default -o value comes from .conf
             subparser.add_argument('-group_by', choices=('date', 'member', 'chunk', 'split', 'automatic'), default=None,
                                    help='Groups the jobs automatically or by date, member, chunk or split')

--- a/docs/source/userguide/modifying_workflow/index.rst
+++ b/docs/source/userguide/modifying_workflow/index.rst
@@ -149,6 +149,8 @@ Additionally, you can have re-run only jobs that won't be included in the defaul
 
 By default, ``create`` does **not** generate plots. To generate plots of the new job list, use the ``-plt`` or ``--plot`` option.
 
+The only exception is ``-txt`` flag that does not require ``-plt`` or ``--plot`` option.
+
 ::
 
     autosubmit create <EXPID>

--- a/test/integration/test_autosubmit.py
+++ b/test/integration/test_autosubmit.py
@@ -24,6 +24,7 @@ from shutil import copy
 from typing import TYPE_CHECKING
 
 import pytest
+import time
 
 from autosubmit.autosubmit import Autosubmit
 from autosubmit.config.basicconfig import BasicConfig
@@ -432,3 +433,24 @@ def test_check_wrappers_and_as_exit(
     jobs_to_check, _ = t
 
     assert len(jobs_to_check) == expected_jobs_to_check
+
+
+def test_create_txt_output_writes_status_file(autosubmit_exp):
+    """Test that -o txt and -d both write a txt file to the status folder."""
+    exp = autosubmit_exp(include_jobs=True)
+
+    # status/ should be empty before test
+    assert not list(exp.status_dir.glob('*.txt')), "status/ should be empty before test"
+
+    # test -o txt creates a file in status/
+    exp.autosubmit.create(exp.expid, noplot=False, hide=True, output='txt', force=True)
+    txt_files_after_txt = list(exp.status_dir.glob('*.txt'))
+    assert len(txt_files_after_txt) == 1, "Expected exactly one txt file in status/ for -o txt"
+
+    # wait to ensure a different timestamp for the second file
+    time.sleep(1)
+
+    # test -d creates another file in status/
+    exp.autosubmit.create(exp.expid, noplot=True, hide=True, output=None, detail=True, force=True)
+    txt_files_after_detail = list(exp.status_dir.glob('*.txt'))
+    assert len(txt_files_after_detail) == 2, "Expected a second txt file in status/ for -d"


### PR DESCRIPTION
The changes made are

- Added txt to the -o flag choices in autosubmit create to match monitor.
- Made -d an alias for -o txt internally in create so that txt file gets created.
- With the autosubmit create <EXPID> -o txt command does not need the -plt flag to be passed.

Closes #2264 

**Check List**

- [X] I have read `CONTRIBUTING.md`.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [X] Tests are included (or explain why tests are not needed).
- [X] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [X] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
