### PR TITLE
Postgres connection DB pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ This release also includes several bug fixes and enhancements to improve the ove
 
 - **Database Method Enhancements**: Support for both PostgreSQL and SQLite with optimized save/load mechanisms. Improved wrapper data storage and load.
 - **Testing Efforts**: Tests have been added for every rework to enhance reliability, with a particular effort on integration tests.
+
+- Enforce connection pool usage when using PostgreSQL as database backend #2973
+
+
+### 4.1.18: Unreleased
+
+**Bug fixes:**
+
+- Fix timeout guard is silently disabled for login/local jobs #3081
+
+**Enhancements:**
+
 - Auto-detect git default branch when `-b` flag not specified #3101
 - Removed `files` arguments from autosubmit sub-commands, and moved code to upgrade scripts out of `autosubmit.py` #2711
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,7 @@ This release also includes several bug fixes and enhancements to improve the ove
 
 - **Database Method Enhancements**: Support for both PostgreSQL and SQLite with optimized save/load mechanisms. Improved wrapper data storage and load.
 - **Testing Efforts**: Tests have been added for every rework to enhance reliability, with a particular effort on integration tests.
-
 - Enforce connection pool usage when using PostgreSQL as database backend #2973
-
-
-### 4.1.18: Unreleased
-
-**Bug fixes:**
-
-- Fix timeout guard is silently disabled for login/local jobs #3081
-
-**Enhancements:**
-
 - Auto-detect git default branch when `-b` flag not specified #3101
 - Removed `files` arguments from autosubmit sub-commands, and moved code to upgrade scripts out of `autosubmit.py` #2711
 

--- a/autosubmit/database/db_common.py
+++ b/autosubmit/database/db_common.py
@@ -697,7 +697,7 @@ def _get_sqlalchemy_conn() -> Connection:
     can use a context-manager and keep the previous behaviour
     intact.
     """
-    return session.create_engine(BasicConfig.DATABASE_CONN_URL).connect()
+    return session.get_engine(db_path=Path(BasicConfig.DB_PATH)).connect()
 
 
 def _create_db_pg() -> bool:
@@ -902,28 +902,6 @@ def _get_experiment_id_sqlalchemy(name: str) -> int:
         raise AutosubmitCritical(f'The experiment "{name}" does not exist', 7005)
 
     return int(row[0])
-
-
-def get_connection_url(db_path: Union['Path', str] | None = None) -> str:
-    """Return a SQLAlchemy connection URL."""
-    if isinstance(db_path, str):
-        Log.warning("The 'db_path' parameter should be a Path object, not a string. Converting it to Path.")
-        db_path = Path(db_path)
-
-    if BasicConfig.DATABASE_BACKEND == "postgres":
-        return BasicConfig.DATABASE_CONN_URL
-
-    if not db_path:
-        raise ValueError('For SQLite databases you MUST provide a database file.')
-
-    if not db_path.exists():
-        if not db_path.parent.exists():
-            db_path.parent.mkdir(parents=True, exist_ok=True)
-            db_path.parent.chmod(0o770)
-        db_path.touch()
-        db_path.chmod(0o770)
-
-    return f'sqlite:///{str(db_path.resolve())}'
 
 
 def check_db_path(db_path: Path | None, must_exists: bool = True) -> bool:

--- a/autosubmit/database/db_manager.py
+++ b/autosubmit/database/db_manager.py
@@ -28,7 +28,6 @@ from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database import session
 from autosubmit.database.tables import TableRegistry, GENERALTABLES, Table
 
-
 class DbManager:
     """A database manager using SQLAlchemy.
 
