### PR TITLE
Flaky bug wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed wrapper deadlock when minimum limits are not reached #2469
 - Fixes 1-N grouped split dependencies #2958
 - Fixed inconsistent log paths in status txt output #3040
+- Follow-up fix for #3007: recover job times that were lost when an experiment was interrupted.
 
 **Enhancements:**
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -63,7 +63,7 @@ from autosubmit.experiment.experiment_common import (
 )
 from autosubmit.git.autosubmit_git import AutosubmitGit
 from autosubmit.git.autosubmit_git import check_unpushed_changes, clean_git
-from autosubmit.helpers.utils import check_jobs_file_exists, get_rc_path, user_yes_no_query
+from autosubmit.helpers.utils import check_jobs_file_exists, get_rc_path, recover_stale_job_data, user_yes_no_query
 from autosubmit.history.experiment_history import ExperimentHistory
 from autosubmit.history.experiment_status import ExperimentStatus
 from autosubmit.job.job import Job
@@ -2221,6 +2221,7 @@ class Autosubmit:
                 while pending_logs:
                     pending_logs = job_list.recover_logs()
                 job_list.save()
+                recover_stale_job_data(expid, as_conf, {p.name: p for p in platforms_to_test})
                 while job_list.get_active():
                     try:
                         if profile is not None:
@@ -2379,6 +2380,7 @@ class Autosubmit:
                         p.log_recovery_process.join(timeout=300)
                         if p.log_recovery_process.is_alive():
                             Log.warning(f"Log recovery process for {p.name} did not terminate within timeout.")
+                    p.clean_log_recovery_process()
 
                 Autosubmit.process_historical_data_iteration(job_list, job_changes_tracker, expid)
 
@@ -3114,6 +3116,8 @@ class Autosubmit:
 
             if save:
                 job_list.recover_last_data()
+                with suppress(Exception):
+                    recover_stale_job_data(expid, as_conf, platforms)
                 job_list.save()
             else:
                 Log.warning('Changes NOT saved to the jobList. Use -s option to save')
@@ -4382,7 +4386,8 @@ class Autosubmit:
                         raise AutosubmitCritical(
                             "There are repeated member names!")
                     rerun = as_conf.get_rerun()
-
+                    with suppress(Exception):
+                        recover_stale_job_data(expid, as_conf)
                     Log.info("\nCreating the jobs list...")
                     job_list = JobList(expid, as_conf, YAMLParserFactory(),
                                        Autosubmit._get_job_list_persistence(expid, as_conf))
@@ -5425,6 +5430,8 @@ class Autosubmit:
                 start = time.time()
                 if save and wrongExpid == 0:
                     job_list.recover_last_data(final_list)
+                    with suppress(Exception):
+                        recover_stale_job_data(expid, as_conf, platforms)
                     job_list.save()
                     end = time.time()
                     Log.info(f"JobList saved in {end - start:.2f} seconds.")

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2221,8 +2221,11 @@ class Autosubmit:
                 while pending_logs:
                     pending_logs = job_list.recover_logs()
                 job_list.save()
-                with suppress(Exception):
+                try:
                     recover_stale_job_data(expid, as_conf, {p.name: p for p in platforms_to_test})
+                except Exception as e:
+                    Log.debug(f"Error while recovering stale job data: {str(e)}")
+
                 while job_list.get_active():
                     try:
                         if profile is not None:
@@ -3117,8 +3120,10 @@ class Autosubmit:
 
             if save:
                 job_list.recover_last_data()
-                with suppress(Exception):
+                try:
                     recover_stale_job_data(expid, as_conf, platforms)
+                except Exception as e:
+                    Log.debug(f"Error while recovering stale job data: {str(e)}")
                 job_list.save()
             else:
                 Log.warning('Changes NOT saved to the jobList. Use -s option to save')
@@ -4387,8 +4392,11 @@ class Autosubmit:
                         raise AutosubmitCritical(
                             "There are repeated member names!")
                     rerun = as_conf.get_rerun()
-                    with suppress(Exception):
+                    try:
                         recover_stale_job_data(expid, as_conf)
+                    except Exception as e:
+                        Log.debug(f"Error while recovering stale job data: {str(e)}")
+
                     Log.info("\nCreating the jobs list...")
                     job_list = JobList(expid, as_conf, YAMLParserFactory(),
                                        Autosubmit._get_job_list_persistence(expid, as_conf))
@@ -5431,8 +5439,10 @@ class Autosubmit:
                 start = time.time()
                 if save and wrongExpid == 0:
                     job_list.recover_last_data(final_list)
-                    with suppress(Exception):
+                    try:
                         recover_stale_job_data(expid, as_conf, platforms)
