### PR TITLE
Refactor `inspect` command to allow execution with multiple filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Implement filters for `recovery` command #2923
 - Add detection of inneficiencies for key CPMIP metrics #3022
 - Allow multiple filters in the `monitor` command #3020
+- Allow multiple filters in the `inspect` command #3029
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -455,22 +455,17 @@ class Autosubmit:
             subparser.add_argument(
                 '-q', '--quick', action="store_true", help='Only checks one job per each section')
 
-            group.add_argument('-fs', '--filter_status', type=str,
-                               choices=('Any', 'READY', 'COMPLETED',
-                                        'WAITING', 'SUSPENDED', 'FAILED', 'UNKNOWN'),
-                               help='Select the original status to filter the list of jobs')
-            group = subparser.add_mutually_exclusive_group(required=False)
-            group.add_argument('-fl', '--list', type=str,
+            subparser.add_argument('-fl', '--list', type=str,
                                help='Supply the list of job names to be filtered. Default = "Any". '
                                     'LIST = "b037_20101101_fc3_21_sim b037_20111101_fc4_26_sim"')
-            group.add_argument('-fc', '--filter_chunks', type=str,
+            subparser.add_argument('-fc', '--filter_chunks', type=str,
                                help='Supply the list of chunks to filter the list of jobs. Default = "Any". '
                                     'LIST = "[ 19601101 [ fc0 [1 2 3 4] fc1 [1] ] 19651101 [ fc0 [16-30] ] ]"')
-            group.add_argument('-fs', '--filter_status', type=str,
+            subparser.add_argument('-fs', '--filter_status', type=str,
                                choices=('Any', 'READY', 'COMPLETED',
                                         'WAITING', 'SUSPENDED', 'FAILED', 'UNKNOWN'),
                                help='Select the original status to filter the list of jobs')
-            group.add_argument('-ft', '--filter_type', type=str,
+            subparser.add_argument('-ft', '--filter_type', type=str,
                                help='Select the job type to filter the list of jobs')
 
             # Check
@@ -1585,55 +1580,30 @@ class Autosubmit:
                         jobs = job_list.get_job_list()
                     else:
                         Log.info("Generating cmd scripts only for selected jobs")
-                        if filter_chunks:
-                            fc = filter_chunks
-                            Log.debug(fc)
-                            if fc == 'Any':
-                                jobs = job_list.get_job_list()
-                            else:
-                                # noinspection PyTypeChecker
-                                data = json.loads(Autosubmit._create_json(fc))
-                                for date_json in data['sds']:
-                                    date = date_json['sd']
-                                    jobs_date = [j for j in job_list.get_job_list() if date2str(
-                                        j.date) == date]
+                        jobs = job_list.get_job_list()
+                        if filter_section or filter_chunks or filter_status or lst:
+                            Autosubmit._validate_job_filters(
+                                as_conf,
+                                job_list,
+                                lst,
+                                filter_chunks,
+                                filter_status,
+                                filter_section,
+                            )
 
-                                    for member_json in date_json['ms']:
-                                        member = member_json['m']
-                                        jobs_member = [j for j in jobs_date if j.member == member]
+                            selected_job_names = apply_job_filters(
+                                job_list=job_list,
+                                base_job_names={job.name for job in jobs},
+                                filter_section=filter_section,
+                                filter_chunk=filter_chunks,
+                                filter_status=filter_status,
+                                filter_list=lst,
+                                filter_sections_splits_fn=Autosubmit._filter_sections_splits,
+                                filter_chunks_fn=Autosubmit._filter_jobs_by_chunks_splits,
+                                status_from_str_fn=Autosubmit._get_status,
+                            )
 
-                                        for chunk_json in member_json['cs']:
-                                            chunk = int(chunk_json)
-                                            jobs = jobs + [job for job in [j for j in jobs_member if j.chunk == chunk]]
-
-                        elif filter_status:
-                            Log.debug(
-                                f"Filtering jobs with status {filter_status}")
-                            if filter_status == 'Any':
-                                jobs = job_list.get_job_list()
-                            else:
-                                fs = Autosubmit._get_status(filter_status)
-                                jobs = [job for job in [j for j in job_list.get_job_list() if j.status == fs]]
-
-                        elif filter_section:
-                            ft = filter_section
-                            Log.debug(ft)
-
-                            if ft == 'Any':
-                                jobs = job_list.get_job_list()
-                            else:
-                                for job in job_list.get_job_list():
-                                    if job.section == ft:
-                                        jobs.append(job)
-                        elif lst:
-                            jobs_lst = lst.split()
-
-                            if jobs == 'Any':
-                                jobs = job_list.get_job_list()
-                            else:
-                                for job in job_list.get_job_list():
-                                    if job.name in jobs_lst:
-                                        jobs.append(job)
+                            jobs = [job for job in jobs if job.name in selected_job_names]
                         else:
                             jobs = job_list.get_job_list()
             if quick:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1098,7 +1098,6 @@ class Autosubmit:
                     host in BasicConfig.ALLOWED_HOSTS[args.command] or fullhost in BasicConfig.ALLOWED_HOSTS[
                 args.command]):
                 raise AutosubmitCritical(message, 7071)
-        
         if (expid != 'None' and expid) and args.command not in expid_less and args.command not in global_log_command:
             if isinstance(expid, list):
                 expids = cast(list[str], expid)
@@ -1517,22 +1516,33 @@ class Autosubmit:
                 check_wrapper=False, quick=False) -> bool:
         """Generates cmd files experiment.
 
-         :param expid: identifier of experiment to be run
-         :param lst:
-         :param filter_chunks:
-         :param filter_status:
-         :param filter_section:
-         :param force:
-         :param check_wrapper:
-         :param quick:
-         :return: True if run to the end, False otherwise
-         """
+        :param expid: Identifier of experiment to be run
+        :type expid: str
+        :param lst: Optional list of job names to filter for inspect.
+        :type lst: Optional[str]
+        :param filter_chunks: Optional list of chunk identifiers to filter for inspect.
+        :type filter_chunks: Optional[str]
+        :param filter_status: Optional list of job statuses to filter for inspect.
+        :type filter_status: Optional[str]
+        :param filter_section: Optional list of job sections to filter for inspect.
+        :type filter_section: Optional[str]
+        :param force: If true, forces the generation of all cmd files.
+        :type force: bool
+        :param check_wrapper: If true, checks the wrapper.
+        :type check_wrapper: bool
+        :param quick: If true, performs a quick inspect.
+        :type quick: bool
+        :return: True if run to the end, False otherwise
+        :rtype: bool
+        :raises AutosubmitCritical: If there is a critical error during the inspection process.
+        """
+
         try:
             Log.info(f"Inspecting experiment {expid}")
             check_ownership(expid, raise_error=True)
-            exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
-            tmp_path = os.path.join(exp_path, BasicConfig.LOCAL_TMP_DIR)
-            if os.path.exists(os.path.join(tmp_path, 'autosubmit.lock')):
+            exp_path = Path(BasicConfig.LOCAL_ROOT_DIR) / expid
+            tmp_path = exp_path / BasicConfig.LOCAL_TMP_DIR
+            if (tmp_path / 'autosubmit.lock').exists():
                 locked = True
             else:
                 locked = False
@@ -1634,13 +1644,13 @@ class Autosubmit:
 
             if isinstance(jobs, type([])):
                 for job in jobs:
-                    file_paths += f"{BasicConfig.LOCAL_ROOT_DIR}/{expid}/tmp/{job.name}.cmd | {job.file}\n"
+                    file_paths += f"{str(tmp_path / (job.name + '.cmd'))} | {job.file}\n"
                     job.status = Status.WAITING
                 Autosubmit.generate_scripts_andor_wrappers(
                     as_conf, job_list, jobs, packages_persistence, False)
             if len(jobs_cw) > 0:
                 for job in jobs_cw:
-                    file_paths += f"{BasicConfig.LOCAL_ROOT_DIR}/{expid}/tmp/{job.name}.cmd\n"
+                    file_paths += f"{str(tmp_path / (job.name + '.cmd'))}\n"
                     job.status = Status.WAITING
                 Autosubmit.generate_scripts_andor_wrappers(
                     as_conf, job_list, jobs_cw, packages_persistence, False)

--- a/docs/source/userguide/debug/index.rst
+++ b/docs/source/userguide/debug/index.rst
@@ -60,6 +60,22 @@ submit them. When combined with the ``--quick`` flag, it only processes one job
 per section, allowing you to verify all your ``.cmd`` templates inexpensively.
 
 
+Filters
+-------
+
+You can limit the jobs to inspect using the same filters available to the
+`monitor`, `recovery` and `setstatus` commands: `-fl` (filter by job names), 
+`-fc` (filter by chunks), `-fs` (filter by status), and `-ft` (filter by section). 
+Concadenating multiple filters applies a logical AND (intersection), meaning a 
+job must match all provided filters to be selected.
+
+Example (combined filters):
+
+.. code-block:: bash
+
+   autosubmit inspect <EXPID> -fl "jobA jobB" -fc "[ 20200101 [ fc0 [1] ] ]" -ft SECTION -fs WAITING
+
+
 What inspect checks
 -------------------
 

--- a/docs/source/userguide/monitor_and_check/index.rst
+++ b/docs/source/userguide/monitor_and_check/index.rst
@@ -111,7 +111,7 @@ with autosubmit.lock present or not:
 without autosubmit.lock:
 ::
 
-    autosubmit inspect <EXPID> -fl [-fc,-fs or ft]
+    autosubmit inspect <EXPID> -fl [-fc,-fs or -ft]
 
 To generate cmd for wrappers:
 ::
@@ -123,10 +123,37 @@ With autosubmit.lock and no (-f) force, it will only generate all files that are
 
 Without autosubmit.lock, it will generate all unless filtered by -fl,-fc,-fs or -ft.
 
+The following filters can be combined to select jobs to inspect.
+
++--------+----------------------------------------------+----------------------------------------------+
+| FILTER | Meaning                                      | Example of VALUE_TO_FILTER                   |
++========+==============================================+==============================================+
+| -fl    | filter by job name                           | ``-fl "a000_20101101_fc3_21_SIM"``         |
++--------+----------------------------------------------+----------------------------------------------+
+| -fs    | filter by job status                         | ``-fs FAILED``                               |
++--------+----------------------------------------------+----------------------------------------------+
+| -ft    | filter by job type  (and optionally split)   | ``-ft TRANSFER``                             |
++--------+----------------------------------------------+----------------------------------------------+
+| -fc    | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``         |
++--------+----------------------------------------------+----------------------------------------------+
+
+If multiple filters are provided (``-fl, -fs, -ft, -fc``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will be selected for inspection.
+
+To combine multiple filters:
+::
+
+    autosubmit inspect <EXPID> \
+        -fc "[20200101 [ fc0 [1] ] ]" \
+        -fs WAITING \
+        -ft LOCALJOB \
+        -fl "<EXPID>_20200101_fc0_1_1_LOCALJOB"
+
+        
 To generate cmd only for one job per section:
 ::
 
     autosubmit inspect <EXPID> -q
+
 
 How to monitor an experiment
 ----------------------------

--- a/docs/source/userguide/monitor_and_check/index.rst
+++ b/docs/source/userguide/monitor_and_check/index.rst
@@ -81,12 +81,17 @@ For example:
 How to generate cmd files
 -------------------------
 
-To generate the cmd files of the current non-active jobs experiment, use the command:
+The `inspect` command generates the ``.cmd`` files for jobs in an experiment without
+submitting them. This allows you to preview the rendered scripts and verify that all
+parameters are correctly substituted prior to submission.
+
+To generate the cmd files of the current **non-active** jobs experiment, use the command:
 ::
 
     autosubmit inspect EXPID
 
 EXPID is the experiment identifier.
+
 Options:
 
 .. runcmd:: autosubmit inspect -h
@@ -116,9 +121,9 @@ To generate cmd for wrappers:
 
 With autosubmit.lock and no (-f) force, it will only generate all files that are not submitted.
 
-Without autosubmit.lock, it will generate all unless filtered by -fl,fc,fs or ft.
+Without autosubmit.lock, it will generate all unless filtered by -fl,-fc,-fs or -ft.
 
-To generate cmd only for a single job of the section :
+To generate cmd only for one job per section:
 ::
 
     autosubmit inspect <EXPID> -q

--- a/docs/source/userguide/monitor_and_check/index.rst
+++ b/docs/source/userguide/monitor_and_check/index.rst
@@ -128,13 +128,13 @@ The following filters can be combined to select jobs to inspect.
 +--------+----------------------------------------------+----------------------------------------------+
 | FILTER | Meaning                                      | Example of VALUE_TO_FILTER                   |
 +========+==============================================+==============================================+
-| -fl    | filter by job name                           | ``-fl "a000_20101101_fc3_21_SIM"``         |
+| -fl    | filter by job name                           | ``-fl "a000_20101101_fc3_21_SIM"``           |
 +--------+----------------------------------------------+----------------------------------------------+
 | -fs    | filter by job status                         | ``-fs FAILED``                               |
 +--------+----------------------------------------------+----------------------------------------------+
 | -ft    | filter by job type  (and optionally split)   | ``-ft TRANSFER``                             |
 +--------+----------------------------------------------+----------------------------------------------+
-| -fc    | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``         |
+| -fc    | filter by chunk/section/split                | ``-fc "[ 19601101 [ fc1 [1] ] ]"``           |
 +--------+----------------------------------------------+----------------------------------------------+
 
 If multiple filters are provided (``-fl, -fs, -ft, -fc``), they will be combined as logical AND, meaning that only jobs matching ALL specified filters will be selected for inspection.
@@ -148,7 +148,7 @@ To combine multiple filters:
         -ft LOCALJOB \
         -fl "<EXPID>_20200101_fc0_1_1_LOCALJOB"
 
-        
+
 To generate cmd only for one job per section:
 ::
 

--- a/test/integration/commands/conftest.py
+++ b/test/integration/commands/conftest.py
@@ -23,6 +23,12 @@ import pytest
 
 
 @pytest.fixture(scope="function")
+def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
+    config_data = general_data | experiment_data | jobs_data
+    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
+
+
+@pytest.fixture(scope="function")
 def general_data(tmp_path: Path) -> dict[str, Any]:
     """
     Provides part of the `experiment_data` dictionary used by the

--- a/test/integration/commands/inspect/test_inspect.py
+++ b/test/integration/commands/inspect/test_inspect.py
@@ -24,6 +24,7 @@ from bscearth.utils.date import date2str
 
 """Integration tests for argument behavior."""
 
+
 @pytest.fixture(scope="function")
 def templates_dir(as_exp) -> Path:
     """Return the path to the templates directory for the given experiment."""

--- a/test/integration/commands/inspect/test_inspect.py
+++ b/test/integration/commands/inspect/test_inspect.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from autosubmit.config.basicconfig import BasicConfig
+from autosubmit.job.job_common import Status
 from bscearth.utils.date import date2str
 
 """Integration tests for argument behavior."""
@@ -62,7 +63,9 @@ def cleanup_lock(as_exp) -> None:
             pass
 
 
-def do_inspect(as_exp, fl=None, fc=None, fs=None, ft=None, quick=False):
+def do_inspect(
+    as_exp, fl=None, fc=None, fs=None, ft=None, quick=False, check_wrapper=False
+):
     """Call the inspect command with the given filters and return the list of generated .cmd files."""
     as_exp.as_conf.set_last_as_command("inspect")
     templates = (
@@ -80,7 +83,7 @@ def do_inspect(as_exp, fl=None, fc=None, fs=None, ft=None, quick=False):
         filter_status=fs,
         filter_section=ft,
         force=False,
-        check_wrapper=False,
+        check_wrapper=check_wrapper,
         quick=quick,
     )
 
@@ -149,3 +152,28 @@ def test_inpect_no_filters_selects_all_jobs(as_exp, mocker):
     do_inspect(as_exp)
 
     assert set(captured_jobs["names"]) == set(all_job_names)
+
+
+def test_check_wrappers_selects_uncompleted_jobs(as_exp, mocker):
+    """Test that when inspect is called with check_wrapper=True, the uncompleted jobs are selected."""
+    job_list = as_exp.autosubmit.load_job_list(as_exp.expid, as_exp.as_conf, new=False)
+    expected_jobs = {job.name for job in job_list.get_uncompleted()}
+
+    captured_jobs = {}
+
+    def capture_generate_scripts(
+        as_conf, job_list_obj, jobs_filtered, packages_persistence, only_wrappers=False
+    ):
+        captured_jobs["names"] = [job.name for job in jobs_filtered]
+
+    mocker.patch(
+        "autosubmit.autosubmit.Autosubmit.generate_scripts_andor_wrappers",
+        side_effect=capture_generate_scripts,
+    )
+
+    do_inspect(as_exp, ft="LOCALJOB", check_wrapper=True)
+
+    assert set(captured_jobs["names"]) == expected_jobs
+    for job_name in captured_jobs["names"]:
+        job = job_list.get_job_by_name(job_name)
+        assert job.status == Status.WAITING

--- a/test/integration/commands/inspect/test_inspect.py
+++ b/test/integration/commands/inspect/test_inspect.py
@@ -22,6 +22,7 @@ import pytest
 from autosubmit.config.basicconfig import BasicConfig
 from bscearth.utils.date import date2str
 
+"""Integration tests for argument behavior."""
 
 @pytest.fixture(scope="function")
 def templates_dir(as_exp) -> Path:
@@ -125,3 +126,25 @@ def test_inspect_combined_filters(as_exp, mocker, templates_dir):
     )
 
     assert captured_jobs["names"] == [target_job]
+
+
+def test_inpect_no_filters_selects_all_jobs(as_exp, mocker):
+    """Test that when inspect is called without filters, all jobs are selected."""
+    job_list = as_exp.autosubmit.load_job_list(as_exp.expid, as_exp.as_conf, new=False)
+    all_job_names = [job.name for job in job_list.get_job_list()]
+
+    captured_jobs = {}
+
+    def capture_generate_scripts(
+        as_conf, job_list_obj, jobs_filtered, packages_persistence, only_wrappers=False
+    ):
+        captured_jobs["names"] = [job.name for job in jobs_filtered]
+
+    mocker.patch(
+        "autosubmit.autosubmit.Autosubmit.generate_scripts_andor_wrappers",
+        side_effect=capture_generate_scripts,
+    )
+
+    do_inspect(as_exp)
+
+    assert set(captured_jobs["names"]) == set(all_job_names)

--- a/test/integration/commands/inspect/test_inspect_filters.py
+++ b/test/integration/commands/inspect/test_inspect_filters.py
@@ -20,21 +20,18 @@ from pathlib import Path
 import pytest
 
 from autosubmit.config.basicconfig import BasicConfig
-from autosubmit.log.log import AutosubmitCritical
 from bscearth.utils.date import date2str
-
-
-@pytest.fixture(scope="function")
-def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
-    config_data = general_data | experiment_data | jobs_data
-    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
 
 
 @pytest.fixture(scope="function")
 def templates_dir(as_exp) -> Path:
     """Return the path to the templates directory for the given experiment."""
     as_conf = as_exp.as_conf
-    return Path(as_conf.basic_config.LOCAL_ROOT_DIR) / as_exp.expid / BasicConfig.LOCAL_TMP_DIR
+    return (
+        Path(as_conf.basic_config.LOCAL_ROOT_DIR)
+        / as_exp.expid
+        / BasicConfig.LOCAL_TMP_DIR
+    )
 
 
 def cleanup_cmds(templates_dir: Path) -> None:
@@ -66,7 +63,11 @@ def cleanup_lock(as_exp) -> None:
 def do_inspect(as_exp, fl=None, fc=None, fs=None, ft=None, quick=False):
     """Call the inspect command with the given filters and return the list of generated .cmd files."""
     as_exp.as_conf.set_last_as_command("inspect")
-    templates = Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR) / as_exp.expid / BasicConfig.LOCAL_TMP_DIR
+    templates = (
+        Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR)
+        / as_exp.expid
+        / BasicConfig.LOCAL_TMP_DIR
+    )
     cleanup_cmds(templates)
     cleanup_lock(as_exp)
 