@@ -36,24 +35,17 @@ class DbManager:
     as Postgres, Mongo, MySQL, etc.
     """
 
-    def __init__(self, connection_url: str, schema: str | None = None, historical: bool | None = False) -> None:
+    def __init__(self, db_path: str, schema: str | None = None, historical: bool | None = False) -> None:
         self.engine = None
         self.engine_historical = None
         if BasicConfig.DATABASE_BACKEND == "sqlite":
             if historical:
-                self.engine_historical = session.create_engine(connection_url)
-                if self.engine_historical.url.database and not Path(self.engine_historical.url.database).exists():
-                    Path(self.engine_historical.url.database).touch()
-                    Path(self.engine_historical.url.database).chmod(0o775)
+                self.engine_historical = session.get_engine(db_path)
             else:
-                self.engine = session.create_engine(connection_url)
-                # make file
-                if self.engine.url.database and not Path(self.engine.url.database).exists():
-                    Path(self.engine.url.database).touch()
-                    Path(self.engine.url.database).chmod(0o775)
+                self.engine = session.get_engine(db_path)
         else:
             # Postgres is unified
-            self.engine: Engine = session.create_engine(connection_url)
+            self.engine: Engine = session.get_engine(db_path)
             self.engine_historical = self.engine
 
         self.schema = schema if BasicConfig.DATABASE_BACKEND != "sqlite" else None

--- a/autosubmit/database/db_manager_historical.py
+++ b/autosubmit/database/db_manager_historical.py
@@ -19,7 +19,6 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from autosubmit.config.basicconfig import BasicConfig
-from autosubmit.database.db_common import get_connection_url
 from autosubmit.database.db_manager import DbManager
 
 if TYPE_CHECKING:
@@ -45,7 +44,7 @@ class HistoricalDbManager(DbManager):
         else:
             historical_persistence_full_path = None
 
-        super().__init__(get_connection_url(historical_persistence_full_path), schema, True)
+        super().__init__(historical_persistence_full_path, schema, True)
         self._job_manager = job_manager
 
     def load_current_edges(self):

--- a/autosubmit/database/db_manager_job_list.py
+++ b/autosubmit/database/db_manager_job_list.py
@@ -24,7 +24,6 @@ from sqlalchemy import and_, or_, not_, func, select, exists, update
 from sqlalchemy.exc import IntegrityError
 
 from autosubmit.config.basicconfig import BasicConfig
-from autosubmit.database.db_common import get_connection_url
 from autosubmit.database.db_manager import DbManager
 from autosubmit.database.tables import ExperimentStructureTable, PreviewWrapperJobsTable, WrapperJobsTable, \
     PreviewWrapperInfoTable, WrapperInfoTable, SectionsStructureTable
@@ -95,7 +94,7 @@ class JobsDbManager(DbManager):
             persistence_full_path = Path(Path(BasicConfig.LOCAL_ROOT_DIR, schema, "db"), Path("job_list.db"))
         else:
             persistence_full_path = None
-        super().__init__(get_connection_url(persistence_full_path), schema)
+        super().__init__(persistence_full_path, schema)
         self._ACTIVE_STATUSES = ['READY', 'SUBMITTED', 'QUEUING', 'HELD', 'RUNNING']
         self._FINAL_STATUSES = ['COMPLETED', 'FAILED']
         self.restore_path = Path(BasicConfig.LOCAL_ROOT_DIR) / 'db' / 'job_list.sql'

--- a/autosubmit/database/session.py
+++ b/autosubmit/database/session.py
@@ -15,20 +15,74 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
+import threading
+from pathlib import Path
+from typing import Union
+
+from autosubmit.config.basicconfig import BasicConfig
 from sqlalchemy import Engine, NullPool, create_engine as sqlalchemy_create_engine
 
+__all__ = ["_resolve_engine", "get_engine"]
 
-def create_engine(connection_url: str) -> Engine:
-    """Create SQLAlchemy Core engine.
+
+def _resolve_engine(connection_url: str) -> Engine:
+    """Create SQLAlchemy Core engine and resolves the connection pool class based on the backend.
 
     :param connection_url: A SQLAlchemy connection URL.
     """
     if not connection_url:
-        raise ValueError(f'Invalid SQLAlchemy connection URL: {connection_url}')
+        raise ValueError(f"Invalid SQLAlchemy connection URL: {connection_url}")
 
     is_sqlite = connection_url.startswith("sqlite")
     pool_class = NullPool if is_sqlite else None
     return sqlalchemy_create_engine(connection_url, poolclass=pool_class)
 
 
