### PR TITLE
Log paths in `status` txt outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Fixes an issue with SUSPENDED parents being ignored when STATUS: RUNNING is set in the dependencies #2960
 - Fixed `autosubmit stats` command that was not considering parameters defined in the platform, like NODES, TASKS, etc. #2978
 - Fixes 1-N grouped split dependencies #2958
-
+- Fixed inconsistent log paths in status txt output #3040
 
 **Enhancements:**
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2791,7 +2791,14 @@ class Autosubmit:
                 monitor_exp.generate_output_txt(
                     expid,
                     jobs,
-                    str(BasicConfig.expid_log_dir(expid)),
+                    str(
+                        Path(
+                            BasicConfig.LOCAL_ROOT_DIR,
+                            expid,
+                            BasicConfig.LOCAL_TMP_DIR,
+                            f"LOG_{expid}",
+                        )
+                    ),
                     txt_logfiles,
                     job_list_object=job_list,
                 )
@@ -2807,7 +2814,7 @@ class Autosubmit:
                 # if file_format is set, use file_format, otherwise use conf value
                 monitor_exp.generate_output(expid,
                                             jobs,
-                                            str(BasicConfig.expid_log_dir(expid)),
+                                            str(Path(BasicConfig.LOCAL_ROOT_DIR, expid, BasicConfig.LOCAL_TMP_DIR, f"LOG_{expid}")),
                                             output_format=file_format if file_format is not None and len(
                                                 str(file_format)) > 0 else output_type,
                                             packages=packages,
@@ -3194,7 +3201,14 @@ class Autosubmit:
                 monitor_exp.generate_output(
                     expid,
                     job_list.get_job_list(),
-                    str(BasicConfig.expid_log_dir(expid)),
+                    str(
+                        Path(
+                            BasicConfig.LOCAL_ROOT_DIR,
+                            expid,
+                            BasicConfig.LOCAL_TMP_DIR,
+                            f"LOG_{expid}",
+                        )
+                    ),
                     output_format=output_type,
                     packages=packages,
                     show=not hide,
@@ -4484,7 +4498,14 @@ class Autosubmit:
                         monitor_exp.generate_output(
                             expid,
                             job_list.get_job_list(),
-                            str(BasicConfig.expid_log_dir(expid)),
+                            str(
+                                Path(
+                                    BasicConfig.LOCAL_ROOT_DIR,
+                                    expid,
+                                    BasicConfig.LOCAL_TMP_DIR,
+                                    f"LOG_{expid}",
+                                )
+                            ),
                             output if output is not None else output_type,
                             packages,
                             not hide,
@@ -5473,14 +5494,23 @@ class Autosubmit:
                         groups_dict = job_grouping.group_jobs()
                     Log.info("\nPlotting joblist...")
                     monitor_exp = Monitor()
-                    monitor_exp.generate_output(expid,
-                                                job_list.get_job_list(),
-                                                str(BasicConfig.expid_log_dir(expid)),
-                                                output_format=output_type,
-                                                packages=packages,
-                                                show=not hide,
-                                                groups=groups_dict,
-                                                job_list_object=job_list)
+                    monitor_exp.generate_output(
+                        expid,
+                        job_list.get_job_list(),
+                        str(
+                            Path(
+                                BasicConfig.LOCAL_ROOT_DIR,
+                                expid,
+                                BasicConfig.LOCAL_TMP_DIR,
+                                f"LOG_{expid}",
+                            )
+                        ),
+                        output_format=output_type,
+                        packages=packages,
+                        show=not hide,
+                        groups=groups_dict,
+                        job_list_object=job_list,
+                    )
                 return True
         except Exception:
             raise

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2788,8 +2788,13 @@ class Autosubmit:
         monitor_exp = Monitor()
         try:
             if txt_only or txt_logfiles or file_format == "txt":
-                monitor_exp.generate_output_txt(expid, jobs, os.path.join(
-                    exp_path, "/tmp/LOG_" + expid), txt_logfiles, job_list_object=job_list)
+                monitor_exp.generate_output_txt(
+                    expid,
+                    jobs,
+                    str(BasicConfig.expid_log_dir(expid)),
+                    txt_logfiles,
+                    job_list_object=job_list,
+                )
                 if txt_only:
                     current_length = len(job_list.get_job_list())
                     if current_length > 1000:
@@ -2802,8 +2807,7 @@ class Autosubmit:
                 # if file_format is set, use file_format, otherwise use conf value
                 monitor_exp.generate_output(expid,
                                             jobs,
-                                            os.path.join(
-                                                exp_path, "/tmp/LOG_", expid),
+                                            str(BasicConfig.expid_log_dir(expid)),
                                             output_format=file_format if file_format is not None and len(
                                                 str(file_format)) > 0 else output_type,
                                             packages=packages,
@@ -3188,9 +3192,15 @@ class Autosubmit:
                 Log.info("\nPlotting the jobs list...")
                 monitor_exp = Monitor()
                 monitor_exp.generate_output(
-                    expid, job_list.get_job_list(), os.path.join(exp_path, "/tmp/LOG_", expid),
-                    output_format=output_type, packages=packages, show=not hide, groups=groups_dict,
-                    job_list_object=job_list)
+                    expid,
+                    job_list.get_job_list(),
+                    str(BasicConfig.expid_log_dir(expid)),
+                    output_format=output_type,
+                    packages=packages,
+                    show=not hide,
+                    groups=groups_dict,
+                    job_list_object=job_list,
+                )
         except Exception as e:
             Log.warning("An error has occurred while plotting the jobs list after recovery. "
                         f"Check if you have X11 redirection and an img viewer correctly set. Trace: {str(e)}")
@@ -4471,14 +4481,16 @@ class Autosubmit:
                         Log.info("\nPlotting the jobs list...")
                         monitor_exp = Monitor()
                         # if output is set, use output
-                        monitor_exp.generate_output(expid, job_list.get_job_list(),
-                                                    os.path.join(
-                                                        exp_path, "/tmp/LOG_", expid),
-                                                    output if output is not None else output_type,
-                                                    packages,
-                                                    not hide,
-                                                    groups=groups_dict,
-                                                    job_list_object=job_list)
+                        monitor_exp.generate_output(
+                            expid,
+                            job_list.get_job_list(),
+                            str(BasicConfig.expid_log_dir(expid)),
+                            output if output is not None else output_type,
+                            packages,
+                            not hide,
+                            groups=groups_dict,
+                            job_list_object=job_list,
+                        )
                     Log.result("\nJob list created successfully")
                     Log.warning(
                         "Remember to MODIFY the MODEL config files!")
@@ -5463,7 +5475,7 @@ class Autosubmit:
                     monitor_exp = Monitor()
                     monitor_exp.generate_output(expid,
                                                 job_list.get_job_list(),
-                                                str(Path(exp_path, "tmp", "LOG_" + expid)),
+                                                str(BasicConfig.expid_log_dir(expid)),
                                                 output_format=output_type,
                                                 packages=packages,
                                                 show=not hide,

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2687,7 +2687,6 @@ class Autosubmit:
             profiler.start()
 
         try:
-            exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
             Log.info("Getting job list...")
             as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
             as_conf.check_conf_files(False)
@@ -3044,7 +3043,6 @@ class Autosubmit:
             Log.warning("Changes will be NOT saved to the jobList. Use -s option to save")
 
         check_ownership(expid, raise_error=True)
-        exp_path = os.path.join(BasicConfig.LOCAL_ROOT_DIR, expid)
         as_conf = AutosubmitConfig(expid, BasicConfig, YAMLParserFactory())
         as_conf.check_conf_files(True)
         Log.info(f'Recovering experiment {expid}')

--- a/autosubmit/monitor/monitor.py
+++ b/autosubmit/monitor/monitor.py
@@ -567,10 +567,10 @@ class Monitor:
                     if job.status in [Status.FAILED, Status.COMPLETED]:
                         if type(job.local_logs) is not tuple:
                             job.local_logs = ("", "")
-                        log_out = path + "/" + job.local_logs[0]
-                        log_err = path + "/" + job.local_logs[1]
+                        log_out = str(Path(path) / job.local_logs[0]) if job.local_logs[0] else ""
+                        log_err = str(Path(path) / job.local_logs[1]) if job.local_logs[1] else ""
 
-                    output = f'{job.name} {Status.VALUE_TO_KEY[job.status]} {log_out} {log_err} \n'
+                    output = f'{job.name} {Status.VALUE_TO_KEY[job.status]} {log_out} {log_err}\n'
                     output_file.write(output)
             else:
                 # Replaced call to function for a call to the function of the object that

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -418,7 +418,9 @@ def test_generate_output_txt(jobs: list[Job], classictxt: bool, status_dir_exist
 
 
 @pytest.mark.parametrize(
-    "status", [Status.FAILED, Status.COMPLETED], ids=["failed job", "completed job"]
+    "status",
+    [Status.FAILED, Status.COMPLETED, Status.RUNNING],
+    ids=["failed job", "completed job", "running job"],
 )
 def test_log_paths_in_outptut_txt(status, tmp_path, autosubmit_config, mocker):
     """Test that the log paths are correctly written in the output txt file."""
@@ -454,13 +456,18 @@ def test_log_paths_in_outptut_txt(status, tmp_path, autosubmit_config, mocker):
         job_list_object=None,
     )
 
-    assert status_file.exists()
-    content = status_file.read_text()
-    expected_line = (
-        f"{job.name} {Status.VALUE_TO_KEY[status]} "
-        f"{expected_log_root / out_filename} {expected_log_root / err_filename}\n"
-    )
-    assert content == expected_line
+    if status in [Status.FAILED, Status.COMPLETED]:
+        assert status_file.exists()
+        content = status_file.read_text()
+        expected_line = (
+            f"{job.name} {Status.VALUE_TO_KEY[status]} "
+            f"{expected_log_root / out_filename} {expected_log_root / err_filename}\n"
+        )
+        assert content == expected_line
+    else:
+        assert status_file.exists()
+        content = status_file.read_text()
+        assert f"{job.name} RUNNING  \n" in content
 
 
 def test_generate_output_txt_job_with_children(tmp_path, autosubmit_config, mocker):

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -456,18 +456,18 @@ def test_log_paths_in_outptut_txt(status, tmp_path, autosubmit_config, mocker):
         job_list_object=None,
     )
 
+    # Assert
+    assert status_file.exists()
+    content = status_file.read_text()
+
     if status in [Status.FAILED, Status.COMPLETED]:
-        assert status_file.exists()
-        content = status_file.read_text()
         expected_line = (
             f"{job.name} {Status.VALUE_TO_KEY[status]} "
             f"{expected_log_root / out_filename} {expected_log_root / err_filename}\n"
         )
         assert content == expected_line
     else:
-        assert status_file.exists()
-        content = status_file.read_text()
-        assert f"{job.name} RUNNING  \n" in content
+        assert f"{job.name} {Status.VALUE_TO_KEY[status]}  \n" in content
 
 
 def test_generate_output_txt_job_with_children(tmp_path, autosubmit_config, mocker):

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -389,6 +389,7 @@ def test_generate_output_unexpected_error(error_msg: str, mocker):
 )
 def test_generate_output_txt(jobs: list[Job], classictxt: bool, status_dir_exists: bool, has_joblist: bool,
                              expected_text: str, expected_lines_count: int, tmp_path, autosubmit_config, mocker):
+    """Test that writing the output txt file works as expected."""
     time_str = 20250429_1200
     mocker.patch('autosubmit.monitor.monitor.time.strftime', return_value=time_str)
 
@@ -414,6 +415,52 @@ def test_generate_output_txt(jobs: list[Job], classictxt: bool, status_dir_exist
     status_file_content = status_file.read_text()
     assert len(status_file_content.split('\n')) == expected_lines_count
     assert expected_text in status_file_content
+
+
+@pytest.mark.parametrize(
+    "status", [Status.FAILED, Status.COMPLETED], ids=["failed job", "completed job"]
+)
+def test_log_paths_in_outptut_txt(status, tmp_path, autosubmit_config, mocker):
+    """Test that the log paths are correctly written in the output txt file."""
+    out_filename = f"{_EXPID}_ONLY_JOB.20250429120010.out"
+    err_filename = f"{_EXPID}_ONLY_JOB.20250429120010.err"
+    time_str = "20250429_120010"
+    mocker.patch("autosubmit.monitor.monitor.time.strftime", return_value=time_str)
+
+    as_conf = autosubmit_config(_EXPID, experiment_data={})
+    exp_root = Path(as_conf.basic_config.LOCAL_ROOT_DIR, _EXPID)
+    expected_log_root = exp_root / as_conf.basic_config.LOCAL_TMP_DIR / f"LOG_{_EXPID}"
+
+    # Create the log directory and log files
+    expected_log_root.mkdir(parents=True, exist_ok=True)
+    (expected_log_root / out_filename).touch()
+    (expected_log_root / err_filename).touch()
+
+    # Create the status directory and the expected output txt file
+    status_path = exp_root / "status"
+    status_path.mkdir(parents=True, exist_ok=True)
+    status_file = status_path / f"{_EXPID}_{time_str}.txt"
+
+    # Create a job with the status and local_logs
+    job = Job(f"{_EXPID}_ONLY_JOB", 1, status)
+    job.local_logs = (out_filename, err_filename)
+
+    monitor = Monitor()
+    monitor.generate_output_txt(
+        _EXPID,
+        joblist=[job],
+        path=str(expected_log_root),
+        classictxt=True,
+        job_list_object=None,
+    )
+
+    assert status_file.exists()
+    content = status_file.read_text()
+    expected_line = (
+        f"{job.name} {Status.VALUE_TO_KEY[status]} "
+        f"{expected_log_root / out_filename} {expected_log_root / err_filename}\n"
+    )
+    assert content == expected_line
 
 
 def test_generate_output_txt_job_with_children(tmp_path, autosubmit_config, mocker):


### PR DESCRIPTION
Closes #3032 

**Things done**
- Standardized paths logged in status txt files. Now they always log the same complete err and out path independent of the command executed.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