+                    except Exception as e:
+                        Log.debug(f"Error while recovering stale job data: {str(e)}")
                     job_list.save()
                     end = time.time()
                     Log.info(f"JobList saved in {end - start:.2f} seconds.")

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2221,7 +2221,8 @@ class Autosubmit:
                 while pending_logs:
                     pending_logs = job_list.recover_logs()
                 job_list.save()
-                recover_stale_job_data(expid, as_conf, {p.name: p for p in platforms_to_test})
+                with suppress(Exception):
+                    recover_stale_job_data(expid, as_conf, {p.name: p for p in platforms_to_test})
                 while job_list.get_active():
                     try:
                         if profile is not None:

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -2385,7 +2385,12 @@ class Autosubmit:
                         if p.log_recovery_process.is_alive():
                             Log.warning(f"Log recovery process for {p.name} did not terminate within timeout.")
                     p.clean_log_recovery_process()
-
+                try:
+                    # Note: This is a safeguard, if the run is not stopped this shouldn't be needed, but maybe the log process dies for others reasons like killed by the system
+                    # so it is good to have this call to avoid leaving bad stat data if the recovery process is not working properly.
+                    recover_stale_job_data(expid, as_conf, {p.name: p for p in platforms_to_test})
+                except Exception as e:
+                    Log.debug(f"Error while recovering stale job data: {str(e)}")
                 Autosubmit.process_historical_data_iteration(job_list, job_changes_tracker, expid)
 
                 for p in platforms_to_test:

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -19,15 +19,19 @@ import os
 import pwd
 import re
 import sys
+from collections import defaultdict
 from contextlib import suppress
 from itertools import zip_longest
 from pathlib import Path
 from typing import Iterable, Optional, Union, TYPE_CHECKING
+from autosubmit.history.experiment_history import ExperimentHistory
 
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.log.log import AutosubmitCritical, Log
 from autosubmit.notifications.mail_notifier import MailNotifier
 from autosubmit.notifications.notifier import Notifier
+from autosubmit.platforms.paramiko_platform import ParamikoPlatform
+from autosubmit.platforms.platform import Platform
 
 if TYPE_CHECKING:
     from autosubmit.config.configcommon import AutosubmitConfig
@@ -329,3 +333,96 @@ def user_yes_no_query(question: str) -> bool:
             sys.stdout.write('Please respond with \'y\' or \'n\'.\n')
         except Exception as e:
             raise AutosubmitCritical("No input detected, the experiment will not be erased.", 7011, str(e))
+
+
+def build_and_connect_platform(platform_name: str, as_conf: 'AutosubmitConfig', expid: str) -> Platform:
+    """Build a minimal platform object and connect to it for STAT recovery.
+
+    :param platform_name: Name of the platform in the experiment configuration.
+    :param as_conf: Autosubmit config object.
+    :param expid: Experiment identifier.
+    :return: Connected ParamikoPlatform instance.
+    """
+    config = {
+        "LOCAL_ROOT_DIR": BasicConfig.LOCAL_ROOT_DIR,
+        "LOCAL_TMP_DIR": BasicConfig.LOCAL_TMP_DIR,
+    }
+    plat = ParamikoPlatform(expid, platform_name, config=config)
+    plat.restore_connection(as_conf)
+    return plat
+
+
+def recover_stale_job_data(
+    expid: str,
+    as_conf: 'AutosubmitConfig',
+    platforms: Optional[dict[str, Platform]] = None
+) -> None:
+    """Fetch STAT files for rows with submit>0 and (start=0 or finish=0)
+    and update job_data directly. Uses existing platform connections when
+    available (e.g. during run_experiment).
+
+    :param expid: Experiment identifier.
+    :param as_conf: Autosubmit config object.
+    :param platforms: Optional dict of name -> connected platform to reuse.
+    """
+    exp_path = Path(BasicConfig.LOCAL_ROOT_DIR) / expid
+    db_path = Path(BasicConfig.JOBDATA_DIR) / f"job_data_{expid}.db"
+    if not db_path.exists():
+        return
+
+    exp_history = ExperimentHistory(expid, force_sql_alchemy=True)
+    stale = exp_history.get_stale_rows()
+    if not stale:
+        return
+
+    Log.info(f"Found {len(stale)} stale job_data rows — connecting to platforms")
+    by_platform = defaultdict(list)
+    for row in stale:
+        by_platform[row.platform].append((row.job_name, int(row.fail_count)))
+
+    for pn, jobs in by_platform.items():
+        plat = platforms.get(pn) if platforms else None
+        if not plat or not getattr(plat, 'connected', False):
+            try:
+                plat = build_and_connect_platform(pn, as_conf, expid)
+            except Exception as e:
+                Log.warning(f"Cannot connect to {pn}: {e}")
+                continue
+
+        for jn, fail_count in jobs:
+            try:
+                start, finish = _fetch_stat_timestamps(plat, exp_path, jn, fail_count)
+                if start or finish:
+                    exp_history.update_job_data_values(jn, fail_count, start, finish)
+            except Exception as e:
+                Log.warning(f"Could not recover {jn} fail_count={fail_count}: {e}")
+
+
+def _fetch_stat_timestamps(
+    plat: Platform,
+    exp_path: Path,
+    job_name: str,
+    fail_count: int
+) -> tuple[int, int]:
+    """Download STAT file from platform and return (start, finish) timestamps.
+
+    :param plat: Connected platform instance.
+    :param exp_path: Experiment root path.
+    :param job_name: Full job name.
+    :param fail_count: Retry attempt number.
+    :return: Tuple of (start, finish) epoch integers.
+    """
+    stat = f"{job_name}_STAT_{fail_count}"
+    local = exp_path / BasicConfig.LOCAL_TMP_DIR / stat
+    if plat.check_file_exists(stat):
+        plat.get_file(stat, True)
+        if local.exists():
+            return _parse_stat_file(local)
+    return 0, 0
+
+
+def _parse_stat_file(path: Path) -> tuple[int, int]:
+    """Read a STAT file and return (start, finish) epoch integers."""
+    lines = [x.strip() for x in path.read_text().splitlines() if x.strip()]
+    values = [int(x) for x in lines[:2]]
+    return (values[0], values[1]) if len(values) >= 2 else (values[0], 0) if values else (0, 0)

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -16,6 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from pathlib import Path
 import pwd
 import re
 import sys