-__all__ = ["create_engine"]
+class PostgreSQLEngineSingleton:
+    """Singleton class to manage a single instance of the PostgreSQL engine."""
+
+    _instance: Engine = None
+    _lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> Engine:
+        """Get the singleton instance of the PostgreSQL engine."""
+        with cls._lock:
+            if cls._instance is None:
+                connection_url = BasicConfig.DATABASE_CONN_URL
+                cls._instance = _resolve_engine(connection_url)
+        return cls._instance
+
+
+def get_engine(db_path: Union[str, Path]) -> Engine:
+    """Get SQLAlchemy Core engine.
+    This will resolve which backend to use based on the AS configuration.
+
+    In case the backend is PostgreSQL, the connection URL will be read from the environment variable,
+    and the engine will be reutilized from the global variable to use the same connection pool.
+
+    In case the backend is SQLite, a new engine will be created for each call based on the provided database path
+    with a NullPool to avoid accumulating open file descriptors.
+
+    :param db_path: Path to the database file, only used for SQLite.
+    """
+    db_backend = BasicConfig.DATABASE_BACKEND
+
+    if db_backend == "sqlite":
+        db_path = Path(db_path) if isinstance(db_path, str) else db_path
+        db_path = db_path.resolve()
+        
+        if not db_path.exists():
+            if not db_path.parent.exists():
+                db_path.parent.mkdir(parents=True, exist_ok=True)
+                db_path.parent.chmod(0o775)
+            db_path.touch()
+            db_path.chmod(0o775)
+
+        connection_url = f"sqlite:///{db_path}"
+        return _resolve_engine(connection_url)
+    elif db_backend == "postgres":
+        # Get from singleton engine
+        return PostgreSQLEngineSingleton.get_instance()
+    else:
+        raise ValueError(f"Unsupported database backend: {db_backend}")

--- a/autosubmit/experiment/detail_updater.py
+++ b/autosubmit/experiment/detail_updater.py
@@ -24,13 +24,13 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Union
 
-from sqlalchemy import Table, select, insert, delete
+from sqlalchemy import Table, delete, insert, select
 
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.config.configcommon import AutosubmitConfig
 from autosubmit.config.yamlparser import YAMLParserFactory
-from autosubmit.database.db_common import get_connection_url, get_experiment_id
-from autosubmit.database.session import create_engine
+from autosubmit.database.db_common import get_experiment_id
+from autosubmit.database.session import get_engine
 from autosubmit.database.tables import TableRegistry
 
 LOCAL_TZ = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
@@ -175,8 +175,7 @@ class ExperimentDetailsSQLAlchemyRepository(ExperimentDetailsRepository):
     def __init__(self):
         table_registry = TableRegistry(None)
         self.table: Table = table_registry.get("details")
-        connection_url = get_connection_url(BasicConfig.DB_PATH)
-        self.engine = create_engine(connection_url=connection_url)
+        self.engine = get_engine(db_path=BasicConfig.DB_PATH)
 
     def get_details(self, exp_id: int):
         with self.engine.connect() as conn:

