### PR TITLE
Exposing LAST DATE as a variable in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 **Enhancements:**
 
+- Added ``CHUNK_END_DATE_LAST`` and ``LDATE`` template variables exposing the experiment's terminal dates to date-aware jobs #2430
 - Autosubmit describe now works on archived experiments, falling back to the last details snapshot stored in the database when the experiment files are not available #2717
 - Moved Autosubmit directory creation from `autosubmit configure` to `autosubmit install` #2640
 - Replaced redundant `list(dict.keys())` and `.keys()` patterns with direct dictionary iteration and membership checks #2477

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -2105,11 +2105,17 @@ class Job(object):
                 self.date, chunk, chunk_length, chunk_unit, cal)
             chunk_end = chunk_end_date(
                 chunk_start, chunk_length, chunk_unit, cal)
+            last_chunk_start = chunk_start_date(
+                self.date, total_chunk, chunk_length, chunk_unit, cal)
+            last_chunk_end = chunk_end_date(
+                last_chunk_start, chunk_length, chunk_unit, cal)
 
             if chunk_unit == 'hour':
                 chunk_end_1 = chunk_end - datetime.timedelta(hours=1)
+                last_day_chunk = last_chunk_end - datetime.timedelta(hours=1)
             else:
                 chunk_end_1 = previous_day(chunk_end, cal)
+                last_day_chunk = previous_day(last_chunk_end, cal)
 
             parameters['DAY_BEFORE'] = date2str(
                 previous_day(self.date, cal), self.date_format)
@@ -2151,15 +2157,8 @@ class Job(object):
                 parameters['CHUNK_LAST'] = 'TRUE'
             else:
                 parameters['CHUNK_LAST'] = 'FALSE'
-            last_start = chunk_start_date(self.date, total_chunk, chunk_length, chunk_unit, cal)
-            last_end = chunk_end_date(last_start, chunk_length, chunk_unit, cal)
-            if chunk_unit == 'hour':
-                last_end_1 = last_end - datetime.timedelta(hours=1)
-            else:
-                last_end_1 = previous_day(last_end, cal)
-
-            parameters['CHUNK_END_DATE_LAST'] = date2str(last_end, self.date_format)
-            parameters['LDATE'] = date2str(last_end_1, self.date_format)
+            parameters['CHUNK_END_DATE_LAST'] = date2str(last_chunk_end, self.date_format)
+            parameters['LDATE'] = date2str(last_day_chunk, self.date_format)
         return parameters
 
     def update_job_parameters(self, as_conf: AutosubmitConfig, parameters: dict, set_attributes: bool) -> dict:

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -2145,6 +2145,8 @@ class Job(object):
             parameters['CHUNK_END_MONTH'] = str(chunk_end.month).zfill(2)
             parameters['CHUNK_END_DAY'] = str(chunk_end.day).zfill(2)
             parameters['CHUNK_END_HOUR'] = str(chunk_end.hour).zfill(2)
+            parameters['CHUNK_END_DATE_LAST'] = date2str(last_chunk_end, self.date_format)
+            parameters['LDATE'] = date2str(last_day_chunk, self.date_format)
 
             parameters['PREV'] = str(subs_dates(self.date, chunk_start, cal))
 
@@ -2157,8 +2159,6 @@ class Job(object):
                 parameters['CHUNK_LAST'] = 'TRUE'
             else:
                 parameters['CHUNK_LAST'] = 'FALSE'
-            parameters['CHUNK_END_DATE_LAST'] = date2str(last_chunk_end, self.date_format)
-            parameters['LDATE'] = date2str(last_day_chunk, self.date_format)
         return parameters
 
     def update_job_parameters(self, as_conf: AutosubmitConfig, parameters: dict, set_attributes: bool) -> dict:

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -105,6 +105,8 @@ EXCLUDED = ["_platform", "_children", "_parents", "submitter"]
             'prev': 'Days since start date at the chunk\'s start.',
             'chunk_first': 'True if the current chunk is the first, false otherwise.',
             'chunk_last': 'True if the current chunk is the last, false otherwise.',
+            'chunk_end_date_last': 'End date of the last chunk, i.e. the experiment end boundary. Available to any date-aware job (notably RUNNING: date jobs).',
+            'ldate': 'Last date of the experiment (the run\'s final day, parallel to SDATE).',
             'run_days': 'Chunk length in days.',
             'notify_on': 'Determine the job statuses you want to be notified.'
         },
@@ -2149,6 +2151,15 @@ class Job(object):
                 parameters['CHUNK_LAST'] = 'TRUE'
             else:
                 parameters['CHUNK_LAST'] = 'FALSE'