@@ -30,8 +31,9 @@ from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.log.log import AutosubmitCritical, Log
 from autosubmit.notifications.mail_notifier import MailNotifier
 from autosubmit.notifications.notifier import Notifier
-from autosubmit.platforms.paramiko_platform import ParamikoPlatform
 from autosubmit.platforms.platform import Platform
+from autosubmit.platforms.locplatform import LocalPlatform
+from autosubmit.platforms.paramiko_submitter import _get_platform_by_type, _get_host
 
 if TYPE_CHECKING:
     from autosubmit.config.configcommon import AutosubmitConfig
@@ -341,21 +343,55 @@ def build_and_connect_platform(platform_name: str, as_conf: 'AutosubmitConfig', 
     :param platform_name: Name of the platform in the experiment configuration.
     :param as_conf: Autosubmit config object.
     :param expid: Experiment identifier.
-    :return: Connected ParamikoPlatform instance.
+    :return: Connected platform instance.
     """
-    config = {
-        "LOCAL_ROOT_DIR": BasicConfig.LOCAL_ROOT_DIR,
-        "LOCAL_TMP_DIR": BasicConfig.LOCAL_TMP_DIR,
-    }
-    plat = ParamikoPlatform(expid, platform_name, config=config)
+    if platform_name.upper() == "LOCAL":
+        config = {
+            "LOCAL_ROOT_DIR": BasicConfig.LOCAL_ROOT_DIR,
+            "LOCAL_TMP_DIR": BasicConfig.LOCAL_TMP_DIR,
+        }
+        plat = LocalPlatform(expid, platform_name, config=config)
+    else:
+        platforms_data = as_conf.experiment_data.get('PLATFORMS', {})
+        platform_config = platforms_data.get(platform_name.upper(), {})
+        platform_type = platform_config.get('TYPE', '').lower()
+        platform_version = platform_config.get('VERSION', '')
+
+        plat = _get_platform_by_type(
+            platform_type, expid, platform_name,
+            as_conf.experiment_data, platform_version, None
+        )
+
+        if plat is None:
+            raise AutosubmitCritical(
+                f"PLATFORMS.{platform_name.upper()}.TYPE: {platform_type} is not supported", 7012
+            )
+        plat.type = platform_type
+        plat._version = platform_version
+
+        add_project_to_host = str(platform_config.get('ADD_PROJECT_TO_HOST', False)).lower() != "false"
+        section_project = platform_config.get('PROJECT', "")
+        section_host = platform_config.get('HOST', "")
+        plat.host = _get_host(section_host, add_project_to_host, section_project)
+        plat.user = platform_config.get('USER', "")
+        plat.scratch = platform_config.get('SCRATCH_DIR', "")
+        plat.temp_dir = platform_config.get('TEMP_DIR', "")
+        plat.root_dir = str(Path(plat.scratch) /
+                             (plat.project if hasattr(plat, 'project') and plat.project else section_project) /
+                             (plat.user if hasattr(plat, 'user') and plat.user else "") /
+                             expid)
+
+        with suppress(Exception):
+            plat.update_cmds()
+
     plat.restore_connection(as_conf)
     return plat
 
 
 def recover_stale_job_data(
-    expid: str,
-    as_conf: 'AutosubmitConfig',
-    platforms: Optional[dict[str, Platform]] = None
+        expid: str,
+        as_conf: 'AutosubmitConfig',
+        platforms: Optional[dict[str, Platform]] = None
 ) -> None:
     """Fetch STAT files for rows with submit>0 and (start=0 or finish=0)
     and update job_data directly. Uses existing platform connections when
@@ -399,10 +435,10 @@ def recover_stale_job_data(
 
 
 def _fetch_stat_timestamps(
-    plat: Platform,
-    exp_path: Path,
-    job_name: str,
-    fail_count: int
+        plat: Platform,
+        exp_path: Path,
+        job_name: str,
+        fail_count: int
 ) -> tuple[int, int]:
     """Download STAT file from platform and return (start, finish) timestamps.
 

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -23,7 +23,6 @@ import sys
 from collections import defaultdict
 from contextlib import suppress
 from itertools import zip_longest
-from pathlib import Path
 from typing import Iterable, Optional, Union, TYPE_CHECKING
 from autosubmit.history.experiment_history import ExperimentHistory
 

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -424,5 +424,9 @@ def _fetch_stat_timestamps(
 def _parse_stat_file(path: Path) -> tuple[int, int]:
     """Read a STAT file and return (start, finish) epoch integers."""
     lines = [x.strip() for x in path.read_text().splitlines() if x.strip()]
-    values = [int(x) for x in lines[:2]]
+    try:
+        values = [int(x) for x in lines[:2]]
+    except ValueError:
+        Log.warning(f"STAT file {path} contains non-integer data, skipping")
+        return 0, 0
     return (values[0], values[1]) if len(values) >= 2 else (values[0], 0) if values else (0, 0)

--- a/autosubmit/history/database_managers/experiment_history_db_manager.py
+++ b/autosubmit/history/database_managers/experiment_history_db_manager.py
@@ -518,6 +518,10 @@ class ExperimentHistoryDatabaseManager(Protocol):
 
     def get_last_job_data_dc_by_job_name_and_fail_counter(self, job_name: str, fail_count: int) -> JobData: ...
 
+    def get_stale_rows(self) -> list: ...
+
+    def update_job_data_values(self, job_name: str, fail_count: int, start: int, finish: int) -> int: ...
+
 
 class SqlAlchemyExperimentHistoryDbManager:
     """A SQLAlchemy experiment history database manager.
@@ -991,6 +995,44 @@ class SqlAlchemyExperimentHistoryDbManager:
             ).fetchall()
         columns = table.c.keys()
         return [tuple(zip(columns, row)) for row in rows]
+
+    def get_stale_rows(self) -> list:
+        """Return all job_data rows with submit>0 and (start=0 or finish=0).
+
+        :return: List of Row objects with job_name, fail_count, platform.
+        :rtype: list
+        """
+        job_data_table = get_table_with_schema(self.schema, JobDataTable)
+        query = select(
+            job_data_table.c.job_name,
+            job_data_table.c.fail_count,
+            job_data_table.c.platform
+        ).where(
+            job_data_table.c.submit > 0,
+            (job_data_table.c.start == 0) | (job_data_table.c.finish == 0)
+        ).distinct()
+        with self.engine.connect() as conn:
+            return conn.execute(query).fetchall()
+
+    def update_job_data_values(self, job_name: str, fail_count: int, start: int, finish: int) -> int:
+        """Update start and finish for a specific job_data row.
+
+        :param job_name: Job identifier.
+        :param fail_count: Retry attempt number.
+        :param start: Start epoch timestamp.
+        :param finish: Finish epoch timestamp.
+        :return: Number of rows updated.
+        :rtype: int
+        """
+        job_data_table = get_table_with_schema(self.schema, JobDataTable)
+        stmt = update(job_data_table).where(
+            job_data_table.c.job_name == job_name,
+            job_data_table.c.fail_count == fail_count
+        ).values(start=start, finish=finish)
+        with self.engine.connect() as conn:
+            result = conn.execute(stmt)
+            conn.commit()
+            return result.rowcount
 
 
 def create_experiment_history_db_manager(db_engine: str, **options: Any) -> ExperimentHistoryDatabaseManager:

--- a/autosubmit/history/database_managers/experiment_history_db_manager.py
+++ b/autosubmit/history/database_managers/experiment_history_db_manager.py
@@ -474,6 +474,12 @@ class ExperimentHistoryDbManager(DatabaseManager):
                 "Error while getting the pragma version. This might be a signal of a deeper problem. Review previous errors.")
         return Models.PragmaVersion(pragma_value).version
 