--- a/autosubmit/history/database_managers/experiment_history_db_manager.py
+++ b/autosubmit/history/database_managers/experiment_history_db_manager.py
@@ -29,7 +29,6 @@ from sqlalchemy.schema import CreateTable, CreateSchema
 import autosubmit.history.utils as HUtils
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database import session
-from autosubmit.database.db_common import get_connection_url
 from autosubmit.database.tables import (
     ExperimentRunTable,
     JobDataTable, TableRegistry,
@@ -597,24 +596,19 @@ class SqlAlchemyExperimentHistoryDbManager:
         :param jobdata_path: Directory (sqlite) or URL Path (postgres).
         :param jobdata_file: Optional DB filename (used for sqlite; ignored for Postgres).
         """
-        if BasicConfig.DATABASE_BACKEND == "postgres":
-            default_base = BasicConfig.DATABASE_CONN_URL
-        else:
-            default_base = BasicConfig.JOBDATA_DIR
+        base = jobdata_path if jobdata_path else BasicConfig.JOBDATA_DIR
+        file_name = jobdata_file if jobdata_file else f"job_data_{schema}.db"
+        db_path = Path(base) / file_name
 
-        base = jobdata_path if jobdata_path is not None else default_base
-
-        # For sqlite we expect a filesystem path; for postgres we expect a connection URL.
+        # Decide whether to use a schema based on the database backend
+        # Postgres supports schemas, while SQLite does not.
         if BasicConfig.DATABASE_BACKEND == "postgres":
-            connection_url = get_connection_url(base)
             self.schema = schema
         else:
-            file_name = jobdata_file if jobdata_file is not None else f"job_data_{schema}.db"
-            db_path = Path(base) / file_name
-            connection_url = get_connection_url(db_path)
             self.schema = None
+
         self.table_registry = TableRegistry(schema=self.schema)
-        self.engine = session.create_engine(connection_url=connection_url)
+        self.engine = session.get_engine(db_path=db_path)
 
     def initialize(self):
         """Create the historical database tables if they do not exist, then migrate any missing columns."""
@@ -661,9 +655,7 @@ class SqlAlchemyExperimentHistoryDbManager:
 
     def my_database_exists(self):
         """Return ``True`` if the schema and tables exist in the database. ``False`` otherwise."""
-        connection_url = get_connection_url(Path(BasicConfig.DATABASE_CONN_URL))
-        engine = session.create_engine(connection_url=connection_url)
-        inspector = inspect(engine)
+        inspector = inspect(self.engine)
         return (
                 (self.schema in inspector.get_schema_names())
                 and inspector.has_table(ExperimentRunTable.name, schema=self.schema)

--- a/autosubmit/history/database_managers/experiment_status_db_manager.py
+++ b/autosubmit/history/database_managers/experiment_status_db_manager.py
@@ -19,16 +19,20 @@ import textwrap
 from pathlib import Path
 from typing import Protocol, cast
 
-from sqlalchemy import insert, select, update
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.schema import CreateTable
 
 import autosubmit.history.utils as HUtils
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database import session
-from autosubmit.database.db_common import get_connection_url
 from autosubmit.database.tables import ExperimentStatusTable, ExperimentTable
 from autosubmit.history.database_managers import database_models as Models
-from autosubmit.history.database_managers.database_manager import DatabaseManager, DEFAULT_LOCAL_ROOT_DIR
+from autosubmit.history.database_managers.database_manager import (
+    DEFAULT_LOCAL_ROOT_DIR,
+    DatabaseManager,
+)
 
 
 class ExperimentStatusDbManager(DatabaseManager):
@@ -144,8 +148,9 @@ class SqlAlchemyExperimentStatusDbManager:
     """
 
     def __init__(self) -> None:
-        connection_url = get_connection_url(Path(BasicConfig.DATABASE_CONN_URL))
-        self.engine = session.create_engine(connection_url=connection_url)
+        self.engine = session.get_engine(
+            db_path=Path(BasicConfig.DB_DIR, BasicConfig.AS_TIMES_DB)
+        )
         with self.engine.connect() as conn:
             with conn.begin():
                 conn.execute(CreateTable(ExperimentStatusTable, if_not_exists=True))
@@ -156,7 +161,7 @@ class SqlAlchemyExperimentStatusDbManager:
     def create_experiment_status_as_running(self, experiment):
         self.create_exp_status(experiment.id, experiment.name, Models.RunningStatus.RUNNING)
 
-    def get_experiment_status_row_by_expid(self, expid: str) -> Models.ExperimentRow | None:
+    def get_experiment_status_row_by_expid(self, expid: str) -> Models.ExperimentStatusRow | None:
         experiment_row = self.get_experiment_row_by_expid(expid)
         return self.get_experiment_status_row_by_exp_id(experiment_row.id)
 
@@ -183,14 +188,29 @@ class SqlAlchemyExperimentStatusDbManager:
         return Models.ExperimentStatusRow(*row)
 
     def create_exp_status(self, exp_id: int, expid: str, status: str) -> int:
+        """
+        Upsert a new experiment status row in the database. If the row already exists, it will be updated.
+        """
+        if BasicConfig.DATABASE_BACKEND == "postgres":
+            _insert_fn = pg_insert
+        else:
+            _insert_fn = sqlite_insert
         query = (
-            insert(ExperimentStatusTable).
+            _insert_fn(ExperimentStatusTable).
             values(
                 exp_id=exp_id,
                 name=expid,
                 status=status,
                 seconds_diff=0,
                 modified=HUtils.get_current_datetime()
+            ).on_conflict_do_update(
+                index_elements=[ExperimentStatusTable.c.exp_id],  # type: ignore
+                set_={
+                    "name": expid,
+                    "status": status,
+                    "seconds_diff": 0,
+                    "modified": HUtils.get_current_datetime()
+                }
             )
         )
         with self.engine.connect() as conn:

--- a/autosubmit/history/database_managers/experiment_status_db_manager.py
+++ b/autosubmit/history/database_managers/experiment_status_db_manager.py
@@ -188,29 +188,28 @@ class SqlAlchemyExperimentStatusDbManager:
         return Models.ExperimentStatusRow(*row)
 
     def create_exp_status(self, exp_id: int, expid: str, status: str) -> int:
-        """
-        Upsert a new experiment status row in the database. If the row already exists, it will be updated.
-        """
+        """Upsert a new experiment status row in the database. If the row already exists, it will be updated."""
         if BasicConfig.DATABASE_BACKEND == "postgres":
             _insert_fn = pg_insert
         else:
             _insert_fn = sqlite_insert
         query = (
-            _insert_fn(ExperimentStatusTable).
-            values(
+            _insert_fn(ExperimentStatusTable)
+            .values(
                 exp_id=exp_id,
                 name=expid,
                 status=status,
                 seconds_diff=0,
-                modified=HUtils.get_current_datetime()
-            ).on_conflict_do_update(
+                modified=HUtils.get_current_datetime(),
+            )
+            .on_conflict_do_update(
                 index_elements=[ExperimentStatusTable.c.exp_id],  # type: ignore
                 set_={
                     "name": expid,
                     "status": status,
                     "seconds_diff": 0,
-                    "modified": HUtils.get_current_datetime()
-                }
+                    "modified": HUtils.get_current_datetime(),
+                },
             )
         )
         with self.engine.connect() as conn:

--- a/autosubmit/job/metrics_processor.py
+++ b/autosubmit/job/metrics_processor.py
@@ -120,21 +120,20 @@ class UserMetricRepository:
     def __init__(self, expid: str):
         self.expid = expid
 
+        exp_path = Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(expid)
+        tmp_path = Path(exp_path).joinpath(BasicConfig.LOCAL_TMP_DIR)
+        db_path = tmp_path.joinpath(f"metrics_{expid}.db")
+
         if BasicConfig.DATABASE_BACKEND == "postgres":
             # Postgres backend
-            self.connection_url = BasicConfig.DATABASE_CONN_URL
             self.schema = self.expid
         else:
             # SQLite backend
-            exp_path = Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(expid)
-            tmp_path = Path(exp_path).joinpath(BasicConfig.LOCAL_TMP_DIR)
-            db_path = tmp_path.joinpath(f"metrics_{expid}.db")
-            self.connection_url = f"sqlite:///{db_path}"
             self.schema = None
 
         self.table_registry = TableRegistry(schema=self.schema)
         self.table = self.table_registry.get("user_metrics")
-        self.engine = session.create_engine(self.connection_url)
+        self.engine = session.get_engine(db_path=db_path)
 
         with self.engine.connect() as conn:
             with conn.begin():

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -472,6 +472,12 @@ def postgres_server(request: "FixtureRequest") -> Generator[PostgresContainer | 
 
             yield container
 
+
+@pytest.fixture(params=[False, True])
+def use_sqlalchemy(request):
+    return request.param
+
+
 @pytest.fixture(params=['postgres', 'sqlite'])
 def as_db(request: "FixtureRequest", autosubmit: Autosubmit, tmp_path: "LocalPath", postgres_server: "DockerContainer",
           autosubmit_exp, monkeypatch):

--- a/test/integration/database/test_db_manager.py
+++ b/test/integration/database/test_db_manager.py
@@ -25,10 +25,11 @@ import pytest
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database.db_common import get_autosubmit_version, _get_autosubmit_version, \
     _update_experiment_description_version, _get_autosubmit_version_sqlalchemy, _last_name_used_sqlalchemy, check_db_path
-from autosubmit.database.db_common import get_connection_url, DbException, create_db, open_conn
+from autosubmit.database.db_common import DbException, create_db, open_conn
 from autosubmit.database.db_manager import DbManager
 from autosubmit.database.tables import DBVersionTable, ExperimentTable
 from autosubmit.log.log import AutosubmitCritical
+from autosubmit.database.session import get_engine
 
 if TYPE_CHECKING:
     # noinspection PyProtectedMember
@@ -36,8 +37,7 @@ if TYPE_CHECKING:
 
 
 def _create_db_manager(db_path: Path):
-    connection_url = get_connection_url(db_path=db_path)
-    return DbManager(connection_url=connection_url)
+    return DbManager(db_path=db_path)
 
 
 def test_db_manager_has_made_correct_initialization(tmp_path: "LocalPath") -> None:

--- a/test/integration/experiment/test_detail_updater.py
+++ b/test/integration/experiment/test_detail_updater.py
@@ -22,7 +22,6 @@ import pytest
 from sqlalchemy.schema import CreateTable
 
 from autosubmit.database import session
-from autosubmit.database.db_common import get_connection_url
 from autosubmit.database.tables import DetailsTable
 from autosubmit.experiment.detail_updater import (
     ExperimentDetails,
@@ -61,10 +60,10 @@ def test_details_properties(autosubmit_exp, mocker):
 @pytest.mark.docker
 @pytest.mark.postgres
 def test_details_repository(tmpdir, as_db: str):
-    connection_url = get_connection_url(Path(tmpdir / 'details.db'))
-    with session.create_engine(connection_url=connection_url).connect() as conn:
-        with conn.begin():
-            conn.execute(CreateTable(DetailsTable, if_not_exists=True))
+    db_path = Path(tmpdir, 'details.db')
+    with session.get_engine(db_path=db_path).connect() as conn:
+        conn.execute(CreateTable(DetailsTable, if_not_exists=True))
+        conn.commit()
 
     details_repo = create_experiment_details_repository(as_db)
 

--- a/test/integration/history/database_managers/test_experiment_status_db_manager.py
+++ b/test/integration/history/database_managers/test_experiment_status_db_manager.py
@@ -44,29 +44,41 @@ def test_create_experiment_status_db_manager_invalid_value():
 
 @pytest.mark.docker
 @pytest.mark.postgres
-def test_experiment_status_db_manager(tmp_path: 'LocalPath', as_db: str, get_next_expid):
+def test_experiment_status_db_manager(tmp_path: 'LocalPath', as_db: str, use_sqlalchemy: bool, get_next_expid):
+    if as_db == "postgres" and not use_sqlalchemy:
+        pytest.skip("Postgres only supports SQLAlchemy")
+
     expid = get_next_expid()
     options = {"expid": expid}
     tmp_test_dir = tmp_path / "test_status"
     tmp_test_dir.mkdir()
 
-    clazz = SqlAlchemyExperimentStatusDbManager
-
-    is_sqlalchemy = as_db == "sqlite"
-    if is_sqlalchemy:
-        clazz = ExperimentStatusDbManager
-
+    if as_db == "sqlite":
         options["db_dir_path"] = tmp_test_dir
         options["local_root_dir_path"] = tmp_test_dir
         options["main_db_name"] = "tests.db"
 
+    if as_db == "sqlite" and use_sqlalchemy:
+        database_manager = SqlAlchemyExperimentStatusDbManager()
+        clazz = SqlAlchemyExperimentStatusDbManager
+    else:
+        database_manager = create_experiment_status_db_manager(as_db, **options)
+        clazz = (
+            ExperimentStatusDbManager
+            if as_db == "sqlite"
+            else SqlAlchemyExperimentStatusDbManager
+        )
+
     # Assert type of database manager
-    database_manager = create_experiment_status_db_manager(as_db, **options)  # type: clazz
     assert isinstance(database_manager, clazz)
 
-    # Test initialization of the table (is possible is created by some previous test)
-    if is_sqlalchemy:
-        assert Path(cast(ExperimentStatusDbManager, database_manager)._as_times_file_path).exists()
+    if as_db == "sqlite" and not use_sqlalchemy:
+        assert Path(
+            cast(ExperimentStatusDbManager, database_manager)._as_times_file_path
+        ).exists()
+    elif as_db == "sqlite" and use_sqlalchemy:
+        inspector = inspect(database_manager.engine)
+        assert inspector.has_table(ExperimentStatusTable.name)
     else:
         inspector = inspect(database_manager.engine)
         assert inspector.has_table(ExperimentStatusTable.name, schema="public")
@@ -113,7 +125,12 @@ def test_get_experiment_status_row_by_expid(tmp_path: 'LocalPath', as_db: str, a
     experiment_status_row = database_manager.get_experiment_status_row_by_expid(exp.expid)
     assert experiment_status_row is None
 
-    experiment_db_id = 1
+    # Get the experiment row
+    experiment_row = database_manager.get_experiment_row_by_expid(exp.expid)
+    experiment_db_id = experiment_row.id if experiment_row else None
+    assert experiment_db_id is not None
+
+    # Create the experiment status row and assert it is created
     last_row_id = database_manager.create_exp_status(experiment_db_id, exp.expid, Status.SUBMITTED)
     assert last_row_id > 0
 

--- a/test/unit/database/test_db_manager.py
+++ b/test/unit/database/test_db_manager.py
@@ -21,21 +21,22 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from autosubmit.database.db_manager import DbManager
+from autosubmit.database.session import get_engine
 from autosubmit.database.tables import ExperimentTable
 
 
 def test_insert_rejects_empty_data():
-    db_manager = DbManager('sqlite:///:memory:', schema='abc')
+    db_manager = DbManager(db_path=':memory:', schema='abc')
     with does_not_raise():
         db_manager.insert(ExperimentTable.name, {})
 
 
 def test_insert_many_rejects_empty_data():
-    db_manager = DbManager('sqlite:///:memory:', schema='abc')
+    db_manager = DbManager(db_path=':memory:', schema='abc')
     assert 0 == db_manager.insert_many(ExperimentTable.name, [])
 
 
 def test_delete_where_raises_empty_data():
-    db_manager = DbManager('sqlite:///:memory:', schema='abc')
+    db_manager = DbManager(db_path=':memory:', schema='abc')
     with pytest.raises(ValueError):
         db_manager.delete_where(ExperimentTable.name, {})

--- a/test/unit/database/test_session.py
+++ b/test/unit/database/test_session.py
@@ -19,21 +19,49 @@ from typing import Union
 
 import pytest
 
-from autosubmit.database.session import create_engine
+from autosubmit.database.session import _resolve_engine, get_engine
 
 
 @pytest.mark.parametrize(
-    'url,expected',
+    "url,expected",
     [
-        ('postgresql://user:pass@host:1984/db', 'postgresql'),
-        ('sqlite://', 'sqlite'),
-        (None, ValueError)
-    ]
+        ("postgresql://user:pass@host:1984/db", "postgresql"),
+        ("sqlite://", "sqlite"),
+        (None, ValueError),
+    ],
 )
-def test_create_engine(url: str, expected: Union[str, Exception]):
+def test_resolve_engine(url: str, expected: Union[str, Exception]):
     if type(expected) is not str:
         with pytest.raises(expected):  # type: ignore
-            create_engine(connection_url=url)
+            _resolve_engine(connection_url=url)
     else:
-        engine = create_engine(connection_url=url)
+        engine = _resolve_engine(connection_url=url)
         assert engine.name == expected
+
+
+def test_get_engine_sqlite(mocker):
+    mocker.patch("autosubmit.config.basicconfig.BasicConfig.DATABASE_BACKEND", "sqlite")
+    mocker.patch("autosubmit.config.basicconfig.BasicConfig.DATABASE_CONN_URL", None)
+    engine = get_engine(db_path=":memory:")
+    assert engine.name == "sqlite"
+
+
+@pytest.mark.postgres
+def test_get_engine_postgres(mocker):
+    mocker.patch(
+        "autosubmit.config.basicconfig.BasicConfig.DATABASE_BACKEND", "postgres"
+    )
+    engine = get_engine(db_path="dummy_path")
+    assert engine.name == "postgresql"
+
+    # Singleton behavior: subsequent calls should return the same instance
+    engine2 = get_engine(db_path="dummy_path")
+    assert engine is engine2
+
+
+def test_get_engine_unsupported_backend(mocker):
+    mocker.patch(
+        "autosubmit.config.basicconfig.BasicConfig.DATABASE_BACKEND", "unsupported"
+    )
+    with pytest.raises(ValueError):
+        get_engine(db_path="dummy_path")

--- a/test/unit/history/database_managers/test_experiment_history_db_manager.py
+++ b/test/unit/history/database_managers/test_experiment_history_db_manager.py
@@ -135,7 +135,6 @@ def test_create_experiment_history_db_manager_invalid():
 
 def test_functions_not_implemented(mocker):
     """Confirm that we do not implement a few functions for Postgres."""
-    mocker.patch('autosubmit.history.database_managers.experiment_history_db_manager.get_connection_url')
     mocker.patch('autosubmit.history.database_managers.experiment_history_db_manager.session')
     db_manager = SqlAlchemyExperimentHistoryDbManager(None, BasicConfig.JOBDATA_DIR)
     # NOTE: These are all parameter-less.


### PR DESCRIPTION
Closes #2973 

This PR changed the `create_engine` function from the session module to handle a persistent instance of the engine used for Postgres to enforce the usage of the Pool strategy and reutilize the connections. In the case of SQLite, this should behave the same.

Additionally, the function to create the experiment status row has been updated to do a native upsert.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