+            last_start = chunk_start_date(self.date, total_chunk, chunk_length, chunk_unit, cal)
+            last_end = chunk_end_date(last_start, chunk_length, chunk_unit, cal)
+            if chunk_unit == 'hour':
+                last_end_1 = last_end - datetime.timedelta(hours=1)
+            else:
+                last_end_1 = previous_day(last_end, cal)
+
+            parameters['CHUNK_END_DATE_LAST'] = date2str(last_end, self.date_format)
+            parameters['LDATE'] = date2str(last_end_1, self.date_format)
         return parameters
 
     def update_job_parameters(self, as_conf: AutosubmitConfig, parameters: dict, set_attributes: bool) -> dict:

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -2935,3 +2935,44 @@ def test_check_wrapper_wallclock_and_handle(mocker, inner_over, wrapper_over, in
     else:
         assert result is False
         wrapper.platform.cancel_jobs.assert_not_called()
+
+
+def test_calendar_chunk_exposes_experiment_terminal_dates():
+    """Issue #2430: date-aware jobs see CHUNK_END_DATE_LAST and LDATE
+    pointing at the experiment's end, independent of their own chunk."""
+    job = Job('A', '1', Status.WAITING, 0)
+    job.date = datetime(2000, 1, 1)
+    job.chunk = None
+    job.date_format = ''
+    parameters = {
+        'EXPERIMENT.NUMCHUNKS': 2,
+        'EXPERIMENT.CHUNKSIZE': 4,
+        'EXPERIMENT.CHUNKSIZEUNIT': 'month',
+        'EXPERIMENT.CALENDAR': 'standard',
+    }
+
+    result = job.calendar_chunk(parameters)
+
+    assert result['CHUNK_END_DATE'] == '20000501'
+    assert result['CHUNK_SECOND_TO_LAST_DATE'] == '20000430'
+    assert result['CHUNK_END_DATE_LAST'] == '20000901'
+    assert result['LDATE'] == '20000831'
+
+
+def test_calendar_chunk_last_chunk_consistency():
+    """On the last chunk the new variables equal the per-chunk ones."""
+    job = Job('A', '1', Status.WAITING, 0)
+    job.date = datetime(2000, 1, 1)
+    job.chunk = 2
+    job.date_format = ''
+    parameters = {
+        'EXPERIMENT.NUMCHUNKS': 2,
+        'EXPERIMENT.CHUNKSIZE': 4,
+        'EXPERIMENT.CHUNKSIZEUNIT': 'month',
+        'EXPERIMENT.CALENDAR': 'standard',
+    }
+
+    result = job.calendar_chunk(parameters)
+
+    assert result['CHUNK_END_DATE'] == result['CHUNK_END_DATE_LAST'] == '20000901'
+    assert result['CHUNK_SECOND_TO_LAST_DATE'] == result['LDATE'] == '20000831'

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -2937,29 +2937,41 @@ def test_check_wrapper_wallclock_and_handle(mocker, inner_over, wrapper_over, in
         wrapper.platform.cancel_jobs.assert_not_called()
 
 
-def test_calendar_chunk_exposes_experiment_terminal_dates():
+@pytest.mark.parametrize("chunk_unit,chunk_size,date_format,expected_end,expected_ldate", [
+    ("month", 4,  "",  "20000901",     "20000831"),
+    ("day",   30, "",  "20000301",     "20000229"),
+    ("year",  1,  "",  "20020101",     "20011231"),
+    ("hour",  12, "H", "2000010200",   "2000010123"),
+])
+def test_calendar_chunk_exposes_experiment_terminal_dates(
+    chunk_unit, chunk_size, date_format, expected_end, expected_ldate
+):
     """Issue #2430: date-aware jobs see CHUNK_END_DATE_LAST and LDATE
     pointing at the experiment's end, independent of their own chunk."""
     job = Job('A', '1', Status.WAITING, 0)
     job.date = datetime(2000, 1, 1)
     job.chunk = None
-    job.date_format = ''
+    job.date_format = date_format
     parameters = {
         'EXPERIMENT.NUMCHUNKS': 2,
-        'EXPERIMENT.CHUNKSIZE': 4,
-        'EXPERIMENT.CHUNKSIZEUNIT': 'month',
+        'EXPERIMENT.CHUNKSIZE': chunk_size,
+        'EXPERIMENT.CHUNKSIZEUNIT': chunk_unit,
         'EXPERIMENT.CALENDAR': 'standard',
     }
 
     result = job.calendar_chunk(parameters)
 
-    assert result['CHUNK_END_DATE'] == '20000501'
-    assert result['CHUNK_SECOND_TO_LAST_DATE'] == '20000430'
-    assert result['CHUNK_END_DATE_LAST'] == '20000901'
-    assert result['LDATE'] == '20000831'
+    assert result['CHUNK_END_DATE_LAST'] == expected_end
+    assert result['LDATE'] == expected_ldate
 
 
-def test_calendar_chunk_last_chunk_consistency():
+@pytest.mark.parametrize("chunk_unit,chunk_size", [
+    ("month", 4),
+    ("day",   30),
+    ("year",  1),
+    ("hour",  12),
+])
+def test_calendar_chunk_last_chunk_consistency(chunk_unit, chunk_size):
     """On the last chunk the new variables equal the per-chunk ones."""
     job = Job('A', '1', Status.WAITING, 0)
     job.date = datetime(2000, 1, 1)
@@ -2967,12 +2979,12 @@ def test_calendar_chunk_last_chunk_consistency():
     job.date_format = ''
     parameters = {
         'EXPERIMENT.NUMCHUNKS': 2,
-        'EXPERIMENT.CHUNKSIZE': 4,
-        'EXPERIMENT.CHUNKSIZEUNIT': 'month',
+        'EXPERIMENT.CHUNKSIZE': chunk_size,
+        'EXPERIMENT.CHUNKSIZEUNIT': chunk_unit,
         'EXPERIMENT.CALENDAR': 'standard',
     }
 
     result = job.calendar_chunk(parameters)
 
-    assert result['CHUNK_END_DATE'] == result['CHUNK_END_DATE_LAST'] == '20000901'
-    assert result['CHUNK_SECOND_TO_LAST_DATE'] == result['LDATE'] == '20000831'
+    assert result['CHUNK_END_DATE'] == result['CHUNK_END_DATE_LAST']
+    assert result['CHUNK_SECOND_TO_LAST_DATE'] == result['LDATE']


### PR DESCRIPTION
Closes #2430 

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