+    def get_stale_rows(self) -> list:
+        raise NotImplementedError("Not implemented for the non-SQLAlchemy manager.")
+
+    def update_job_data_values(self, job_name: str, fail_count: int, start: int, finish: int) -> int:
+        raise NotImplementedError("Not implemented for the non-SQLAlchemy manager.")
+
 
 class ExperimentHistoryDatabaseManager(Protocol):
     def initialize(self): ...

--- a/autosubmit/history/experiment_history.py
+++ b/autosubmit/history/experiment_history.py
@@ -485,3 +485,23 @@ class ExperimentHistory:
                 result[job.status_str] += 1
         result["TOTAL"] = len(job_list)
         return result
+
+    def get_stale_rows(self) -> list:
+        """Return all job_data rows with submit>0 and (start=0 or finish=0).
+
+        :return: List of Row objects with job_name, fail_count, platform.
+        :rtype: list
+        """
+        return self.manager.get_stale_rows()
+
+    def update_job_data_values(self, job_name: str, fail_count: int, start: int, finish: int) -> int:
+        """Update start and finish for a specific job_data row.
+
+        :param job_name: Job identifier.
+        :param fail_count: Retry attempt number.
+        :param start: Start epoch timestamp.
+        :param finish: Finish epoch timestamp.
+        :return: Number of rows updated.
+        :rtype: int
+        """
+        return self.manager.update_job_data_values(job_name, fail_count, start, finish)

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
 
 Log.get_logger("Autosubmit")
 