@@ -89,7 +90,8 @@ def test_inspect_combined_filters(as_exp, mocker, templates_dir):
     job_list = as_exp.autosubmit.load_job_list(as_exp.expid, as_exp.as_conf, new=False)
 
     target = next(
-        job for job in job_list.get_job_list()
+        job
+        for job in job_list.get_job_list()
         if job.section == "LOCALJOB"
         and date2str(job.date) == "20200101"
         and job.member == "fc0"
@@ -97,12 +99,16 @@ def test_inspect_combined_filters(as_exp, mocker, templates_dir):
         and str(job.split) == "2"
     )
     target_job = target.name
-    no_matching_job = next(job.name for job in job_list.get_job_list() if job.name != target_job)
+    no_matching_job = next(
+        job.name for job in job_list.get_job_list() if job.name != target_job
+    )
     filter_list = f"{target_job} {no_matching_job}"
 
     captured_jobs = {}
 
-    def capture_generate_scripts(as_conf, job_list_obj, jobs_filtered, packages_persistence, only_wrappers=False):
+    def capture_generate_scripts(
+        as_conf, job_list_obj, jobs_filtered, packages_persistence, only_wrappers=False
+    ):
         captured_jobs["names"] = [job.name for job in jobs_filtered]
 
     mocker.patch(

--- a/test/integration/commands/inspect/test_inspect_filters.py
+++ b/test/integration/commands/inspect/test_inspect_filters.py
@@ -1,0 +1,121 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+from autosubmit.config.basicconfig import BasicConfig
+from autosubmit.log.log import AutosubmitCritical
+from bscearth.utils.date import date2str
+
+
+@pytest.fixture(scope="function")
+def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
+    config_data = general_data | experiment_data | jobs_data
+    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
+
+
+@pytest.fixture(scope="function")
+def templates_dir(as_exp) -> Path:
+    """Return the path to the templates directory for the given experiment."""
+    as_conf = as_exp.as_conf
+    return Path(as_conf.basic_config.LOCAL_ROOT_DIR) / as_exp.expid / BasicConfig.LOCAL_TMP_DIR
+
+
+def cleanup_cmds(templates_dir: Path) -> None:
+    """Remove any .cmd files from the templates directory."""
+    if templates_dir.exists():
+        for f in templates_dir.glob("*.cmd"):
+            try:
+                f.unlink()
+            except Exception:
+                pass
+
+
+# TODO: this will not be necessary once the lock file is deleted correctly
+def cleanup_lock(as_exp) -> None:
+    """Remove the inspect lock file if the fixture created one."""
+    lock_file = (
+        Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR)
+        / as_exp.expid
+        / BasicConfig.LOCAL_TMP_DIR
+        / "autosubmit.lock"
+    )
+    if lock_file.exists():
+        try:
+            lock_file.unlink()
+        except Exception:
+            pass
+
+
+def do_inspect(as_exp, fl=None, fc=None, fs=None, ft=None, quick=False):
+    """Call the inspect command with the given filters and return the list of generated .cmd files."""
+    as_exp.as_conf.set_last_as_command("inspect")
+    templates = Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR) / as_exp.expid / BasicConfig.LOCAL_TMP_DIR
+    cleanup_cmds(templates)
+    cleanup_lock(as_exp)
+
+    as_exp.autosubmit.inspect(
+        expid=as_exp.expid,
+        lst=fl,
+        filter_chunks=fc,
+        filter_status=fs,
+        filter_section=ft,
+        force=False,
+        check_wrapper=False,
+        quick=quick,
+    )
+
+    return [p.name for p in templates.glob("*.cmd")]
+
+
+def test_inspect_combined_filters(as_exp, mocker, templates_dir):
+    """Test that when inspect and multiple filters are used, selected jobs must match the intersecion of the filters."""
+    job_list = as_exp.autosubmit.load_job_list(as_exp.expid, as_exp.as_conf, new=False)
+
+    target = next(
+        job for job in job_list.get_job_list()
+        if job.section == "LOCALJOB"
+        and date2str(job.date) == "20200101"
+        and job.member == "fc0"
+        and str(job.chunk) == "1"
+        and str(job.split) == "2"
+    )
+    target_job = target.name
+    no_matching_job = next(job.name for job in job_list.get_job_list() if job.name != target_job)
+    filter_list = f"{target_job} {no_matching_job}"
+
+    captured_jobs = {}
+
+    def capture_generate_scripts(as_conf, job_list_obj, jobs_filtered, packages_persistence, only_wrappers=False):
+        captured_jobs["names"] = [job.name for job in jobs_filtered]
+
+    mocker.patch(
+        "autosubmit.autosubmit.Autosubmit.generate_scripts_andor_wrappers",
+        side_effect=capture_generate_scripts,
+    )
+
+    do_inspect(
+        as_exp,
+        fl=filter_list,
+        fc="[20200101 [fc0 [1] ] ]",
+        ft="LOCALJOB",
+        fs="WAITING",
+    )
+
+    assert captured_jobs["names"] == [target_job]

