### PR TITLE
Drop 3.9 from pyproject and RTD, fix major->minor (semver)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz
     - sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-### 4.2.0: Major release
-This is a major release of Autosubmit that introduces significant changes in the management of jobs and dependencies. 
+### 4.2.0: Minor release
+
+This is a minor release of Autosubmit that introduces significant changes in the management of jobs and dependencies. 
 The main highlight of this release is the introduction of a new database backend for the joblist using SQLAlchemy, which allows for better scalability in handling large workflows.
 This release also includes several bug fixes and enhancements to improve the overall user experience.
 
+**Bug fixes:**
+
+- Fix timeout guard is silently disabled for login/local jobs #3081
+
 **New Features:**
+
 - Introduced SQLAlchemy as the main database backend for joblist management, replacing the previous pickle-based system. This change allows for better scalability and flexibility in handling large workflows.
 - Added support for PostgreSQL as a database backend, in addition to the default SQLite. This provides users with more options for database management.
 - Improved the performance of job and dependency management, especially for large workflows with thousands of jobs.
@@ -16,36 +22,20 @@ This release also includes several bug fixes and enhancements to improve the ove
 **Memory and Performance Improvements**:
 
 - Significant reduction in memory usage by loading only necessary jobs and dependencies for active employment.
-
 - Enhanced performance during autosubmit runs and ongoing improvements to the log process management through direct database interactions to reduce the communication with the main process.
-
 - Overall job management features have been improved to ensure better tracking and status updates, removing redundant code to enhance the efficiency of a loop 
-
 - The recovery and set status commands have been improved for version 4.2.0 and later 4.1.16, resulting in faster operations.
-
 - Removal of _COMPLETED files to reduce the amount of inodes generated
-
 - A significant rework of the wrapper building process has been implemented to address ongoing issues and prevent regressions, particularly with 2D wrappers.
-
 - Various functions have been optimized to minimize calls to save/load operations, enhancing the software's overall efficiency and responsiveness.
 
-**Enchanments**
+**Enhancements**
 
 - **Database Method Enhancements**: Support for both PostgreSQL and SQLite with optimized save/load mechanisms. Improved wrapper data storage and load.
-
 - **Testing Efforts**: Tests have been added for every rework to enhance reliability, with a particular effort on integration tests.
-
-### 4.1.18: Unreleased
-
-**Bug fixes:**
-
-- Fix timeout guard is silently disabled for login/local jobs #3081
-
-**Enhancements:**
-
 - Auto-detect git default branch when `-b` flag not specified #3101
 
-### 4.1.17: Unreleased
+### 4.1.17: Bug fixes and enhancements
 
 **Bug fixes:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "setuptools.build_meta"
 name = "autosubmit"
 dynamic = ["version", "readme"]
 description = "Autosubmit is a Python-based workflow manager to create, manage and monitor complex tasks involving different substeps, such as scientific computational experiments. These workflows may involve multiple computing systems for their completion, from HPCs to post-processing clusters or workstations. Autosubmit can orchestrate all the tasks integrating the workflow by managing their dependencies, interfacing with all the platforms involved, and handling eventual errors."
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 authors = [
   { name="The Autosubmit Team - Models and Workflows Team (MWT) - Barcelona Supercomputing Center (BSC)", email="support-autosubmit@bsc.es" },
 ]
@@ -35,7 +35,6 @@ keywords = ["climate", "weather", "workflow", "HPC"]
 license = {file = "LICENSE"}
 
 classifiers = [
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Drops the RTD 3.9 (issue found by @VindeeR and fixed in his PR -- Erick, I'll apply that to master now :+1: ), and also in pyproject.toml.

I was trying to fix the optionals with `ruff check autosubmit/job/job_packages.py --select UP045` but ruff was refusing the comply. Turns out ruff checks the pyproject.toml, and if we are on py3.9, it refuses changing the code to avoid breaking 3.9 compatibility (I believe their behaviour is correct).

I've also adjusted the changelog.

The 4.1.8 release entries are actually in 4.2.0 as the 4.2.0 was merged into master. If there's a 4.1.18, then we will cut a release from the 4.1.17 branch, which doesn't contain the entries that were in CHANGELOG for 4.1.18.

Also adjusted that 4.2.0 is a minor release.

<img width="906" height="439" alt="image" src="https://github.com/user-attachments/assets/960182aa-46f3-4e97-a96f-e5007cf8ba8b" />

3.0 is a major release, and so it 4.0. 4.1 is a minor, and 4.1.17 is a patch or bugfix release. So 4.2.0 is a minor release.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [ ] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
