### PR TITLE
Fixes hpc2020 issues on the hubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Jobs now validated individually via STAT files in check_jobs to confirm completion or failure, for both wrapped and non-wrapped jobs #3007
 - Expanded ECPlatform, paramiko platform support, and platform code cleanup #3007
 - Changed JOBS_IN_WRAPPER unknown job from critical error to warning #3006
+- Added ``ECACCESS_RETRIES`` platform config key to configure SSL retries for ecaccess platforms. Defaults to 100 #3059
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/autosubmit/platforms/ecplatform.py
+++ b/autosubmit/platforms/ecplatform.py
@@ -88,7 +88,7 @@ class EcPlatform(ParamikoPlatform):
         :param jobs_id: Comma-separated job IDs (ignored by ecaccess).
         :return: ``ecaccess-job-list`` command.
         """
-        return "ecaccess-job-list"
+        return f"ecaccess-job-list {self._ec_retry_flag}"
 
     def _check_jobid_in_queue(self, ssh_output: str, job_list_cmd: str) -> bool:
         """Bypass the retry loop for missing job IDs.
@@ -121,6 +121,17 @@ class EcPlatform(ParamikoPlatform):
         self._pathdir = "\\$HOME/LOG_" + self.expid
         self._allow_arrays = False
         self._allow_wrappers = False  # TODO
+        try:
+            self._ec_retry_count = int(
+                self.config.get("PLATFORMS", {}).get(self.name.upper(), {}).get("ECACCESS_RETRIES", 100)
+            )
+        except (ValueError, TypeError):
+            Log.warning(
+                f"Invalid ECACCESS_RETRIES value for {self.name}, "
+                f"falling back to default 100."
+            )
+            self._ec_retry_count = 100
+        self._ec_retry_flag = f"-retry {self._ec_retry_count}"
         self._allow_python_jobs = False
         self.root_dir = ""
         self.remote_log_dir = ""
@@ -144,30 +155,28 @@ class EcPlatform(ParamikoPlatform):
         self.has_scheduler = False
 
     def update_cmds(self):
-        """
-        Updates commands for platforms
-        """
+        """Updates commands for platforms"""
         self.root_dir = os.path.join(self.scratch, self.project, self.user, self.expid)
         self.remote_log_dir = os.path.join(self.root_dir, "LOG_" + self.expid)
-        self.cancel_cmd = "ecaccess-job-delete"
-        self._checkjob_cmd = "ecaccess-job-list "
-        self._checkhost_cmd = "ecaccess-certificate-list"
-        self._checkvalidcert_cmd = "ecaccess-gateway-connected"
-        self._submit_command_name = "ecaccess-job-submit"
-        self.put_cmd = "ecaccess-file-put"
-        self.get_cmd = "ecaccess-file-get"
-        self.del_cmd = "ecaccess-file-delete"
-        self.mkdir_cmd = ("ecaccess-file-mkdir " + self.host + ":" + self.scratch + "/" + self.project + "/" +
-                          self.user + "/" + self.expid + "; " + "ecaccess-file-mkdir " + self.host + ":" +
+        self.cancel_cmd = f"ecaccess-job-delete {self._ec_retry_flag}"
+        self._checkjob_cmd = f"ecaccess-job-list {self._ec_retry_flag} "
+        self._checkhost_cmd = f"ecaccess-certificate-list {self._ec_retry_flag}"
+        self._checkvalidcert_cmd = f"ecaccess-gateway-connected {self._ec_retry_flag}"
+        self._submit_command_name = f"ecaccess-job-submit {self._ec_retry_flag}"
+        self.put_cmd = f"ecaccess-file-put {self._ec_retry_flag}"
+        self.get_cmd = f"ecaccess-file-get {self._ec_retry_flag}"
+        self.del_cmd = f"ecaccess-file-delete {self._ec_retry_flag}"
+        self.mkdir_cmd = (f"ecaccess-file-mkdir {self._ec_retry_flag} " + self.host + ":" + self.scratch + "/" + self.project + "/" +
+                          self.user + "/" + self.expid + "; " + f"ecaccess-file-mkdir {self._ec_retry_flag} " + self.host + ":" +
                           self.remote_log_dir)
-        self.check_remote_permissions_cmd = "ecaccess-file-mkdir " + self.host + ":" + os.path.join(self.scratch,
-                                                                                                    self.project,
-                                                                                                    self.user,
-                                                                                                    "_permission_checker_azxbyc")
-        self.check_remote_permissions_remove_cmd = "ecaccess-file-rmdir " + self.host + ":" + os.path.join(self.scratch,
-                                                                                                           self.project,
-                                                                                                           self.user,
-                                                                                                           "_permission_checker_azxbyc")
+        self.check_remote_permissions_cmd = f"ecaccess-file-mkdir {self._ec_retry_flag} " + self.host + ":" + os.path.join(self.scratch,
+                                                                                                                          self.project,
+                                                                                                                          self.user,
+                                                                                                                          "_permission_checker_azxbyc")
+        self.check_remote_permissions_remove_cmd = f"ecaccess-file-rmdir {self._ec_retry_flag} " + self.host + ":" + os.path.join(self.scratch,
+                                                                                                                                 self.project,
+                                                                                                                                 self.user,
+                                                                                                                                 "_permission_checker_azxbyc")
 
     def get_remote_log_dir(self):
         return self.remote_log_dir
@@ -191,10 +200,10 @@ class EcPlatform(ParamikoPlatform):
         ]
         for path in levels[:-1]:
             with suppress(Exception):