--- a/test/integration/commands/inspect/test_inspect_local.py
+++ b/test/integration/commands/inspect/test_inspect_local.py
@@ -24,6 +24,8 @@ from ruamel.yaml import YAML
 
 from autosubmit.config.basicconfig import BasicConfig
 
+"""Integration tests focused on `inspect` command output and template content."""
+
 # -- Tests
 _TEMPLATE_CONTENT = dedent("""
 echo "Hello World with id=Success"

--- a/test/integration/commands/test_autosubmit_commands.py
+++ b/test/integration/commands/test_autosubmit_commands.py
@@ -23,12 +23,6 @@ from autosubmit.history.database_managers.experiment_history_db_manager import (
 )
 
 
-@pytest.fixture(scope="function")
-def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
-    config_data = general_data | experiment_data | jobs_data
-    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
-
-
 @pytest.mark.parametrize("noplot", [True, False])
 def test_create_noplot_calls_generate_output(as_exp, mocker, noplot):
     """Test that create calls generate_output when noplot is False and does not call it when noplot is True."""

--- a/test/integration/commands/test_monitor.py
+++ b/test/integration/commands/test_monitor.py
@@ -24,12 +24,6 @@ from autosubmit.history.database_managers.experiment_history_db_manager import (
 )
 
 
-@pytest.fixture(scope="function")
-def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
-    config_data = general_data | experiment_data | jobs_data
-    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
-
-
 def reset(as_exp_, target="WAITING"):
     job_list_ = as_exp_.autosubmit.load_job_list(
         as_exp_.expid, as_exp_.as_conf, new=False

--- a/test/integration/commands/test_recovery.py
+++ b/test/integration/commands/test_recovery.py
@@ -37,12 +37,6 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(scope="function")
-def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
-    config_data = general_data | experiment_data | jobs_data
-    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
-
-
-@pytest.fixture(scope="function")
 def submitter(as_exp):
     submitter = as_exp.autosubmit._get_submitter(as_exp.as_conf)
     submitter.load_platforms(as_exp.as_conf)

--- a/test/integration/commands/test_recovery.py
+++ b/test/integration/commands/test_recovery.py
@@ -122,7 +122,7 @@ def reset(as_exp_, target="WAITING"):
 
 
 def do_recovery(as_exp, fl=None, fc=None, fs=None, ft=None, all_jobs=True):
-
+    """Call the recovery command with the given filters and return the job list after recovery."""
     as_exp.autosubmit.recovery(
         as_exp.expid,
         noplot=False,

--- a/test/integration/commands/test_run_command.py
+++ b/test/integration/commands/test_run_command.py
@@ -133,7 +133,7 @@ def test_run_command(
         assert exp.autosubmit.run_command(args=args) == 0
     else:
         assert exp.autosubmit.run_command(args=args)
-    
+
 
 @pytest.mark.parametrize(
     "command",
@@ -440,4 +440,3 @@ def test_run_report_template_edge_cases(
     report = next(Path(exp.tmp_dir).glob(f"{expid}_report_*"))
     rendered = report.read_text().rstrip('\n')
     assert rendered == expected_output
-            

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -27,12 +27,6 @@ from autosubmit.log.log import AutosubmitCritical
 from bscearth.utils.date import date2str
 
 
-@pytest.fixture(scope="function")
-def as_exp(autosubmit_exp, general_data, experiment_data, jobs_data):
-    config_data = general_data | experiment_data | jobs_data
-    return autosubmit_exp(experiment_data=config_data, include_jobs=False, create=True)
-
-
 def reset(as_exp_, target="WAITING"):
     job_list_ = as_exp_.autosubmit.load_job_list(
         as_exp_.expid, as_exp_.as_conf, new=False

--- a/test/unit/test_commands.py
+++ b/test/unit/test_commands.py
@@ -73,8 +73,8 @@ def test_exceptions_raised(exception: BaseException, raised: BaseException, stat
 
 @pytest.mark.parametrize(
     "command",
-    ["setstatus", "monitor", "recovery"],
-    ids=["setstatus", "monitor", "recovery"],
+    ["setstatus", "monitor", "recovery", "inspect"],
+    ids=["setstatus", "monitor", "recovery", "inspect"],
 )
 def test_combined_filters_parsed_for_commands(mocker, command):
     """Test combined filters parse correctly for multiple commands."""
@@ -109,8 +109,8 @@ def test_combined_filters_parsed_for_commands(mocker, command):
 
 @pytest.mark.parametrize(
     "command",
-    ["setstatus", "monitor", "recovery"],
-    ids=["setstatus", "monitor", "recovery"],
+    ["setstatus", "monitor", "recovery", "inspect"],
+    ids=["setstatus", "monitor", "recovery", "inspect"],
 )
 def test_command_accepts_section_splits_in_ft(mocker, command):
     """Test command accepts section/split syntax in ``-ft``."""


### PR DESCRIPTION
Closes #3025 

As implemented previously for setstatus and recovery and monitor, inspect now allows being executed with multiple filters at the same time (-ft, -fs, -fc, -fl) and follows the same filter code structure.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
