### PR TITLE
Allow changes in the AQUA catalog submodule

### DIFF
--- a/autosubmit/git/autosubmit_git.py
+++ b/autosubmit/git/autosubmit_git.py
@@ -39,7 +39,7 @@ _GIT_URL_PATTERN = re.compile(
     )''', re.VERBOSE)
 """Regular expression to match Git URL."""
 
-_GIT_UNCOMMITTED_CMD = ('git', 'status', '--porcelain')
+_GIT_UNCOMMITTED_CMD = ('git', 'status', '--porcelain', '--', '.', ':(exclude)catalog')
 """Command to check if there are changes not committed go local Git repository."""
 
 _GIT_UNPUSHED_CMD = ('git', 'log', '--branches', '--not', '--remotes')

--- a/test/integration/git/test_autosubmit_git.py
+++ b/test/integration/git/test_autosubmit_git.py
@@ -76,6 +76,7 @@ def _get_experiment_data(tmp_path) -> dict:
         ('git', False, False, 'a810', does_not_raise()),
         ('git', True, False, 'a811', does_not_raise()),
         ('git', True, True, 'a812', does_not_raise()),
+        ('git', False, False, 'o813', does_not_raise()),
     ],
     ids=[
         'NOK: Did not commit nor push an operational experiment',
@@ -83,7 +84,8 @@ def _get_experiment_data(tmp_path) -> dict:
         'OK: Commited and pushed an operational experiment',
         'OK: Did not commit nor push a common experiment',
         'OK: Committed but did not commit nor push a common experiment',
-        'OK: Committed and pushed a common experiment'
+        'OK: Committed and pushed a common experiment',
+        'OK: Commited and pushed an operational experiment'
     ]
 )
 @pytest.mark.docker
@@ -117,6 +119,13 @@ def test_git_local_dirty(
 
     if project_type == 'git' and commit:
         git_commit_all_in_dir(proj_dir, push=push)
+
+    # test whether aqua catalog changes will trigger the error
+    if expid == 'o813':
+        catalog_dir = proj_dir / 'catalog'
+        catalog_dir.mkdir(parents=True, exist_ok=True)
+        with open(catalog_dir / "a_file.yaml", "w") as f:
+            f.write("initial content")
 
     with expected:
         check_unpushed_changes(expid, as_conf)


### PR DESCRIPTION
Closes #3041 

**Check List**

- [ ] I have read `CONTRIBUTING.md`.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [ ] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