-
 # A wrapper for encapsulate threads , TODO: Python 3+ to be replaced by the < from concurrent.futures >
 
 

--- a/test/integration/commands/run/test_run_local_scenarios.py
+++ b/test/integration/commands/run/test_run_local_scenarios.py
@@ -24,7 +24,9 @@ import pytest
 from ruamel.yaml import YAML
 
 from autosubmit.config.basicconfig import BasicConfig
+from autosubmit.helpers.utils import build_and_connect_platform
 from autosubmit.log.log import AutosubmitCritical
+from autosubmit.platforms.locplatform import LocalPlatform
 from test.integration.commands.run.conftest import (
     _assert_db_fields,
     _assert_exit_code,
@@ -786,3 +788,15 @@ def test_run_failed_set_to_ready_on_new_run(
     exit_code = as_exp.autosubmit.run_experiment(as_exp.expid)
 
     _assert_exit_code("SUCCESS", exit_code)
+
+
+def test_build_and_connect_platform_local(autosubmit_exp, general_data):
+    """build_and_connect_platform creates a connected LocalPlatform from real config."""
+    experiment_data = general_data | {
+        "EXPERIMENT": {"MEMBERS": "fc0", "NUMCHUNKS": "1"},
+    }
+    as_exp = autosubmit_exp(experiment_data=experiment_data, include_jobs=False, create=True)
+    plat = build_and_connect_platform("LOCAL", as_exp.as_conf, as_exp.expid)
+    assert isinstance(plat, LocalPlatform)
+    assert plat.type == "local"
+    assert plat.connected

--- a/test/integration/commands/run/test_run_slurm_scenarios.py
+++ b/test/integration/commands/run/test_run_slurm_scenarios.py
@@ -27,6 +27,7 @@ import pytest
 from ruamel.yaml import YAML
 
 from autosubmit.config.basicconfig import BasicConfig
+from autosubmit.helpers.utils import build_and_connect_platform
 from autosubmit.log.log import AutosubmitCritical, Log
 from test.integration.commands.run.conftest import _check_db_fields, _assert_exit_code, _check_files_recovered, \
     _assert_db_fields, _assert_files_recovered, run_in_thread, assert_run_results, _check_wrapper_db_fields, \
@@ -1637,3 +1638,18 @@ def test_recover_stale_row(
                 assert int(r["finish"]) >= int(r["submit"])
                 if int(r["start"]) > 0:
                     assert int(r["finish"]) >= int(r["start"])
+
+
+@pytest.mark.docker
+@pytest.mark.slurm
+@pytest.mark.ssh
+def test_build_and_connect_platform_slurm(autosubmit_exp, slurm_server, general_data):
+    """build_and_connect_platform creates a connected SlurmPlatform from real config."""
+    experiment_data = general_data | {
+        "EXPERIMENT": {"MEMBERS": "fc0", "NUMCHUNKS": "1"},
+    }
+    as_exp = autosubmit_exp(experiment_data=experiment_data, include_jobs=False, create=True)
+    plat = build_and_connect_platform("TEST_SLURM", as_exp.as_conf, as_exp.expid)
+    assert type(plat).__name__ == "SlurmPlatform"
+    assert plat.type == "slurm"
+    assert plat.connected

--- a/test/integration/commands/run/test_run_slurm_scenarios.py
+++ b/test/integration/commands/run/test_run_slurm_scenarios.py
@@ -17,6 +17,7 @@
 
 """Tests that run diverse scenarios for Autosubmit run with a ``slurm`` platform
 and checks the database for expected results."""
+import sqlite3
 import time
 from pathlib import Path
 from textwrap import dedent
@@ -1581,3 +1582,58 @@ def test_inspect_monitor_run_uninterrupted_destine_like(
             run_tmpdir, as_exp.expid, preview=False, expected_wrappers=7, expected_inner_jobs=26
         )
         _assert_wrapper_db_fields(wrapper_db_check)
+
+
+@pytest.mark.docker
+@pytest.mark.slurm
+@pytest.mark.ssh
+@pytest.mark.parametrize("script, retrials, wrong_data", [
+    pytest.param("echo 'success'", 0, [], id="success_ok"),
+    pytest.param("echo 'success'", 0, [0], id="success_stale"),
+    pytest.param("d_echo 'fail'", 2, [], id="failure_ok"),
+    pytest.param("d_echo 'fail'", 2, [0], id="failure_first"),
+    pytest.param("d_echo 'fail'", 2, [1], id="failure_second"),
+    pytest.param("d_echo 'fail'", 2, [2], id="failure_third"),
+    pytest.param("d_echo 'fail'", 2, [0, 1, 2], id="failure_all"),
+])
+def test_recover_stale_row(
+    autosubmit_exp,
+    slurm_server,
+    general_data,
+    script,
+    retrials,
+    wrong_data,
+):
+    experiment_data = general_data | {
+        "EXPERIMENT": {"MEMBERS": "fc0", "NUMCHUNKS": "1"},
+        "JOBS": {"JOB1": {"SCRIPT": script, "PLATFORM": "TEST_SLURM",
+                          "RUNNING": "once", "wallclock": "00:01", "retrials": retrials}},
+    }
+    as_exp = autosubmit_exp(experiment_data=experiment_data, include_jobs=False, create=True)
+    as_exp.as_conf.set_last_as_command('run')
+    as_exp.autosubmit.run_experiment(expid=as_exp.expid)
+    db_path = Path(BasicConfig.JOBDATA_DIR) / f"job_data_{as_exp.expid}.db"
+    with sqlite3.connect(db_path) as conn:
+        for fc in wrong_data:
+            conn.execute("UPDATE job_data SET start=0 WHERE fail_count=?", (fc,))
+        conn.commit()
+    as_exp.as_conf.set_last_as_command('run')
+    as_exp.autosubmit.run_experiment(expid=as_exp.expid)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT submit, start, finish, counter, fail_count, status FROM job_data WHERE job_name LIKE '%JOB1%' ORDER BY counter"
+        ).fetchall()
+        expected = retrials + 1
+        assert len(rows) == expected, f"Expected {expected} rows, got {len(rows)}"
+        for r in rows:
+            assert r["submit"] > 0
+            assert r["status"] in ("COMPLETED", "FAILED")
+            assert int(r["counter"]) >= 0
+            assert int(r["fail_count"]) >= 0
+            if int(r["start"]) > 0:
+                assert int(r["start"]) >= int(r["submit"])
+            if int(r["finish"]) > 0:
+                assert int(r["finish"]) >= int(r["submit"])
+                if int(r["start"]) > 0:
+                    assert int(r["finish"]) >= int(r["start"])

--- a/test/unit/helpers/test_utils.py
+++ b/test/unit/helpers/test_utils.py
@@ -178,13 +178,16 @@ def test_recover_stale_job_data_builds_new_platform(tmp_path, mocker):
     mock_plat.check_file_exists.assert_called_once_with("a000_j1_STAT_0")
 
 
-@pytest.mark.parametrize("content,start,finish", [
-    pytest.param("1781078007\n1781078010\nCOMPLETED\n", 1781078007, 1781078010, id="realistic_completed"),
-    pytest.param("1781078007\n1781078010\nFAILED\n", 1781078007, 1781078010, id="realistic_failed"),
-    pytest.param("500\n", 500, 0, id="only_start_line"),
-    pytest.param("500\n\n", 500, 0, id="trailing_empty_line"),
+@pytest.mark.parametrize("content,start,finish,expected_update", [
+    pytest.param("1000\n2000\nCOMPLETED\n", 1000, 2000, True, id="typical"),
+    pytest.param("1781078007\n1781078010\nCOMPLETED\n", 1781078007, 1781078010, True, id="realistic_completed"),
+    pytest.param("1781078007\n1781078010\nFAILED\n", 1781078007, 1781078010, True, id="realistic_failed"),
+    pytest.param("500\n", 500, 0, True, id="only_start_line"),
+    pytest.param("500\n\n", 500, 0, True, id="trailing_empty_line"),
+    pytest.param("BAD_DATA\n", 0, 0, False, id="non_integer"),
+    pytest.param("1000\nBAD_DATA\n", 0, 0, False, id="partial_non_integer"),
 ])
-def test_recover_stale_job_data_with_stat(tmp_path, mocker, content, start, finish):
+def test_recover_stale_job_data_with_stat(tmp_path, mocker, content, start, finish, expected_update):
     """recover_stale_job_data fetches STAT file remotely, reads timestamps and updates job_data."""
     mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
     mocker.patch('autosubmit.helpers.utils.BasicConfig.LOCAL_ROOT_DIR', str(tmp_path))
@@ -202,5 +205,8 @@ def test_recover_stale_job_data_with_stat(tmp_path, mocker, content, start, fini
     recover_stale_job_data("a000", mocker.MagicMock(), {"TEST": mock_plat})
     mock_plat.check_file_exists.assert_called_once_with("a000_j1_STAT_0")
     mock_plat.get_file.assert_called_once_with("a000_j1_STAT_0", True)
-    ExperimentHistory.update_job_data_values.assert_called_once_with("a000_j1", 0, start, finish)
+    if expected_update:
+        ExperimentHistory.update_job_data_values.assert_called_once_with("a000_j1", 0, start, finish)
+    else:
+        ExperimentHistory.update_job_data_values.assert_not_called()
 

--- a/test/unit/helpers/test_utils.py
+++ b/test/unit/helpers/test_utils.py
@@ -20,7 +20,8 @@ from typing import Union
 
 import pytest
 
-from autosubmit.helpers.utils import get_rc_path, strtobool, user_yes_no_query
+from autosubmit.helpers.utils import get_rc_path, recover_stale_job_data, strtobool, user_yes_no_query
+from autosubmit.history.experiment_history import ExperimentHistory
 
 
 @pytest.mark.parametrize(
@@ -107,3 +108,99 @@ def test_user_yes_no_query(answer: str, expected_or_error: Union[bool, Exception
     else:
         mocker.patch('autosubmit.helpers.utils.input', return_value=answer)
         assert expected_or_error == user_yes_no_query('Sure?')
+
+
+def test_recover_stale_job_data_no_db(tmp_path, mocker):
+    """recover_stale_job_data returns early when the job_data DB file does not exist."""
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
+    recover_stale_job_data("a000", mocker.MagicMock())
+
+
+@pytest.mark.parametrize("has_stale", [False, True], ids=["no_stale", "with_stale"])
+def test_recover_stale_job_data_stale_variants(tmp_path, mocker, has_stale):
+    """recover_stale_job_data handles empty and non-empty stale results."""
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
+    Path(tmp_path / "job_data_a000.db").touch()
+    mocker.patch.object(ExperimentHistory, 'get_stale_rows', return_value=(
+        [mocker.MagicMock(platform="TEST", job_name="a000_j1", fail_count=0)] if has_stale else []
+    ))
+    as_conf = mocker.MagicMock()
+    recover_stale_job_data("a000", as_conf)
+
+
+def test_recover_stale_job_data_uses_existing_platform(tmp_path, mocker):
+    """recover_stale_job_data reuses a connected platform when available."""
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
+    Path(tmp_path / "job_data_a000.db").touch()
+    mocker.patch.object(ExperimentHistory, 'get_stale_rows', return_value=[
+        mocker.MagicMock(platform="TEST", job_name="a000_j1", fail_count=0)
+    ])
+    mock_plat = mocker.MagicMock()
+    mock_plat.connected = True
+    mock_plat.check_file_exists.return_value = False
+    recover_stale_job_data("a000", mocker.MagicMock(), {"TEST": mock_plat})
+    mock_plat.check_file_exists.assert_called_once_with("a000_j1_STAT_0")
+
+
+def test_recover_stale_job_data_builds_when_disconnected(tmp_path, mocker):
+    """recover_stale_job_data builds a new platform when existing one is disconnected."""
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
+    Path(tmp_path / "job_data_a000.db").touch()
+    mocker.patch.object(ExperimentHistory, 'get_stale_rows', return_value=[
+        mocker.MagicMock(platform="TEST", job_name="a000_j1", fail_count=0)
+    ])
+    mock_build = mocker.patch('autosubmit.helpers.utils.build_and_connect_platform')
+    mock_new_plat = mocker.MagicMock()
+    mock_new_plat.connected = True
+    mock_build.return_value = mock_new_plat
+    mock_new_plat.check_file_exists.return_value = False
+    as_conf = mocker.MagicMock()
+    recover_stale_job_data("a000", as_conf, {"TEST": mocker.MagicMock(connected=False)})
+    mock_build.assert_called_once_with("TEST", as_conf, "a000")
+    mock_new_plat.check_file_exists.assert_called_once_with("a000_j1_STAT_0")
+
+
+def test_recover_stale_job_data_builds_new_platform(tmp_path, mocker):
+    """recover_stale_job_data calls build_and_connect_platform when no platforms dict is provided."""
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
+    Path(tmp_path / "job_data_a000.db").touch()
+    mocker.patch.object(ExperimentHistory, 'get_stale_rows', return_value=[
+        mocker.MagicMock(platform="TEST", job_name="a000_j1", fail_count=0)
+    ])
+    mock_build = mocker.patch('autosubmit.helpers.utils.build_and_connect_platform')
+    mock_plat = mocker.MagicMock()
+    mock_plat.connected = True
+    mock_build.return_value = mock_plat
+    mock_plat.check_file_exists.return_value = False
+    as_conf = mocker.MagicMock()
+    recover_stale_job_data("a000", as_conf)
+    mock_build.assert_called_once_with("TEST", as_conf, "a000")
+    mock_plat.check_file_exists.assert_called_once_with("a000_j1_STAT_0")
+
+
+@pytest.mark.parametrize("content,start,finish", [
+    pytest.param("1781078007\n1781078010\nCOMPLETED\n", 1781078007, 1781078010, id="realistic_completed"),
+    pytest.param("1781078007\n1781078010\nFAILED\n", 1781078007, 1781078010, id="realistic_failed"),
+    pytest.param("500\n", 500, 0, id="only_start_line"),
+    pytest.param("500\n\n", 500, 0, id="trailing_empty_line"),
+])
+def test_recover_stale_job_data_with_stat(tmp_path, mocker, content, start, finish):
+    """recover_stale_job_data fetches STAT file remotely, reads timestamps and updates job_data."""
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.JOBDATA_DIR', str(tmp_path))
+    mocker.patch('autosubmit.helpers.utils.BasicConfig.LOCAL_ROOT_DIR', str(tmp_path))
+    Path(tmp_path / "job_data_a000.db").touch()
+    mocker.patch.object(ExperimentHistory, 'get_stale_rows', return_value=[
+        mocker.MagicMock(platform="TEST", job_name="a000_j1", fail_count=0)
+    ])
+    mock_plat = mocker.MagicMock()
+    mock_plat.connected = True
+    mock_plat.check_file_exists.return_value = True
+    mock_plat.get_file.return_value = True
+    mocker.patch.object(Path, 'exists', return_value=True)
+    mocker.patch.object(Path, 'read_text', return_value=content)
+    mocker.patch.object(ExperimentHistory, 'update_job_data_values')
+    recover_stale_job_data("a000", mocker.MagicMock(), {"TEST": mock_plat})
+    mock_plat.check_file_exists.assert_called_once_with("a000_j1_STAT_0")
+    mock_plat.get_file.assert_called_once_with("a000_j1_STAT_0", True)
+    ExperimentHistory.update_job_data_values.assert_called_once_with("a000_j1", 0, start, finish)
+

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -1476,6 +1476,7 @@ def test_write_submit_time_ignore_exp_history(total_stats_exists: bool, autosubm
 
     It ignores what happens to the experiment history object."""
     mocker.patch('autosubmit.job.job.ExperimentHistory')
+    mocker.patch('autosubmit.job.job.Job._get_submit_data_dc_from_db', return_value=None)
 
     as_conf = autosubmit_config(_EXPID, experiment_data={})
     tmp_path = Path(as_conf.basic_config.LOCAL_ROOT_DIR, _EXPID, as_conf.basic_config.LOCAL_TMP_DIR)


### PR DESCRIPTION
Fixes a flaky bug derived from #3007 


When an experiment is interrupted ... sometimes the database could end up with job entries that have a submit timestamp but no start or finish time. Because the async recovery process never completed writing them. 

On the next run, those entries were stuck because no code was looking for them.

This PR adds a function called recover_stale_job_data that runs once at the start of every experiment run,  in the create ( before generating a new run ), and during recovery commands.

It queries the database for those incomplete records, fetches the STAT files from the remote platforms (which contain the real timestamps), and writes the missing start and finish times directly into the database.

The submit time is never stale, because it is written by the main process. 

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
