### PR TITLE
4.1.17 - infinite loop fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed inconsistent log paths in status txt output #3040
 - Follow-up fix for #3007: recover job times that were lost when an experiment was interrupted.
 - Fixed `num_max_spits` unit conversion to months when `split_unit` is "month" #2944
+- Fixed infinite loop when STAT file stays on RUNNING, now falls back to scheduler status after IO_SAFE_WAIT #3059
 
 **Enhancements:**
 

--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -32,7 +32,7 @@ from io import BufferedReader
 from pathlib import Path
 from threading import Thread
 from time import sleep
-from typing import Optional, Union, TYPE_CHECKING, Any
+from typing import Optional, Tuple, Union, TYPE_CHECKING, Any
 
 import Xlib.support.connect as xlib_connect
 import paramiko
@@ -906,6 +906,45 @@ class ParamikoPlatform(Platform):
         else:
             return Status.QUEUING
 
+    @staticmethod
+    def _resolve_stat_status(
+        job_name: str,
+        stat_status: Status,
+        scheduler_job_status: Status,
+        finished_time: Optional[float],
+        io_safe_wait: int,
+        now: float,
+    ) -> Tuple[Status, Optional[float]]:
+        """Resolve final job status from STAT file and scheduler information.
+
+        :param job_name: Job name for logging.
+        :param stat_status: Status from STAT file lookup.
+        :param scheduler_job_status: Status from scheduler.
+        :param finished_time: Current finished_time of the job (timer start).
+        :param io_safe_wait: IO_SAFE_WAIT threshold in seconds.
+        :param now: Current time (epoch seconds) for elapsed calculation.
+        :return: Tuple of (new_status, new_finished_time).
+        """
+        if stat_status in (Status.COMPLETED, Status.FAILED):
+            return stat_status, None
+
+        if scheduler_job_status in (Status.COMPLETED, Status.FAILED):
+            if finished_time is None:
+                finished_time = now
+            elapsed = now - finished_time
+            if elapsed >= io_safe_wait:
+                Log.warning(
+                    f"Couldn't fetch status from STAT file for job {job_name} after waiting {elapsed} seconds since job finished. "
+                    f"Falling back to scheduler status {scheduler_job_status} for final job status."
+                )
+                return scheduler_job_status, None
+            return Status.RUNNING, finished_time
+
+        if stat_status == Status.RUNNING:
+            return Status.RUNNING, None
+
+        return scheduler_job_status, None
+
     def confirm_done_jobs_via_stat(self, job_list: list) -> dict[str, "Status"]:
         """Checks the STAT files for the given jobs to confirm their completion status.
         This method retrieves the last line of each STAT file corresponding to the jobs in the job_list and resolves their status using the _resolve_status method.
@@ -1048,27 +1087,12 @@ class ParamikoPlatform(Platform):
                         scheduler_job_status = Status.UNKNOWN
 
                     stat_status = stat_statuses.get(job.name, Status.UNKNOWN)
-
-                    if stat_status in [Status.COMPLETED, Status.FAILED, Status.RUNNING]:
-                        job_status = stat_status
-                    # Safeguard 1 to avoid infinite loops when there is no STAT file for unknown reasons and the scheduler says that the job is finished.
-                    elif scheduler_job_status in [Status.COMPLETED, Status.FAILED]:
-                        if not job.finished_time:
-                            job.finished_time = time.time()
-                        elapsed = time.time() - job.finished_time
-                        if elapsed >= self.IO_SAFE_WAIT:
-                            job.finished_time = None
-                            job_status = scheduler_job_status
-                            Log.warning(
-                                f"Couldn't fetch status from STAT file for job {job.name} after waiting {elapsed} seconds since job finished. "
-                                f"Falling back to scheduler status {scheduler_job_status} for final job status.")
-                        else:
-                            # safe_wait for IO operations (flushing logs, STAT file creation...)
-                            job_status = Status.RUNNING
-                    else:
-                        job_status = scheduler_job_status
-
-                    job.new_status = job_status
+                    new_status, new_finished_time = self._resolve_stat_status(
+                        job.name, stat_status, scheduler_job_status,
+                        job.finished_time, self.IO_SAFE_WAIT, time.time(),
+                    )
+                    job.finished_time = new_finished_time
+                    job.new_status = new_status
 
             # check and set if there is any_job without timestamp
             self.set_start_time_from_remote_stat_file([job for job in job_list if

--- a/test/unit/platforms/test_paramiko_platform.py
+++ b/test/unit/platforms/test_paramiko_platform.py
@@ -1033,3 +1033,74 @@ def test_change_status_handles_send_command_failure_gracefully(
     for job in jobs:
         assert job.status == Status.FAILED
         assert job.name in changes
+
+
+@pytest.mark.parametrize(
+    "stat_status, scheduler_status, finished_time, io_safe_wait, now, expected_status, expected_finished_time, expect_warning",
+    [
+        (Status.COMPLETED, Status.RUNNING, 100.0, 5, 200.0, Status.COMPLETED, None, False),
+        (Status.FAILED, Status.RUNNING, 100.0, 5, 200.0, Status.FAILED, None, False),
+        (Status.RUNNING, Status.COMPLETED, None, 5, 100.0, Status.RUNNING, 100.0, False),
+        (Status.RUNNING, Status.COMPLETED, 100.0, 5, 102.0, Status.RUNNING, 100.0, False),
+        (Status.RUNNING, Status.COMPLETED, 100.0, 5, 200.0, Status.COMPLETED, None, True),
+        (Status.RUNNING, Status.FAILED, None, 5, 100.0, Status.RUNNING, 100.0, False),
+        (Status.RUNNING, Status.FAILED, 100.0, 5, 102.0, Status.RUNNING, 100.0, False),
+        (Status.RUNNING, Status.FAILED, 100.0, 5, 200.0, Status.FAILED, None, True),
+        (Status.RUNNING, Status.RUNNING, 999.0, 5, 200.0, Status.RUNNING, None, False),
+        (Status.RUNNING, Status.QUEUING, 999.0, 5, 200.0, Status.RUNNING, None, False),
+        (Status.UNKNOWN, Status.COMPLETED, None, 5, 100.0, Status.RUNNING, 100.0, False),
+        (Status.UNKNOWN, Status.COMPLETED, 100.0, 5, 102.0, Status.RUNNING, 100.0, False),
+        (Status.UNKNOWN, Status.COMPLETED, 100.0, 5, 200.0, Status.COMPLETED, None, True),
+        (Status.UNKNOWN, Status.FAILED, None, 5, 100.0, Status.RUNNING, 100.0, False),
+        (Status.UNKNOWN, Status.FAILED, 100.0, 5, 102.0, Status.RUNNING, 100.0, False),
+        (Status.UNKNOWN, Status.FAILED, 100.0, 5, 200.0, Status.FAILED, None, True),
+        (Status.UNKNOWN, Status.RUNNING, 999.0, 5, 200.0, Status.RUNNING, None, False),
+        (Status.QUEUING, Status.COMPLETED, None, 5, 100.0, Status.RUNNING, 100.0, False),
+        (Status.QUEUING, Status.COMPLETED, 100.0, 5, 102.0, Status.RUNNING, 100.0, False),
+        (Status.QUEUING, Status.COMPLETED, 100.0, 5, 200.0, Status.COMPLETED, None, True),
+        (Status.QUEUING, Status.FAILED, None, 5, 100.0, Status.RUNNING, 100.0, False),
+        (Status.QUEUING, Status.FAILED, 100.0, 5, 102.0, Status.RUNNING, 100.0, False),
+        (Status.QUEUING, Status.FAILED, 100.0, 5, 200.0, Status.FAILED, None, True),
+        (Status.QUEUING, Status.RUNNING, 999.0, 5, 200.0, Status.RUNNING, None, False),
+    ],
+    ids=[
+        "stat_COMPLETED_expect_COMPLETED",
+        "stat_FAILED_expect_FAILED",
+        "stuck_RUNNING_sched_COMPLETED_timer_expect_RUNNING",
+        "stuck_RUNNING_sched_COMPLETED_wait_expect_RUNNING",
+        "stuck_RUNNING_sched_COMPLETED_fallback_expect_COMPLETED",
+        "stuck_RUNNING_sched_FAILED_timer_expect_RUNNING",
+        "stuck_RUNNING_sched_FAILED_wait_expect_RUNNING",
+        "stuck_RUNNING_sched_FAILED_fallback_expect_FAILED",
+        "stat_RUNNING_sched_RUNNING_expect_RUNNING",
+        "stat_RUNNING_sched_QUEUING_expect_RUNNING",
+        "no_STAT_sched_COMPLETED_timer_expect_RUNNING",
+        "no_STAT_sched_COMPLETED_wait_expect_RUNNING",
+        "no_STAT_sched_COMPLETED_fallback_expect_COMPLETED",
+        "no_STAT_sched_FAILED_timer_expect_RUNNING",
+        "no_STAT_sched_FAILED_wait_expect_RUNNING",
+        "no_STAT_sched_FAILED_fallback_expect_FAILED",
+        "no_STAT_sched_RUNNING_expect_RUNNING",
+        "stat_QUEUING_sched_COMPLETED_timer_expect_RUNNING",
+        "stat_QUEUING_sched_COMPLETED_wait_expect_RUNNING",
+        "stat_QUEUING_sched_COMPLETED_fallback_expect_COMPLETED",
+        "stat_QUEUING_sched_FAILED_timer_expect_RUNNING",
+        "stat_QUEUING_sched_FAILED_wait_expect_RUNNING",
+        "stat_QUEUING_sched_FAILED_fallback_expect_FAILED",
+        "stat_QUEUING_sched_RUNNING_expect_RUNNING",
+    ],
+)
+def test_resolve_stat_status(
+    stat_status, scheduler_status, finished_time, io_safe_wait, now,
+    expected_status, expected_finished_time, expect_warning, mocker,
+):
+    mock_log = mocker.patch("autosubmit.platforms.paramiko_platform.Log")
+    result_status, result_finished_time = ParamikoPlatform._resolve_stat_status(
+        "test_job", stat_status, scheduler_status, finished_time, io_safe_wait, now,
+    )
+    assert result_status == expected_status
+    assert result_finished_time == expected_finished_time
+    if expect_warning:
+        mock_log.warning.assert_called_once()
+    else:
+        mock_log.warning.assert_not_called()


### PR DESCRIPTION
@agarci3 reported seeing jobs get permanently stuck in RUNNING status. 

The root cause is that when a job finishes but its STAT file still shows RUNNING (typically because the job's trap failed and did not write the final COMPLETED/FAILED line, which is another separated issue cc: @kinow, @agarci3 will open an issue for that), the old code trusted the STAT file unconditionally. It returned RUNNING no matter what the scheduler said. The IO_SAFE_WAIT fallback that should catch this never triggered because RUNNING was grouped together with COMPLETED and FAILED in the same early return branch.

I've extracted the logic outside the check_job function to add an unit test


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