-                subprocess.check_output(f"ecaccess-file-mkdir {path}", shell=True,
+                subprocess.check_output(f"ecaccess-file-mkdir {self._ec_retry_flag} {path}", shell=True,
                                         stderr=subprocess.DEVNULL)
         try:
-            subprocess.check_output(f"ecaccess-file-mkdir {levels[-1]}", shell=True,
+            subprocess.check_output(f"ecaccess-file-mkdir {self._ec_retry_flag} {levels[-1]}", shell=True,
                                     stderr=subprocess.DEVNULL)
             Log.debug(f"{self.remote_log_dir} has been created on {self.host}.")
         except subprocess.CalledProcessError:
@@ -221,7 +230,7 @@ class EcPlatform(ParamikoPlatform):
 
         # List files in the remote log directory
         try:
-            self.send_command(f"ecaccess-file-dir {self.host}:{self.remote_log_dir}")
+            self.send_command(f"ecaccess-file-dir {self._ec_retry_flag} {self.host}:{self.remote_log_dir}")
             dir_output = self.get_ssh_output()
         except Exception:
             return result
@@ -269,7 +278,7 @@ class EcPlatform(ParamikoPlatform):
             return
 
         # List files in the remote log directory
-        self.send_command(f"ecaccess-file-dir {self.host}:{self.remote_log_dir}")
+        self.send_command(f"ecaccess-file-dir {self._ec_retry_flag} {self.host}:{self.remote_log_dir}")
         dir_output = self.get_ssh_output()
 
         # ecaccess-file-dir output format: filename|size  NNNN
@@ -311,7 +320,7 @@ class EcPlatform(ParamikoPlatform):
     def _set_submit_cmd(self, ec_queue: str):
         """Set the ecaccess-job-submit command for the given queue.
 
-        The ``-retry 3w0`` flag tells ecaccess to retry the **initial SSL handshake**
+        The ``-retry`` flag tells ecaccess to retry the **initial SSL handshake**
         up to 30 times (one attempt per ~5 s) before giving up. This guards against
         transient SSL failures that occasionally occur when first connecting to the
         ECMWF gateway; without it, a single bad handshake would abort the submission
@@ -322,8 +331,7 @@ class EcPlatform(ParamikoPlatform):
 
         :param ec_queue: Queue to submit the job to.
         """
-        # even with 30 it false failed.. increasing it
-        self._submit_cmd = f"{self._submit_command_name} -retry 100 -distant -queueName {ec_queue} {self.host}:"
+        self._submit_cmd = f"{self._submit_command_name} -distant -queueName {ec_queue} {self.host}:"
 
     def _construct_final_call(self, script_name: str, pre: str, post: str, x11_options: str):
         """Gets the command to submit a job, for the current platform, with the given parameters.
@@ -425,15 +433,15 @@ class EcPlatform(ParamikoPlatform):
         with suppress(Exception):
             subprocess.check_output(self.check_remote_permissions_remove_cmd, shell=True)
         with suppress(Exception):
-            subprocess.check_output(f"ecaccess-file-mkdir {self.host}:{self.scratch}", shell=True)
+            subprocess.check_output(f"ecaccess-file-mkdir {self._ec_retry_flag} {self.host}:{self.scratch}", shell=True)
         with suppress(Exception):
-            subprocess.check_output(f"ecaccess-file-mkdir {self.host}:{self.scratch}/{self.project}", shell=True)
+            subprocess.check_output(f"ecaccess-file-mkdir {self._ec_retry_flag} {self.host}:{self.scratch}/{self.project}", shell=True)
         with suppress(Exception):
-            subprocess.check_output(f"ecaccess-file-mkdir {self.host}:{self.scratch}/{self.project}/{self.user}",
+            subprocess.check_output(f"ecaccess-file-mkdir {self._ec_retry_flag} {self.host}:{self.scratch}/{self.project}/{self.user}",
                                     shell=True)
         with suppress(Exception):
             subprocess.check_output(
-                f"ecaccess-file-mkdir {self.host}:{self.scratch}/{self.project}/{self.user}/{self.expid}", shell=True)
+                f"ecaccess-file-mkdir {self._ec_retry_flag} {self.host}:{self.scratch}/{self.project}/{self.user}/{self.expid}", shell=True)
         try:
             subprocess.check_output(self.check_remote_permissions_cmd, shell=True)
             subprocess.check_output(self.check_remote_permissions_remove_cmd, shell=True)
@@ -471,7 +479,7 @@ class EcPlatform(ParamikoPlatform):
         return True
 
     def move_file(self, src, dest, must_exist=False):
-        command = (f"ecaccess-file-move {self.host}:{os.path.join(self.remote_log_dir, src)} "
+        command = (f"ecaccess-file-move {self._ec_retry_flag} {self.host}:{os.path.join(self.remote_log_dir, src)} "
                    f"{self.host}:{os.path.join(self.remote_log_dir, dest)}")
         try:
             retries = 0
@@ -587,7 +595,7 @@ class EcPlatform(ParamikoPlatform):
                 else None
             )
 
-            cmd = f"ecaccess-file-dir {self.host}:{self.remote_log_dir}"
+            cmd = f"ecaccess-file-dir {self._ec_retry_flag} {self.host}:{self.remote_log_dir}"
             self.send_command(cmd)
             output = self.get_ssh_output()
 
@@ -634,7 +642,7 @@ class EcPlatform(ParamikoPlatform):
         if not job_names or self.expid not in str(self.remote_log_dir):
             return
         try:
-            self.send_command(f"ecaccess-file-dir {self.host}:{self.remote_log_dir}")
+            self.send_command(f"ecaccess-file-dir {self._ec_retry_flag} {self.host}:{self.remote_log_dir}")
             output = self.get_ssh_output()
             name_set = set(job_names)
             # ecaccess-file-dir output format: filename|size  NNNN
@@ -745,7 +753,7 @@ class EcPlatform(ParamikoPlatform):
         """
 
         with suppress(Exception):
-            self.send_command("ecaccess-job-list")
+            self.send_command(f"ecaccess-job-list {self._ec_retry_flag}")
             output = self.get_ssh_output()
             pre: dict[str, set[int]] = {}
             for line in output.splitlines():
@@ -779,7 +787,7 @@ class EcPlatform(ParamikoPlatform):
             Returns an empty list if any script name has no newly submitted job.
         :rtype: list[int]
         """
-        self.send_command("ecaccess-job-list")
+        self.send_command(f"ecaccess-job-list {self._ec_retry_flag}")
         output = self.get_ssh_output()
 
         name_to_ids: dict[str, set[int]] = {}

--- a/docs/source/userguide/configure/index.rst
+++ b/docs/source/userguide/configure/index.rst
@@ -376,6 +376,7 @@ To add a new platform, open the ``platforms_<EXPID>.yml`` file and add:
             ADD_PROJECT_TO_HOST: False
             MAX_PROCESSORS: <N>
             EC_QUEUE : <ec_queue> # only when type == ecaccess
+            ECACCESS_RETRIES : 100 # optional, only when type == ecaccess
             VERSION: <version>
             2FA: False
             2FA_TIMEOUT: <timeout> # default 300
@@ -413,6 +414,8 @@ This will create a platform named *new_platform*. The options specified are all 
       - Maximum number of processors allowed for a job in the platform.
     * - ``EC_QUEUE``
       - Queue for the ecaccess platform. (hpc, ecs).
+    * - ``ECACCESS_RETRIES``
+      - Number of SSL connection retries for ecaccess commands. Only applies to ecaccess platforms. Defaults to 100.
 
 .. warning:: With some platform types, Autosubmit may also need the version, forcing you to add the parameter
     VERSION. For example, ecaccess (options: pbs, loadleveler, slurm).

--- a/test/unit/platforms/test_cancel_jobs.py
+++ b/test/unit/platforms/test_cancel_jobs.py
@@ -44,7 +44,7 @@ def test_cancel_jobs_empty_list_sends_no_command(
 
 @pytest.mark.parametrize("platform_fixture,job_id,expected_command", [
     ("slurm_platform", "42", "scancel 42"),
-    ("ec_platform", "9001", "ecaccess-job-delete 9001"),
+    ("ec_platform", "9001", "ecaccess-job-delete -retry 100 9001"),
     ("local_platform", "1234", "kill -2 1234"),
     ("ps_platform", "5678", "kill -2 5678"),
     ("pbs_platform", "9876", "qdel 9876"),
@@ -111,5 +111,6 @@ def test_ec_cancel_jobs_multiple_ids_uses_semicolon_join(
 
     assert len(sent) == 1
     for job_id in job_ids:
-        assert f"ecaccess-job-delete {job_id}" in sent[0]
+        assert job_id in sent[0]
+    assert f"ecaccess-job-delete {ec_platform._ec_retry_flag}" in sent[0]
     assert " ; " in sent[0]

--- a/test/unit/platforms/test_ecplatform.py
+++ b/test/unit/platforms/test_ecplatform.py
@@ -40,6 +40,26 @@ def ec_platform(tmp_path: 'LocalPath'):
     yield EcPlatform(expid='t000', name='pytest-slurm', config=config, scheduler='slurm')
 
 
+@pytest.mark.parametrize("config_retry,expected", [
+    (None, 100),
+    (50, 50),
+    (0, 0),
+])
+def test_ec_retry_count_from_config(
+    tmp_path: 'LocalPath',
+    config_retry: int,
+    expected: int,
+) -> None:
+    """Verify _ec_retry_count reads from PLATFORMS.<NAME>.ECACCESS_RETRIES, defaults to 100."""
+    platforms = {}
+    if config_retry is not None:
+        platforms["TEST_ECMWF"] = {"ECACCESS_RETRIES": config_retry}
+    config = {"LOCAL_ROOT_DIR": str(tmp_path), "LOCAL_TMP_DIR": "tmp", "PLATFORMS": platforms}
+    platform = EcPlatform(expid='t000', name='TEST_ECMWF', config=config, scheduler='slurm')
+    assert platform._ec_retry_count == expected
+    assert platform._ec_retry_flag == f"-retry {expected}"
+
+
 def test_file_read_size_and_send(ec_platform: EcPlatform, mocker):
     path = ec_platform.config.get("LOCAL_ROOT_DIR")
     assert isinstance(path, str)
@@ -155,7 +175,7 @@ def test_get_submitted_jobs_by_name_queries_ecaccess_job_list(
 
     ec_platform.get_submitted_jobs_by_name(["a000_INI.cmd", "a000_SIM.cmd"])
 
-    assert sent_commands == ["ecaccess-job-list"]
+    assert sent_commands == [f"ecaccess-job-list {ec_platform._ec_retry_flag}"]
 
 
 def test_get_submitted_jobs_by_name_filters_pre_existing_job_ids(
@@ -624,6 +644,79 @@ def test_pre_submission_snapshot_called_with_empty_list(
     assert snapshot_calls == [[]]
 
 
+@pytest.mark.parametrize("cmd_attr,command_name", [
+    ("cancel_cmd", "ecaccess-job-delete"),
+    ("_checkjob_cmd", "ecaccess-job-list"),
+    ("_checkhost_cmd", "ecaccess-certificate-list"),
+    ("_checkvalidcert_cmd", "ecaccess-gateway-connected"),
+    ("_submit_command_name", "ecaccess-job-submit"),
+    ("put_cmd", "ecaccess-file-put"),
+    ("get_cmd", "ecaccess-file-get"),
+    ("del_cmd", "ecaccess-file-delete"),
+], ids=[
+    "cancel_cmd",
+    "checkjob_cmd",
+    "checkhost_cmd",
+    "checkvalidcert_cmd",
+    "submit_command_name",
+    "put_cmd",
+    "get_cmd",
+    "del_cmd",
+])
+def test_update_cmds_includes_retry_in_command(
+    ec_platform: EcPlatform,
+    cmd_attr: str,
+    command_name: str,
+) -> None:
+    """Verify each command variable from update_cmds contains the retry flag."""
+    value = getattr(ec_platform, cmd_attr)
+    assert ec_platform._ec_retry_flag in value, (
+        f"{cmd_attr}={value!r} missing {ec_platform._ec_retry_flag!r}"
+    )
+    assert value.startswith(command_name), (
+        f"{cmd_attr}={value!r} should start with {command_name!r}"
+    )
+
+
+@pytest.mark.parametrize("cmd_attr", [
+    "mkdir_cmd",
+    "check_remote_permissions_cmd",
+    "check_remote_permissions_remove_cmd",
+])
+def test_update_cmds_includes_retry_in_path_commands(
+    ec_platform: EcPlatform,
+    cmd_attr: str,
+) -> None:
+    """Verify path-bearing command variables contain the retry flag in every ecaccess call."""
+    value = getattr(ec_platform, cmd_attr)
+    # Count how many separate ecaccess commands are in this string
+    ecaccess_calls = [part for part in value.split(";") if "ecaccess-" in part]
+    for call in ecaccess_calls:
+        assert ec_platform._ec_retry_flag in call, (
+            f"{cmd_attr} call {call!r} missing {ec_platform._ec_retry_flag!r}"
+        )
+
+
+@pytest.mark.parametrize("retry_count,expected_flag", [
+    (30, "-retry 30"),
+    (100, "-retry 100"),
+])
+def test_set_submit_cmd_uses_configured_retry(
+    tmp_path: 'LocalPath',
+    retry_count: int,
+    expected_flag: str,
+) -> None:
+    """Verify _set_submit_cmd includes the configured retry flag via _submit_command_name."""
+    config = {
+        "LOCAL_ROOT_DIR": str(tmp_path), "LOCAL_TMP_DIR": "tmp",
+        "PLATFORMS": {"TEST_ECMWF": {"ECACCESS_RETRIES": retry_count}},
+    }
+    platform = EcPlatform(expid='t000', name='TEST_ECMWF', config=config, scheduler='slurm')
+    platform._set_submit_cmd("hpc")
+    assert expected_flag in platform._submit_cmd
+    assert "-queueName hpc" in platform._submit_cmd
+
+
 # -- Batch checking (check_all_jobs) tests
 
 _JOB_LIST_TABLE = (
@@ -639,7 +732,7 @@ def test_get_check_all_jobs_cmd_returns_ecaccess_job_list(
     ec_platform: EcPlatform,
 ) -> None:
     """Verify get_check_all_jobs_cmd returns the batch ecaccess list command."""
-    assert ec_platform.get_check_all_jobs_cmd("10001,10002") == "ecaccess-job-list"
+    assert ec_platform.get_check_all_jobs_cmd("10001,10002") == f"ecaccess-job-list {ec_platform._ec_retry_flag}"
 
 
 def test_parse_all_jobs_output_finds_status_by_job_id(

--- a/test/unit/platforms/test_ecplatform.py
+++ b/test/unit/platforms/test_ecplatform.py
@@ -60,6 +60,24 @@ def test_ec_retry_count_from_config(
     assert platform._ec_retry_flag == f"-retry {expected}"
 
 
+@pytest.mark.parametrize("invalid_value", [
+    "abc",
+    "12.5",
+    [1, 2, 3],
+    {"key": "val"},
+])
+def test_ec_retry_count_fallback(
+    tmp_path: 'LocalPath',
+    invalid_value: object,
+) -> None:
+    """Verify _ec_retry_count falls back to 100 when ECACCESS_RETRIES is invalid."""
+    platforms = {"TEST_ECMWF": {"ECACCESS_RETRIES": invalid_value}}
+    config = {"LOCAL_ROOT_DIR": str(tmp_path), "LOCAL_TMP_DIR": "tmp", "PLATFORMS": platforms}
+    platform = EcPlatform(expid='t000', name='TEST_ECMWF', config=config, scheduler='slurm')
+    assert platform._ec_retry_count == 100
+    assert platform._ec_retry_flag == "-retry 100"
+
+
 def test_file_read_size_and_send(ec_platform: EcPlatform, mocker):
     path = ec_platform.config.get("LOCAL_ROOT_DIR")
     assert isinstance(path, str)


### PR DESCRIPTION
Objective: Apply SSL handshake retry to all ECACCESS commands previously; only `ecaccess-job-submit` passed  `-retry` for SSL handshake retries. 

Now every ECACCESS command gets the retry flag, sourced from the new `ECACCESS_RETRIES` platform config key (default 100, matching the old hardcoded value on submit).

docs:
https://confluence.ecmwf.int/display/ECAC/ecaccess-file-get

Note:
* 0 is a valid number for the --retry
* All commands accept this flag ( transport layer flag)


**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
