### PR TITLE
Fixes run_modes issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This release also includes several bug fixes and enhancements to improve the ove
 
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166
+- Fixed `--start-after` not starting the experiment when the monitored experiment completed, because the run totals were wiped to zero at the end of the run #3151
+- Fixed `--start-after` with a non-existent experiment blocking the run; the trigger is now reported and ignored
+- Fixed `--run-only-members` (`-rom`) submitting jobs of all members instead of only the allowed ones
 
 **New Features:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ several bug fixes and enhancements to improve the overall user experience.
 
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166
+- Fixed `--start-after` not starting the experiment when the monitored experiment completed, because the run totals were wiped to zero at the end of the run #3151
+- Fixed `--start-after` with a non-existent experiment blocking the run; the trigger is now reported and ignored
+- Fixed `--run-only-members` (`-rom`) submitting jobs of all members instead of only the allowed ones
 
 **New Features:**
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -1844,7 +1844,8 @@ class Autosubmit:
             exp_history.initialize_database()
             run_dc = exp_history.process_status_changes(job_list.get_job_list(), as_conf.get_chunk_size_unit(),
                                                         as_conf.get_chunk_size(),
-                                                        current_config=as_conf.get_full_config_as_json())
+                                                        current_config=as_conf.get_full_config_as_json(),
+                                                        status_counts=job_list.get_status_counts())
             job_list.run_id = run_dc.run_id if run_dc else None
             Autosubmit.database_backup(expid)
         except Exception:
@@ -1870,7 +1871,8 @@ class Autosubmit:
         """
         exp_history = ExperimentHistory(expid)
         if len(job_changes_tracker) > 0:
-            exp_history.process_job_list_changes_to_experiment_totals(job_list.get_job_list())
+            exp_history.process_job_list_changes_to_experiment_totals(job_list.get_job_list(),
+                                                                      status_counts=job_list.get_status_counts())
             Autosubmit.database_backup(expid)
 
     @staticmethod
@@ -1943,10 +1945,12 @@ class Autosubmit:
 
         if recover:
             Log.info("Recovering job_list")
+        # Check if the user has launch autosubmit run with -rom option.
+        allowed_members = AutosubmitHelper.get_allowed_members(run_only_members, as_conf)
         try:
             job_list = Autosubmit.load_job_list(
                 expid, as_conf, new=False, full_load=False, submitter=submitter,
-                check_failed_jobs=True, run_mode=False)
+                check_failed_jobs=True, run_mode=False, run_members=allowed_members)
 
         except OSError as e:
             raise AutosubmitError(
@@ -1994,12 +1998,10 @@ class Autosubmit:
         if not recover:
             Log.info(f"Autosubmit is running with v{Autosubmit.autosubmit_version}")
             # Before starting main loop, setup historical database tables and main information
-        # Check if the user has launch autosubmit run with -rom option ( previously named -rm )
-        allowed_members = AutosubmitHelper.get_allowed_members(run_only_members, as_conf)
+        # Check if the user has launch autosubmit run with -rom option ( previously named -rm ).
+        # run_members was already applied in load_job_list before generating the
+        # graph, so only report the restriction here.
         if allowed_members:
-            # Set allowed members after checks have been performed.
-            # This triggers the setter and main logic of the -rm feature.
-            job_list.run_members = allowed_members
             Log.result(f"Only jobs with member value in {str(allowed_members)} or no member will be allowed in this "
                        f"run. Also, those jobs already SUBMITTED, QUEUING, or RUNNING will be allowed to complete and"
                        f" will be tracked.")
@@ -5184,7 +5186,7 @@ class Autosubmit:
     # TODO: To be moved to utils
     @staticmethod
     def load_job_list(expid, as_conf, monitor=False, new=True, full_load=True, submitter=None,
-                      check_failed_jobs=False, run_mode=False) -> JobList:
+                      check_failed_jobs=False, run_mode=False, run_members: list[str] | None = None) -> JobList:
         """Load the JobList for a given experiment.
 
         :param expid: experiment id
@@ -5195,10 +5197,15 @@ class Autosubmit:
         :param submitter: submitter to be used
         :param check_failed_jobs: whether to check failed jobs or not
         :param run_mode: whether to load the job list in run mode or not
+        :param run_members: optional list of members to restrict the run to. Set
+            before loading the job graph so that only the allowed members are
+            loaded into memory and therefore submitted.
         :return: JobList object
         """
         rerun = as_conf.get_rerun()
         job_list = JobList(expid, as_conf, YAMLParserFactory(), run_mode=run_mode, submitter=submitter)
+        if run_members:
+            job_list.run_members = run_members
         date_list = as_conf.get_date_list()
         date_format = ''
         if as_conf.get_chunk_size_unit() == ChunkUnit.HOUR:

--- a/autosubmit/helpers/autosubmit_helper.py
+++ b/autosubmit/helpers/autosubmit_helper.py
@@ -72,8 +72,11 @@ def handle_start_after(start_after: str, expid: str) -> None:
             Log.info(
                 "Hey! What do you think is going to happen? In theory, "
                 "your experiment will run again after it has been completed. Good luck!")
-        # Check if experiment exists. If False or None, it does not exist
-        if not check_experiment_exists(start_after):
+        # Check if experiment exists. If False or None, it does not exist.
+        # error_on_inexistence is disabled because a missing experiment must not
+        # block the run: it is reported and ignored.
+        if not check_experiment_exists(start_after, error_on_inexistence=False):
+            Log.warning(f"Experiment {start_after} does not exist. Ignoring the start_after trigger.")
             return
         # Historical Database: We use the historical database to retrieve the current progress
         # data of the supplied expid (start_after)

--- a/autosubmit/helpers/autosubmit_helper.py
+++ b/autosubmit/helpers/autosubmit_helper.py
@@ -77,6 +77,8 @@ def handle_start_after(start_after: str, expid: str) -> None:
         # block the run: it is reported and ignored.
         if not check_experiment_exists(start_after, error_on_inexistence=False):
             Log.warning(f"Experiment {start_after} does not exist. Ignoring the start_after trigger.")
+            # Keep the warning readable before the console is cleared.
+            sleep(3)
             return
         # Historical Database: We use the historical database to retrieve the current progress
         # data of the supplied expid (start_after)

--- a/autosubmit/helpers/autosubmit_helper.py
+++ b/autosubmit/helpers/autosubmit_helper.py
@@ -90,16 +90,34 @@ def handle_start_after(start_after: str, expid: str) -> None:
                  f"suspended jobs becomes equal to the total number of jobs of experiment {start_after}, experiment "
                  f"{expid} will start. Querying every 60 seconds. Status format "
                  f"Completed/Queuing/Running/Suspended/Failed.")
-        while current_run := exp_history.manager.get_experiment_run_dc_with_max_id():
-            if (current_run.finish > 0 and current_run.total > 0
-                    and current_run.total == current_run.completed + current_run.suspended):
-                break
-            sys.stdout.write(
-                f"\rExperiment {start_after} ({current_run.total} total jobs) status {current_run.completed}/"
-                f"{current_run.queuing}/{current_run.running}/{current_run.suspended}/{current_run.failed}")
+        waiting_for_first_run_reported = False
+        current_run = exp_history.manager.get_experiment_run_dc_with_max_id_or_none()
+        while not _run_is_completed(current_run):
+            if current_run is None:
+                if not waiting_for_first_run_reported:
+                    Log.warning(f"Experiment {start_after} exists but has not registered a run yet. "
+                                f"Autosubmit will keep waiting for it to start before launching experiment {expid}.")
+                    waiting_for_first_run_reported = True
+                sys.stdout.write(f"\rWaiting for experiment {start_after} to start...")
+            else:
+                sys.stdout.write(
+                    f"\rExperiment {start_after} ({current_run.total} total jobs) status {current_run.completed}/"
+                    f"{current_run.queuing}/{current_run.running}/{current_run.suspended}/{current_run.failed}")
             sys.stdout.flush()
             # Update every 60 seconds
             sleep(60)
+            current_run = exp_history.manager.get_experiment_run_dc_with_max_id_or_none()
+        Log.info(f"Experiment {start_after} finished. Starting experiment {expid}.")
+
+
+def _run_is_completed(current_run) -> bool:
+    """A run is completed when it was finished and all its jobs reached a terminal state."""
+    return bool(
+        current_run
+        and current_run.finish > 0
+        and current_run.total > 0
+        and current_run.total == current_run.completed + current_run.suspended
+    )
 
 
 def get_allowed_members(run_members: str, as_conf: AutosubmitConfig) -> list[str] | list[Any]:

--- a/autosubmit/history/experiment_history.py
+++ b/autosubmit/history/experiment_history.py
@@ -14,6 +14,7 @@
 
 import traceback
 from time import time
+from typing import TYPE_CHECKING
 
 import autosubmit.history.database_managers.database_models as Models
 import autosubmit.history.utils as HUtils
@@ -34,6 +35,9 @@ from autosubmit.history.strategies import (
     TwoDimWrapperDistributionStrategy,
 )
 from autosubmit.log.log import Log
+
+if TYPE_CHECKING:
+    from autosubmit.job.job import Job
 
 SECONDS_WAIT_PLATFORM = 60
 
@@ -315,8 +319,28 @@ class ExperimentHistory:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def process_status_changes(self, job_list=None, chunk_unit="NA", chunk_size=0, current_config="", create=False):
-        """ Detect status differences between job_list and current job_data rows, and update. Creates a new run if necessary. """
+    def process_status_changes(self, job_list: "list[Job] | None" = None, chunk_unit: str = "NA", chunk_size: int = 0,
+                               current_config: str = "", create: bool = False,
+                               status_counts: "dict[str, int] | None" = None) -> ExperimentRun | None:
+        """ Detect status differences between job_list and current job_data rows, and update. Creates a new run if necessary.
+
+        :param job_list: the jobs of the experiment as a plain list.
+        :type job_list: list[Job] | None
+        :param chunk_unit: the chunk unit (e.g. month) of the current run.
+        :type chunk_unit: str
+        :param chunk_size: the chunk size of the current run.
+        :type chunk_size: int
+        :param current_config: the experiment configuration as a JSON string.
+        :type current_config: str
+        :param create: whether a new run must be created regardless of changes.
+        :type create: bool
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database, which includes jobs unloaded from memory).
+            When omitted they are computed from ``job_list``.
+        :type status_counts: dict[str, int] | None
+        :return: the current ``ExperimentRun`` or None if the database failed.
+        :rtype: ExperimentRun | None
+        """
         try:
             try:
                 current_experiment_run_dc = self.manager.get_experiment_run_dc_with_max_id()
@@ -332,28 +356,40 @@ class ExperimentHistory:
             if len(update_these_changes) > 0 and not should_create_new_run:
                 self.manager.update_many_job_data_change_status(update_these_changes)
             if should_create_new_run:
-                return self.create_new_experiment_run(chunk_unit, chunk_size, current_config, job_list)
-            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list)
+                return self.create_new_experiment_run(chunk_unit, chunk_size, current_config, job_list,
+                                                      status_counts=status_counts)
+            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list,
+                                                           status_counts=status_counts)
         except Exception as exp:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def _get_built_list_of_changes(self, job_list):
+    def _get_built_list_of_changes(self, job_list: "list[Job]"):
         """ Return: List of (current timestamp, current datetime str, status, rowstatus, id in job_data). One tuple per change. """
         job_data_dcs = self.detect_changes_in_job_list(job_list)
         return [(HUtils.get_current_datetime(), job.status, Models.RowStatus.CHANGED, job._id) for job in job_data_dcs]
 
-    def process_job_list_changes_to_experiment_totals(self, job_list=None):
-        """ Updates current experiment_run row with totals calculated from job_list. """
+    def process_job_list_changes_to_experiment_totals(self, job_list: "list[Job] | None" = None,
+                                                      status_counts: "dict[str, int] | None" = None) -> ExperimentRun | None:
+        """ Updates current experiment_run row with totals calculated from job_list.
+
+        :param job_list: the jobs of the experiment as a plain list.
+        :type job_list: list[Job] | None
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database, which includes jobs unloaded from memory).
+            When omitted they are computed from ``job_list``.
+        :type status_counts: dict[str, int] | None
+        """
         try:
             current_experiment_run_dc = self.manager.get_experiment_run_dc_with_max_id()
-            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list)
+            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list,
+                                                           status_counts=status_counts)
         except Exception as exp:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def should_we_create_a_new_run(self, job_list, changes_count, current_experiment_run_dc, new_chunk_unit,
-                                   new_chunk_size, create=False):
+    def should_we_create_a_new_run(self, job_list: "list[Job]", changes_count: int, current_experiment_run_dc,
+                                   new_chunk_unit: str, new_chunk_size: int, create: bool = False) -> bool:
         if create:
             return True
         elif not create and self.expid[0].lower() != "t":
@@ -370,9 +406,21 @@ class ExperimentHistory:
             return True
         return False
 
-    def update_counts_on_experiment_run_dc(self, experiment_run_dc, job_list=None):
-        """ Return updated row as Models.ExperimentRun. """
-        status_counts = self.get_status_counts_from_job_list(job_list)
+    def update_counts_on_experiment_run_dc(self, experiment_run_dc, job_list: "list[Job] | None" = None,
+                                           status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
+        """ Return updated row as Models.ExperimentRun.
+
+        :param experiment_run_dc: the run to update.
+        :type experiment_run_dc: ExperimentRun
+        :param job_list: the jobs of the experiment as a plain list. Used to
+            compute the counts when ``status_counts`` is not provided.
+        :type job_list: list[Job] | None
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database, which includes jobs unloaded from memory).
+        :type status_counts: dict[str, int] | None
+        """
+        if status_counts is None:
+            status_counts = self.get_status_counts_from_job_list(job_list)
         experiment_run_dc.completed = status_counts[HUtils.SupportedStatus.COMPLETED]
         experiment_run_dc.failed = status_counts[HUtils.SupportedStatus.FAILED]
         experiment_run_dc.queuing = status_counts[HUtils.SupportedStatus.QUEUING]
@@ -389,15 +437,28 @@ class ExperimentHistory:
             return self.manager.update_experiment_run_dc_by_id(current_experiment_run_dc)
         return None
 
-    def create_new_experiment_run(self, chunk_unit="NA", chunk_size=0, current_config="", job_list=None):
-        """ Also writes the finish timestamp of the previous run.  """
+    def create_new_experiment_run(self, chunk_unit: str = "NA", chunk_size: int = 0, current_config: str = "",
+                                  job_list: "list[Job] | None" = None,
+                                  status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
+        """ Also writes the finish timestamp of the previous run.
+
+        :param job_list: the jobs of the experiment as a plain list.
+        :type job_list: list[Job] | None
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database). When omitted they are computed from ``job_list``.
+        :type status_counts: dict[str, int] | None
+        """
         self.finish_current_experiment_run()
         return self._create_new_experiment_run_dc_with_counts(chunk_unit=chunk_unit, chunk_size=chunk_size,
-                                                              current_config=current_config, job_list=job_list)
+                                                              current_config=current_config, job_list=job_list,
+                                                              status_counts=status_counts)
 
-    def _create_new_experiment_run_dc_with_counts(self, chunk_unit, chunk_size, current_config="", job_list=None):
+    def _create_new_experiment_run_dc_with_counts(self, chunk_unit: str, chunk_size: int, current_config: str = "",
+                                                  job_list: "list[Job] | None" = None,
+                                                  status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
         """ Create new experiment_run row and return the new Models.ExperimentRun data class from database. """
-        status_counts = self.get_status_counts_from_job_list(job_list)
+        if status_counts is None:
+            status_counts = self.get_status_counts_from_job_list(job_list)
         experiment_run_dc = ExperimentRun(0,
                                           chunk_unit=chunk_unit,
                                           chunk_size=chunk_size,
@@ -412,7 +473,7 @@ class ExperimentHistory:
                                           suspended=status_counts[HUtils.SupportedStatus.SUSPENDED])
         return self.manager.register_experiment_run_dc(experiment_run_dc)
 
-    def detect_changes_in_job_list(self, job_list):
+    def detect_changes_in_job_list(self, job_list: "list[Job]"):
         """ Detect changes in job_list compared to the current contents of job_data table. Returns a list of JobData data classes where the status of each item is the new status."""
         job_name_to_job = {str(job.name): job for job in job_list}
         current_job_data_dcs = self.manager.get_all_last_job_data_dcs()
@@ -448,16 +509,15 @@ class ExperimentHistory:
         else:
             return max_counter
 
-    def _get_date_member_completed_count(self, job_list):
+    def _get_date_member_completed_count(self, job_list: "list[Job] | None" = None) -> int:
         """ Each item in the job_list must have attributes: date, member, status_str. """
         job_list = job_list if job_list else []
         return sum(1 for job in job_list if
                    job.date is not None and job.member is not None and job.status_str == HUtils.SupportedStatus.COMPLETED)
 
-    def get_status_counts_from_job_list(self, job_list):
-        """
-        Return dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING, SUSPENDED, TOTAL.
-        """
+    def get_status_counts_from_job_list(self, job_list: "list[Job] | None" = None) -> "dict[str, int]":
+        """Return dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING, SUSPENDED, TOTAL."""
+        job_list = job_list or []
         result = {
             HUtils.SupportedStatus.COMPLETED: 0,
             HUtils.SupportedStatus.FAILED: 0,
@@ -465,11 +525,7 @@ class ExperimentHistory:
             HUtils.SupportedStatus.SUBMITTED: 0,
             HUtils.SupportedStatus.RUNNING: 0,
             HUtils.SupportedStatus.SUSPENDED: 0,
-            "TOTAL": 0
         }
-
-        if not job_list:
-            job_list = []
 
         for job in job_list:
             if job.status_str in result:

--- a/autosubmit/history/experiment_history.py
+++ b/autosubmit/history/experiment_history.py
@@ -324,24 +324,19 @@ class ExperimentHistory:
     def process_status_changes(self, job_list: "list[Job] | None" = None, chunk_unit: str = "NA", chunk_size: int = 0,
                                current_config: str = "", create: bool = False,
                                status_counts: "dict[str, int] | None" = None) -> ExperimentRun | None:
-        """ Detect status differences between job_list and current job_data rows, and update. Creates a new run if necessary.
+        """Detect status differences between the job list and the ``job_data`` rows and update them.
+
+        Creates a new run if necessary.
 
         :param job_list: the jobs of the experiment as a plain list.
-        :type job_list: list[Job] | None
         :param chunk_unit: the chunk unit (e.g. month) of the current run.
-        :type chunk_unit: str
         :param chunk_size: the chunk size of the current run.
-        :type chunk_size: int
         :param current_config: the experiment configuration as a JSON string.
-        :type current_config: str
         :param create: whether a new run must be created regardless of changes.
-        :type create: bool
         :param status_counts: optional pre-computed status counts (e.g. from the
             complete jobs database, which includes jobs unloaded from memory).
             When omitted they are computed from ``job_list``.
-        :type status_counts: dict[str, int] | None
         :return: the current ``ExperimentRun`` or None if the database failed.
-        :rtype: ExperimentRun | None
         """
         try:
             try:
@@ -373,14 +368,12 @@ class ExperimentHistory:
 
     def process_job_list_changes_to_experiment_totals(self, job_list: "list[Job] | None" = None,
                                                       status_counts: "dict[str, int] | None" = None) -> ExperimentRun | None:
-        """ Updates current experiment_run row with totals calculated from job_list.
+        """Updates the current ``experiment_run`` row with totals computed from the given ``status_counts``.
 
         :param job_list: the jobs of the experiment as a plain list.
-        :type job_list: list[Job] | None
         :param status_counts: optional pre-computed status counts (e.g. from the
             complete jobs database, which includes jobs unloaded from memory).
             When omitted they are computed from ``job_list``.
-        :type status_counts: dict[str, int] | None
         """
         try:
             current_experiment_run_dc = self.manager.get_experiment_run_dc_with_max_id()
@@ -390,7 +383,7 @@ class ExperimentHistory:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def should_we_create_a_new_run(self, job_list: "list[Job]", changes_count: int, current_experiment_run_dc,
+    def should_we_create_a_new_run(self, job_list: "list[Job]", changes_count: int, current_experiment_run_dc: ExperimentRun,
                                    new_chunk_unit: str, new_chunk_size: int, create: bool = False) -> bool:
         if create:
             return True
@@ -408,29 +401,27 @@ class ExperimentHistory:
             return True
         return False
 
-    def update_counts_on_experiment_run_dc(self, experiment_run_dc, job_list: "list[Job] | None" = None,
+    def update_counts_on_experiment_run_dc(self, current_experiment_run_dc: ExperimentRun, job_list: "list[Job] | None" = None,
                                            status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
-        """ Return updated row as Models.ExperimentRun.
+        """Updates the counts of the run from the given ``status_counts`` and returns the updated row.
 
-        :param experiment_run_dc: the run to update.
-        :type experiment_run_dc: ExperimentRun
+        :param current_experiment_run_dc: the run to update.
         :param job_list: the jobs of the experiment as a plain list. Used to
             compute the counts when ``status_counts`` is not provided.
-        :type job_list: list[Job] | None
         :param status_counts: optional pre-computed status counts (e.g. from the
             complete jobs database, which includes jobs unloaded from memory).
-        :type status_counts: dict[str, int] | None
+            When omitted they are computed from ``job_list``.
         """
         if status_counts is None:
             status_counts = self.get_status_counts_from_job_list(job_list)
-        experiment_run_dc.completed = status_counts[HUtils.SupportedStatus.COMPLETED]
-        experiment_run_dc.failed = status_counts[HUtils.SupportedStatus.FAILED]
-        experiment_run_dc.queuing = status_counts[HUtils.SupportedStatus.QUEUING]
-        experiment_run_dc.submitted = status_counts[HUtils.SupportedStatus.SUBMITTED]
-        experiment_run_dc.running = status_counts[HUtils.SupportedStatus.RUNNING]
-        experiment_run_dc.suspended = status_counts[HUtils.SupportedStatus.SUSPENDED]
-        experiment_run_dc.total = status_counts["TOTAL"]
-        return self.manager.update_experiment_run_dc_by_id(experiment_run_dc)
+        current_experiment_run_dc.completed = status_counts[HUtils.SupportedStatus.COMPLETED]
+        current_experiment_run_dc.failed = status_counts[HUtils.SupportedStatus.FAILED]
+        current_experiment_run_dc.queuing = status_counts[HUtils.SupportedStatus.QUEUING]
+        current_experiment_run_dc.submitted = status_counts[HUtils.SupportedStatus.SUBMITTED]
+        current_experiment_run_dc.running = status_counts[HUtils.SupportedStatus.RUNNING]
+        current_experiment_run_dc.suspended = status_counts[HUtils.SupportedStatus.SUSPENDED]
+        current_experiment_run_dc.total = status_counts["TOTAL"]
+        return self.manager.update_experiment_run_dc_by_id(current_experiment_run_dc)
 
     def finish_current_experiment_run(self):
         if self.manager.is_there_a_last_experiment_run():
@@ -442,13 +433,11 @@ class ExperimentHistory:
     def create_new_experiment_run(self, chunk_unit: str = "NA", chunk_size: int = 0, current_config: str = "",
                                   job_list: "list[Job] | None" = None,
                                   status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
-        """ Also writes the finish timestamp of the previous run.
+        """Create a new ``experiment_run`` row, also writing the finish timestamp of the previous run.
 
         :param job_list: the jobs of the experiment as a plain list.
-        :type job_list: list[Job] | None
         :param status_counts: optional pre-computed status counts (e.g. from the
             complete jobs database). When omitted they are computed from ``job_list``.
-        :type status_counts: dict[str, int] | None
         """
         self.finish_current_experiment_run()
         return self._create_new_experiment_run_dc_with_counts(chunk_unit=chunk_unit, chunk_size=chunk_size,
@@ -517,7 +506,7 @@ class ExperimentHistory:
         return sum(1 for job in job_list if
                    job.date is not None and job.member is not None and job.status_str == HUtils.SupportedStatus.COMPLETED)
 
-    def get_status_counts_from_job_list(self, job_list: "list[Job] | None" = None) -> "dict[str, int]":
+    def get_status_counts_from_job_list(self, job_list: "list[Job] | None" = None) -> dict[str, int]:
         """Return dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING, SUSPENDED, TOTAL."""
         job_list = job_list or []
         result = {

--- a/autosubmit/history/experiment_history.py
+++ b/autosubmit/history/experiment_history.py
@@ -15,6 +15,7 @@
 import os
 import traceback
 from time import time
+from typing import TYPE_CHECKING
 
 import autosubmit.history.database_managers.database_models as Models
 import autosubmit.history.utils as HUtils
@@ -36,6 +37,9 @@ from autosubmit.history.strategies import (
     TwoDimWrapperDistributionStrategy,
 )
 from autosubmit.log.log import Log
+
+if TYPE_CHECKING:
+    from autosubmit.job.job import Job
 
 SECONDS_WAIT_PLATFORM = 60
 
@@ -317,8 +321,28 @@ class ExperimentHistory:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def process_status_changes(self, job_list=None, chunk_unit="NA", chunk_size=0, current_config="", create=False):
-        """ Detect status differences between job_list and current job_data rows, and update. Creates a new run if necessary. """
+    def process_status_changes(self, job_list: "list[Job] | None" = None, chunk_unit: str = "NA", chunk_size: int = 0,
+                               current_config: str = "", create: bool = False,
+                               status_counts: "dict[str, int] | None" = None) -> ExperimentRun | None:
+        """ Detect status differences between job_list and current job_data rows, and update. Creates a new run if necessary.
+
+        :param job_list: the jobs of the experiment as a plain list.
+        :type job_list: list[Job] | None
+        :param chunk_unit: the chunk unit (e.g. month) of the current run.
+        :type chunk_unit: str
+        :param chunk_size: the chunk size of the current run.
+        :type chunk_size: int
+        :param current_config: the experiment configuration as a JSON string.
+        :type current_config: str
+        :param create: whether a new run must be created regardless of changes.
+        :type create: bool
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database, which includes jobs unloaded from memory).
+            When omitted they are computed from ``job_list``.
+        :type status_counts: dict[str, int] | None
+        :return: the current ``ExperimentRun`` or None if the database failed.
+        :rtype: ExperimentRun | None
+        """
         try:
             try:
                 current_experiment_run_dc = self.manager.get_experiment_run_dc_with_max_id()
@@ -334,28 +358,40 @@ class ExperimentHistory:
             if len(update_these_changes) > 0 and not should_create_new_run:
                 self.manager.update_many_job_data_change_status(update_these_changes)
             if should_create_new_run:
-                return self.create_new_experiment_run(chunk_unit, chunk_size, current_config, job_list)
-            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list)
+                return self.create_new_experiment_run(chunk_unit, chunk_size, current_config, job_list,
+                                                      status_counts=status_counts)
+            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list,
+                                                           status_counts=status_counts)
         except Exception as exp:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def _get_built_list_of_changes(self, job_list):
+    def _get_built_list_of_changes(self, job_list: "list[Job]"):
         """ Return: List of (current timestamp, current datetime str, status, rowstatus, id in job_data). One tuple per change. """
         job_data_dcs = self.detect_changes_in_job_list(job_list)
         return [(HUtils.get_current_datetime(), job.status, Models.RowStatus.CHANGED, job._id) for job in job_data_dcs]
 
-    def process_job_list_changes_to_experiment_totals(self, job_list=None):
-        """ Updates current experiment_run row with totals calculated from job_list. """
+    def process_job_list_changes_to_experiment_totals(self, job_list: "list[Job] | None" = None,
+                                                      status_counts: "dict[str, int] | None" = None) -> ExperimentRun | None:
+        """ Updates current experiment_run row with totals calculated from job_list.
+
+        :param job_list: the jobs of the experiment as a plain list.
+        :type job_list: list[Job] | None
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database, which includes jobs unloaded from memory).
+            When omitted they are computed from ``job_list``.
+        :type status_counts: dict[str, int] | None
+        """
         try:
             current_experiment_run_dc = self.manager.get_experiment_run_dc_with_max_id()
-            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list)
+            return self.update_counts_on_experiment_run_dc(current_experiment_run_dc, job_list,
+                                                           status_counts=status_counts)
         except Exception as exp:
             self._log.log(str(exp), traceback.format_exc())
             Log.debug(f'Historical Database error: {str(exp)} {traceback.format_exc()}')
 
-    def should_we_create_a_new_run(self, job_list, changes_count, current_experiment_run_dc, new_chunk_unit,
-                                   new_chunk_size, create=False):
+    def should_we_create_a_new_run(self, job_list: "list[Job]", changes_count: int, current_experiment_run_dc,
+                                   new_chunk_unit: str, new_chunk_size: int, create: bool = False) -> bool:
         if create:
             return True
         elif not create and self.expid[0].lower() != "t":
@@ -372,9 +408,21 @@ class ExperimentHistory:
             return True
         return False
 
-    def update_counts_on_experiment_run_dc(self, experiment_run_dc, job_list=None):
-        """ Return updated row as Models.ExperimentRun. """
-        status_counts = self.get_status_counts_from_job_list(job_list)
+    def update_counts_on_experiment_run_dc(self, experiment_run_dc, job_list: "list[Job] | None" = None,
+                                           status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
+        """ Return updated row as Models.ExperimentRun.
+
+        :param experiment_run_dc: the run to update.
+        :type experiment_run_dc: ExperimentRun
+        :param job_list: the jobs of the experiment as a plain list. Used to
+            compute the counts when ``status_counts`` is not provided.
+        :type job_list: list[Job] | None
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database, which includes jobs unloaded from memory).
+        :type status_counts: dict[str, int] | None
+        """
+        if status_counts is None:
+            status_counts = self.get_status_counts_from_job_list(job_list)
         experiment_run_dc.completed = status_counts[HUtils.SupportedStatus.COMPLETED]
         experiment_run_dc.failed = status_counts[HUtils.SupportedStatus.FAILED]
         experiment_run_dc.queuing = status_counts[HUtils.SupportedStatus.QUEUING]
@@ -391,15 +439,28 @@ class ExperimentHistory:
             return self.manager.update_experiment_run_dc_by_id(current_experiment_run_dc)
         return None
 
-    def create_new_experiment_run(self, chunk_unit="NA", chunk_size=0, current_config="", job_list=None):
-        """ Also writes the finish timestamp of the previous run.  """
+    def create_new_experiment_run(self, chunk_unit: str = "NA", chunk_size: int = 0, current_config: str = "",
+                                  job_list: "list[Job] | None" = None,
+                                  status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
+        """ Also writes the finish timestamp of the previous run.
+
+        :param job_list: the jobs of the experiment as a plain list.
+        :type job_list: list[Job] | None
+        :param status_counts: optional pre-computed status counts (e.g. from the
+            complete jobs database). When omitted they are computed from ``job_list``.
+        :type status_counts: dict[str, int] | None
+        """
         self.finish_current_experiment_run()
         return self._create_new_experiment_run_dc_with_counts(chunk_unit=chunk_unit, chunk_size=chunk_size,
-                                                              current_config=current_config, job_list=job_list)
+                                                              current_config=current_config, job_list=job_list,
+                                                              status_counts=status_counts)
 
-    def _create_new_experiment_run_dc_with_counts(self, chunk_unit, chunk_size, current_config="", job_list=None):
+    def _create_new_experiment_run_dc_with_counts(self, chunk_unit: str, chunk_size: int, current_config: str = "",
+                                                  job_list: "list[Job] | None" = None,
+                                                  status_counts: "dict[str, int] | None" = None) -> ExperimentRun:
         """ Create new experiment_run row and return the new Models.ExperimentRun data class from database. """
-        status_counts = self.get_status_counts_from_job_list(job_list)
+        if status_counts is None:
+            status_counts = self.get_status_counts_from_job_list(job_list)
         experiment_run_dc = ExperimentRun(0,
                                           chunk_unit=chunk_unit,
                                           chunk_size=chunk_size,
@@ -414,7 +475,7 @@ class ExperimentHistory:
                                           suspended=status_counts[HUtils.SupportedStatus.SUSPENDED])
         return self.manager.register_experiment_run_dc(experiment_run_dc)
 
-    def detect_changes_in_job_list(self, job_list):
+    def detect_changes_in_job_list(self, job_list: "list[Job]"):
         """ Detect changes in job_list compared to the current contents of job_data table. Returns a list of JobData data classes where the status of each item is the new status."""
         job_name_to_job = {str(job.name): job for job in job_list}
         current_job_data_dcs = self.manager.get_all_last_job_data_dcs()
@@ -450,16 +511,15 @@ class ExperimentHistory:
         else:
             return max_counter
 
-    def _get_date_member_completed_count(self, job_list):
+    def _get_date_member_completed_count(self, job_list: "list[Job] | None" = None) -> int:
         """ Each item in the job_list must have attributes: date, member, status_str. """
         job_list = job_list if job_list else []
         return sum(1 for job in job_list if
                    job.date is not None and job.member is not None and job.status_str == HUtils.SupportedStatus.COMPLETED)
 
-    def get_status_counts_from_job_list(self, job_list):
-        """
-        Return dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING, SUSPENDED, TOTAL.
-        """
+    def get_status_counts_from_job_list(self, job_list: "list[Job] | None" = None) -> "dict[str, int]":
+        """Return dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING, SUSPENDED, TOTAL."""
+        job_list = job_list or []
         result = {
             HUtils.SupportedStatus.COMPLETED: 0,
             HUtils.SupportedStatus.FAILED: 0,
@@ -467,11 +527,7 @@ class ExperimentHistory:
             HUtils.SupportedStatus.SUBMITTED: 0,
             HUtils.SupportedStatus.RUNNING: 0,
             HUtils.SupportedStatus.SUSPENDED: 0,
-            "TOTAL": 0
         }
-
-        if not job_list:
-            job_list = []
 
         for job in job_list:
             if job.status_str in result:
@@ -515,7 +571,8 @@ def get_historical_database(expid, job_list, as_conf):
         exp_history.initialize_database()
         run_dc = exp_history.process_status_changes(job_list.get_job_list(), as_conf.get_chunk_size_unit(),
                                                     as_conf.get_chunk_size(),
-                                                    current_config=as_conf.get_full_config_as_json())
+                                                    current_config=as_conf.get_full_config_as_json(),
+                                                    status_counts=job_list.get_status_counts())
         job_list.run_id = run_dc.run_id if run_dc else None
         # TODO: Restore database backup after 4.2.0 joblist? https://github.com/BSC-ES/autosubmit/issues/3179
         # Autosubmit.database_backup(expid)

--- a/autosubmit/job/job_list.py
+++ b/autosubmit/job/job_list.py
@@ -2262,6 +2262,23 @@ class JobList:
         """
         return self.job_list
 
+    def get_status_counts(self) -> dict[str, int]:
+        """Return status counts of ALL jobs from the database.
+
+        The counts are computed from the persisted ``jobs`` table, which keeps
+        every job (including finished jobs unloaded from memory), so they are
+        complete. Keys follow the same convention as
+        ``ExperimentHistory.get_status_counts_from_job_list``
+
+        :return: dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING,
+            SUSPENDED and TOTAL.
+        :rtype: dict[str, int]
+        """
+        statuses = ["COMPLETED", "FAILED", "QUEUING", "SUBMITTED", "RUNNING", "SUSPENDED"]
+        counts = {status: self.dbmanager.count_where("jobs", {"status": status}) for status in statuses}
+        counts["TOTAL"] = self.dbmanager.count("jobs")
+        return counts
+
     def get_date_format(self):
         date_format = ''
         for date in self.get_date_list():

--- a/autosubmit/job/job_list.py
+++ b/autosubmit/job/job_list.py
@@ -2272,11 +2272,7 @@ class JobList:
         The counts are computed from the persisted ``jobs`` table, which keeps
         every job (including finished jobs unloaded from memory), so they are
         complete. Keys follow the same convention as
-        ``ExperimentHistory.get_status_counts_from_job_list``
-
-        :return: dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING,
-            SUSPENDED and TOTAL.
-        :rtype: dict[str, int]
+        ``ExperimentHistory.get_status_counts_from_job_list``.
         """
         statuses = ["COMPLETED", "FAILED", "QUEUING", "SUBMITTED", "RUNNING", "SUSPENDED"]
         counts = {status: self.dbmanager.count_where("jobs", {"status": status}) for status in statuses}

--- a/autosubmit/job/job_list.py
+++ b/autosubmit/job/job_list.py
@@ -2266,6 +2266,23 @@ class JobList:
         """
         return self.job_list
 
+    def get_status_counts(self) -> dict[str, int]:
+        """Return status counts of ALL jobs from the database.
+
+        The counts are computed from the persisted ``jobs`` table, which keeps
+        every job (including finished jobs unloaded from memory), so they are
+        complete. Keys follow the same convention as
+        ``ExperimentHistory.get_status_counts_from_job_list``
+
+        :return: dict with keys COMPLETED, FAILED, QUEUING, SUBMITTED, RUNNING,
+            SUSPENDED and TOTAL.
+        :rtype: dict[str, int]
+        """
+        statuses = ["COMPLETED", "FAILED", "QUEUING", "SUBMITTED", "RUNNING", "SUSPENDED"]
+        counts = {status: self.dbmanager.count_where("jobs", {"status": status}) for status in statuses}
+        counts["TOTAL"] = self.dbmanager.count("jobs")
+        return counts
+
     def get_date_format(self):
         date_format = ''
         for date in self.get_date_list():
@@ -4305,6 +4322,7 @@ def load_job_list(
     submitter=None,
     check_failed_jobs=False,
     run_mode=False,
+    run_members: list[str] | None = None,
 ) -> JobList:
     """Load the JobList for a given experiment.
 
@@ -4316,12 +4334,17 @@ def load_job_list(
     :param submitter: submitter to be used
     :param check_failed_jobs: whether to check failed jobs or not
     :param run_mode: whether to load the job list in run mode or not
+    :param run_members: optional list of members to restrict the run to. Set
+        before loading the job graph so that only the allowed members are
+        loaded into memory and therefore submitted.
     :return: JobList object
     """
     rerun = as_conf.get_rerun()
     job_list = JobList(
         expid, as_conf, YAMLParserFactory(), run_mode=run_mode, submitter=submitter
     )
+    if run_members:
+        job_list.run_members = run_members
     date_list = as_conf.get_date_list()
     date_format = ""
     if as_conf.get_chunk_size_unit() == ChunkUnit.HOUR:

--- a/autosubmit/workflow/manage.py
+++ b/autosubmit/workflow/manage.py
@@ -163,6 +163,8 @@ def _prepare_run(
 
     if recover:
         Log.info("Recovering job_list")
+    # Check if the user has launch autosubmit run with -rom option.
+    allowed_members = AutosubmitHelper.get_allowed_members(run_only_members, as_conf)
     try:
         job_list = load_job_list(
             expid,
@@ -172,6 +174,7 @@ def _prepare_run(
             submitter=submitter,
             check_failed_jobs=True,
             run_mode=False,
+            run_members=allowed_members,
         )
 
     except OSError as e:
@@ -220,12 +223,10 @@ def _prepare_run(
     job_list.save_jobs()
     as_conf.save()
     # Before starting main loop, setup historical database tables and main information
-    # Check if the user has launch autosubmit run with -rom option ( previously named -rm )
-    allowed_members = AutosubmitHelper.get_allowed_members(run_only_members, as_conf)
+    # Check if the user has launch autosubmit run with -rom option ( previously named -rm ).
+    # run_members was already applied in load_job_list before generating the
+    # graph, so only report the restriction here.
     if allowed_members:
-        # Set allowed members after checks have been performed.
-        # This triggers the setter and main logic of the -rm feature.
-        job_list.run_members = allowed_members
         Log.result(
             f"Only jobs with member value in {str(allowed_members)} or no member will be allowed in this "
             f"run. Also, those jobs already SUBMITTED, QUEUING, or RUNNING will be allowed to complete and"
@@ -583,7 +584,7 @@ def _process_historical_data_iteration(job_list, job_changes_tracker, expid):
     exp_history = ExperimentHistory(expid)
     if len(job_changes_tracker) > 0:
         exp_history.process_job_list_changes_to_experiment_totals(
-            job_list.get_job_list()
+            job_list.get_job_list(), status_counts=job_list.get_status_counts()
         )
         database_backup(expid)
 

--- a/autosubmit/workflow/manage.py
+++ b/autosubmit/workflow/manage.py
@@ -163,7 +163,7 @@ def _prepare_run(
 
     if recover:
         Log.info("Recovering job_list")
-    # Check if the user has launch autosubmit run with -rom option.
+    # Check if the user launched autosubmit run with -rom option.
     allowed_members = AutosubmitHelper.get_allowed_members(run_only_members, as_conf)
     try:
         job_list = load_job_list(
@@ -223,7 +223,7 @@ def _prepare_run(
     job_list.save_jobs()
     as_conf.save()
     # Before starting main loop, setup historical database tables and main information
-    # Check if the user has launch autosubmit run with -rom option ( previously named -rm ).
+    # Check if the user launched autosubmit run with -rom option ( previously named -rm ).
     # run_members was already applied in load_job_list before generating the
     # graph, so only report the restriction here.
     if allowed_members:

--- a/test/integration/commands/run/test_run_local_scenarios.py
+++ b/test/integration/commands/run/test_run_local_scenarios.py
@@ -14,7 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+import sqlite3
 import sys
+from datetime import datetime, timedelta
 from multiprocessing import Process
 from pathlib import Path
 from textwrap import dedent
@@ -33,8 +35,44 @@ from test.integration.commands.run.conftest import (
     _assert_files_recovered,
     _check_db_fields,
     _check_files_recovered,
+    run_in_thread,
 )
 from test.integration.test_utils.misc import wait_locker
+
+
+def _job_data_db(expid: str) -> Path:
+    """Return the path to an experiment historical database file."""
+    return Path(BasicConfig.LOCAL_ROOT_DIR) / 'metadata/data' / f'job_data_{expid}.db'
+
+
+def _get_last_run_row(expid: str) -> sqlite3.Row:
+    """Return the latest ``experiment_run`` row of an experiment historical database."""
+    with sqlite3.connect(_job_data_db(expid)) as conn:
+        conn.row_factory = sqlite3.Row
+        return conn.execute("SELECT * FROM experiment_run ORDER BY run_id DESC LIMIT 1").fetchone()
+
+
+def _count_job_data_entries(expid: str) -> int:
+    """Return the number of rows in the ``job_data`` table of an experiment."""
+    with sqlite3.connect(_job_data_db(expid)) as conn:
+        return conn.execute("SELECT COUNT(*) FROM job_data").fetchone()[0]
+
+
+def _bounded_poll_sleep(max_polls: int = 100):
+    """Return a ``sleep`` replacement that raises ``TimeoutError`` after ``max_polls`` calls.
+
+    Used to bound the ``handle_start_after`` poll loop in the tests: if the
+    monitored experiment never satisfies the completion condition, the poll
+    stops after ``max_polls`` iterations and the running thread finishes.
+    """
+    state = {"polls": 0}
+
+    def _sleep(_):
+        state["polls"] += 1
+        if state["polls"] > max_polls:
+            raise TimeoutError("start_after monitor never triggered")
+
+    return _sleep
 
 # -- Tests
 
@@ -66,7 +104,7 @@ from test.integration.test_utils.misc import wait_locker
             PLATFORM: LOCAL
             RUNNING: chunk
             wallclock: 00:01
-            retrials: 2  
+            retrials: 2
 
     """), (2 + 1) * 2, "FAILED", "simple"),  # No wrappers, simple type
 
@@ -91,7 +129,7 @@ from test.integration.test_utils.misc import wait_locker
         CHUNKSIZE: '1'
         CHUNKUNIT: 'month'
         DATELIST: "20000101"
-        
+
     JOBS:
         job:
             SCRIPT: |
@@ -181,7 +219,7 @@ def test_run_uninterrupted(
                 PLATFORM: LOCAL
                 RUNNING: chunk
                 wallclock: 00:01
-                retrials: 2  
+                retrials: 2
 
         """), (2 + 1) * 2, "FAILED", "simple"),  # No wrappers, simple type
 ], ids=["Success", "Failure"])
@@ -736,6 +774,248 @@ def test_run_uninterrupted_get_call_options(
         pytest.fail(e_msg + str(e))
 
 
+@pytest.mark.timeout(35)
+@pytest.mark.parametrize("run_mode, members, num_chunks, expected_db_entries", [
+    ("start_time", None, 1, 1),
+    ("start_time", None, 3, 3),
+    ("start_after", None, 1, 1),
+    ("start_after", None, 3, 3),
+    ("run_only_members", "fc0 fc1", 1, 1),
+    ("run_only_members", "fc0 fc1", 3, 3),
+], ids=[
+    "start_time-1chunk",
+    "start_time-3chunks",
+    "start_after-1chunk",
+    "start_after-3chunks",
+    "run_only_members-1chunk",
+    "run_only_members-3chunks",
+])
+def test_run_with_run_modes(
+        autosubmit_exp,
+        general_data,
+        prepare_scratch,
+        run_mode: str,
+        members: str | None,
+        num_chunks: int,
+        expected_db_entries: int,
+        monkeypatch,
+):
+    """Test the different ``autosubmit run`` trigger/filter flags.
+
+    - ``-st`` / ``--start_time``: the run waits until the given time.
+    - ``-sa`` / ``--start_after``: the run starts when the given experiment completes.
+    - ``-rom`` / ``--run_only_members``: only the given members are submitted.
+
+    Each mode is exercised with 1- and 3-chunk workflows so the run-totals and
+    member-filtering logic is covered for different job counts.
+    """
+    yaml = YAML(typ='rt')
+    jobs_data = dedent(f"""\
+    EXPERIMENT:
+        NUMCHUNKS: '{num_chunks}'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+                sleep 1
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+    experiment_data = yaml.load(jobs_data)
+    if members:
+        experiment_data["EXPERIMENT"]["MEMBERS"] = members
+
+    as_exp = autosubmit_exp(experiment_data=general_data | experiment_data, include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp.expid)
+    as_exp.as_conf.set_last_as_command('run')
+
+    if run_mode == "start_time":
+        monkeypatch.setattr("autosubmit.helpers.autosubmit_helper.sleep", lambda _: None)
+        start_time = (datetime.now() + timedelta(seconds=3)).strftime("%Y-%m-%d %H:%M:%S")
+        exit_code = as_exp.autosubmit.run_experiment(expid=as_exp.expid, start_time=start_time)
+        _assert_exit_code("COMPLETED", exit_code)
+    elif run_mode == "run_only_members":
+        exit_code = as_exp.autosubmit.run_experiment(expid=as_exp.expid, run_only_members="fc0")
+        _assert_exit_code("COMPLETED", exit_code)
+    elif run_mode == "start_after":
+        # Experiment A finishes first; experiment B is launched waiting for A's
+        # completion via `start_after=A`.
+        as_exp_a = autosubmit_exp(
+            experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+        prepare_scratch(expid=as_exp_a.expid)
+        as_exp_a.as_conf.set_last_as_command('run')
+        exit_code_a = as_exp_a.autosubmit.run_experiment(expid=as_exp_a.expid)
+        _assert_exit_code("COMPLETED", exit_code_a)
+        # Speed up the `handle_start_after` poll (sleeps 60s per iteration) and
+        # bound it so the thread does not leak if B never starts.
+        monkeypatch.setattr("autosubmit.helpers.autosubmit_helper.sleep", _bounded_poll_sleep())
+        # Avoid hanging the test if B can't start after A finishes
+        thread, result, _ = run_in_thread(
+            as_exp.autosubmit.run_experiment, expid=as_exp.expid, start_after=as_exp_a.expid)
+        thread.join(timeout=15)
+        assert not thread.is_alive(), "Experiment B never started after experiment A finished"
+        assert result["exception"] is None
+        exit_code = result["exit_code"]
+        _assert_exit_code("COMPLETED", exit_code)
+        last_run_a = _get_last_run_row(as_exp_a.expid)
+        assert last_run_a is not None
+        assert last_run_a["finish"] > 0
+        assert last_run_a["total"] > 0
+        assert last_run_a["total"] == last_run_a["completed"]
+    else:
+        raise AssertionError(f"Unknown run_mode: {run_mode}")
+
+    # Check and display results
+    run_tmpdir = Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR)
+    db_check_list = _check_db_fields(run_tmpdir, expected_db_entries, as_exp.expid)
+    _assert_db_fields(db_check_list)
+
+
+@pytest.mark.parametrize("scenario", ["failed_job", "not_completed"])
+def test_start_after_does_not_start(
+        autosubmit_exp,
+        general_data,
+        prepare_scratch,
+        scenario: str,
+        monkeypatch,
+):
+    """B must NOT start when experiment A did not complete all its jobs.
+
+    ``handle_start_after`` only triggers once A's run is finished
+    (``finish > 0``) and all its jobs reached a terminal state
+    (``total == completed + suspended``). If A has a failed job, or it was
+    interrupted before completing, B must keep waiting.
+    """
+    yaml = YAML(typ='rt')
+    if scenario == "failed_job":
+        jobs_data = dedent("""\
+        EXPERIMENT:
+            NUMCHUNKS: '1'
+        JOBS:
+            job:
+                SCRIPT: |
+                    d_echo "Hello World with id=FAILED"
+                PLATFORM: LOCAL
+                RUNNING: chunk
+                wallclock: 00:01
+                retrials: 1
+        """)
+    else:  # not_completed
+        # job2 depends on job1. job1 sleeps long enough so that job2 never runs
+        # before the run is interrupted.
+        jobs_data = dedent("""\
+        EXPERIMENT:
+            NUMCHUNKS: '1'
+        JOBS:
+            job:
+                SCRIPT: |
+                    sleep 60
+                PLATFORM: LOCAL
+                RUNNING: chunk
+                wallclock: 00:05
+            job2:
+                SCRIPT: |
+                    echo "Hello World with id=NOT_RUN"
+                DEPENDENCIES:
+                    job:
+                PLATFORM: LOCAL
+                RUNNING: chunk
+                wallclock: 00:01
+        """)
+
+    as_exp_a = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp_a.expid)
+    as_exp_a.as_conf.set_last_as_command('run')
+
+    if scenario == "failed_job":
+        exit_code_a = as_exp_a.autosubmit.run_experiment(expid=as_exp_a.expid)
+        _assert_exit_code("FAILED", exit_code_a)
+    else:  # not_completed
+        # Run A in a child process and interrupt it while job1 is still running,
+        # so job2 (dependent on job1) never runs. `Autosubmit.stop` cannot be
+        # used here: it matches processes by their `autosubmit run <expid>`
+        # command line, which does not apply to a Python-call child process.
+        exp_path = Path(BasicConfig.LOCAL_ROOT_DIR, as_exp_a.expid)
+        lock_file = exp_path / BasicConfig.LOCAL_TMP_DIR / 'autosubmit.lock'
+        process = Process(target=as_exp_a.autosubmit.run_experiment, args=(as_exp_a.expid,))
+        process.start()
+        wait_locker(lock_file, expect_locked=True, timeout=60)
+        process.terminate()
+        process.join(timeout=30)
+        if process.is_alive():
+            process.kill()
+            process.join()
+        wait_locker(lock_file, expect_locked=False, timeout=60)
+
+    # A's run must not be finalized: `finish` is only set on a successful run,
+    # which is why B can never satisfy the start_after condition.
+    last_run_a = _get_last_run_row(as_exp_a.expid)
+    assert last_run_a is not None
+    assert last_run_a["finish"] == 0
+    if scenario == "not_completed":
+        assert last_run_a["completed"] < last_run_a["total"]
+
+    # B waits for A and must never start.
+    as_exp_b = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp_b.expid)
+    as_exp_b.as_conf.set_last_as_command('run')
+    # Speed up and bound the `handle_start_after` poll so the thread finishes.
+    monkeypatch.setattr("autosubmit.helpers.autosubmit_helper.sleep", _bounded_poll_sleep())
+    thread, result, _ = run_in_thread(
+        as_exp_b.autosubmit.run_experiment, expid=as_exp_b.expid, start_after=as_exp_a.expid)
+    thread.join(timeout=15)
+    # B never started: its run did not complete and no job was submitted.
+    assert result["exception"] is not None, "B started even though A did not complete all its jobs"
+    assert _count_job_data_entries(as_exp_b.expid) == 0
+
+
+def test_run_only_members_invalid_member(autosubmit_exp, general_data, prepare_scratch):
+    """An invalid member in ``-rom`` must fail before the run starts."""
+    yaml = YAML(typ='rt')
+    jobs_data = dedent("""\
+    EXPERIMENT:
+        NUMCHUNKS: '1'
+        MEMBERS: 'fc0 fc1'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+    as_exp = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp.expid)
+    as_exp.as_conf.set_last_as_command('run')
+
+    with pytest.raises(AutosubmitCritical, match="do not exist"):
+        as_exp.autosubmit.run_experiment(expid=as_exp.expid, run_only_members="nonexistent")
+
+
+def test_start_after_inexistent_experiment(autosubmit_exp, general_data, prepare_scratch):
+    """``start_after`` pointing to a non-existent experiment must not block the run."""
+    yaml = YAML(typ='rt')
+    jobs_data = dedent("""\
+    EXPERIMENT:
+        NUMCHUNKS: '1'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+    as_exp = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp.expid)
+    as_exp.as_conf.set_last_as_command('run')
+
+    exit_code = as_exp.autosubmit.run_experiment(expid=as_exp.expid, start_after="a000")
+
+    _assert_exit_code("COMPLETED", exit_code)
+
+
 @pytest.mark.parametrize("jobs_data, expected_db_entries, final_status, wrapper_type", [
     # Failure
     (dedent("""\
@@ -750,7 +1030,7 @@ def test_run_uninterrupted_get_call_options(
             PLATFORM: local
             RUNNING: chunk
             wallclock: 00:01
-            retrials: 1  
+            retrials: 1
     """), (2 + 1) * 2, "FAILED", "simple"),  # No wrappers, simple type
 ], ids=["Force Failure -> Correct it -> Completed"])
 def test_run_failed_set_to_ready_on_new_run(

--- a/test/integration/commands/run/test_run_local_scenarios.py
+++ b/test/integration/commands/run/test_run_local_scenarios.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta
 from multiprocessing import Process
 from pathlib import Path
 from textwrap import dedent
+from threading import Event
 
 import pytest
 from ruamel.yaml import YAML
@@ -1000,6 +1001,121 @@ def test_run_with_run_modes(
     run_tmpdir = Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR)
     db_check_list = _check_db_fields(run_tmpdir, expected_db_entries, as_exp.expid)
     _assert_db_fields(db_check_list)
+
+
+def _blocking_poll_sleep(release_event: Event, polling_started: Event, max_polls: int = 100, timeout: int = 60):
+    """Return a ``sleep`` replacement that blocks until ``release_event`` is set."""
+    state = {"polls": 0}
+
+    def _sleep(_):
+        state["polls"] += 1
+        if state["polls"] > max_polls:
+            raise TimeoutError("start_after monitor never triggered")
+        polling_started.set()
+        if not release_event.wait(timeout=timeout):
+            raise TimeoutError("start_after monitor never released")
+
+    return _sleep
+
+
+def test_start_after_concurrent_launch(
+        autosubmit_exp,
+        general_data,
+        prepare_scratch,
+        monkeypatch,
+):
+    """B launched at the same time as A must start once A completes."""
+    yaml = YAML(typ='rt')
+    jobs_data = dedent("""\
+    EXPERIMENT:
+        NUMCHUNKS: '1'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+                sleep 1
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+
+    # Create both experiments. A completes first; B waits for A via start_after.
+    as_exp_a = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp_a.expid)
+    as_exp_a.as_conf.set_last_as_command('run')
+    as_exp_b = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp_b.expid)
+    as_exp_b.as_conf.set_last_as_command('run')
+
+    release_event = Event()
+    polling_started = Event()
+    monkeypatch.setattr("autosubmit.helpers.autosubmit_helper.sleep",
+                        _blocking_poll_sleep(release_event, polling_started))
+
+    # Start B first: it starts monitoring A before A is even launched.
+    thread_b, result_b, _ = run_in_thread(
+        run, expid=as_exp_b.expid, start_after=as_exp_a.expid)
+    assert polling_started.wait(timeout=60), "B never started polling A's run"
+
+    # Now launch A and let it finish while B keeps waiting on the release event.
+    process_a = Process(target=run, args=(as_exp_a.expid,))
+    process_a.start()
+    process_a.join(timeout=60)
+    assert not process_a.is_alive(), "Experiment A did not finish"
+    assert process_a.exitcode == 0
+
+    # Release B: it must now see A completed and start its own run.
+    release_event.set()
+    thread_b.join(timeout=60)
+    assert not thread_b.is_alive(), "Experiment B never started after experiment A finished"
+    assert result_b["exception"] is None, f"Experiment B failed: {result_b['exception']}"
+    _assert_exit_code("COMPLETED", result_b["exit_code"])
+
+    # A's run must be finalized with non-zero totals
+    last_run_a = _get_last_run_row(as_exp_a.expid)
+    assert last_run_a is not None
+    assert last_run_a["finish"] > 0
+    assert last_run_a["total"] > 0
+    assert last_run_a["total"] == last_run_a["completed"]
+
+
+def test_start_after_monitors_experiment_without_runs_yet(
+        autosubmit_exp,
+        general_data,
+        prepare_scratch,
+        monkeypatch,
+):
+    """B must keep polling (not crash) when A exists but has no run row yet."""
+    yaml = YAML(typ='rt')
+    jobs_data = dedent("""\
+    EXPERIMENT:
+        NUMCHUNKS: '1'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+                sleep 1
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+
+    # A is created but never run: its experiment_run table stays empty.
+    as_exp_a = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=False)
+    prepare_scratch(expid=as_exp_a.expid)
+    as_exp_a.as_conf.set_last_as_command('run')
+    as_exp_b = autosubmit_exp(experiment_data=general_data | yaml.load(jobs_data), include_jobs=False, create=True)
+    prepare_scratch(expid=as_exp_b.expid)
+    as_exp_b.as_conf.set_last_as_command('run')
+
+    monkeypatch.setattr("autosubmit.helpers.autosubmit_helper.sleep", _bounded_poll_sleep(max_polls=5))
+    thread_b, result_b, _ = run_in_thread(
+        run, expid=as_exp_b.expid, start_after=as_exp_a.expid)
+    thread_b.join(timeout=5)
+    assert not thread_b.is_alive()
+    assert result_b["exception"] is not None
+    assert "start_after monitor never triggered" in str(result_b["exception"]), (
+        f"B crashed instead of waiting for A's run row: {result_b['exception']!r}")
 
 
 @pytest.mark.parametrize("scenario", ["failed_job", "not_completed"])

--- a/test/integration/commands/run/test_run_local_scenarios.py
+++ b/test/integration/commands/run/test_run_local_scenarios.py
@@ -14,7 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+import sqlite3
 import sys
+from datetime import datetime, timedelta
 from multiprocessing import Process
 from pathlib import Path
 from textwrap import dedent
@@ -35,8 +37,47 @@ from test.integration.commands.run.conftest import (
     _assert_files_recovered,
     _check_db_fields,
     _check_files_recovered,
+    run_in_thread,
 )
 from test.integration.test_utils.misc import wait_locker
+
+
+def _job_data_db(expid: str) -> Path:
+    """Return the path to an experiment historical database file."""
+    return Path(BasicConfig.LOCAL_ROOT_DIR) / "metadata/data" / f"job_data_{expid}.db"
+
+
+def _get_last_run_row(expid: str) -> sqlite3.Row:
+    """Return the latest ``experiment_run`` row of an experiment historical database."""
+    with sqlite3.connect(_job_data_db(expid)) as conn:
+        conn.row_factory = sqlite3.Row
+        return conn.execute(
+            "SELECT * FROM experiment_run ORDER BY run_id DESC LIMIT 1"
+        ).fetchone()
+
+
+def _count_job_data_entries(expid: str) -> int:
+    """Return the number of rows in the ``job_data`` table of an experiment."""
+    with sqlite3.connect(_job_data_db(expid)) as conn:
+        return conn.execute("SELECT COUNT(*) FROM job_data").fetchone()[0]
+
+
+def _bounded_poll_sleep(max_polls: int = 100):
+    """Return a ``sleep`` replacement that raises ``TimeoutError`` after ``max_polls`` calls.
+
+    Used to bound the ``handle_start_after`` poll loop in the tests: if the
+    monitored experiment never satisfies the completion condition, the poll
+    stops after ``max_polls`` iterations and the running thread finishes.
+    """
+    state = {"polls": 0}
+
+    def _sleep(_):
+        state["polls"] += 1
+        if state["polls"] > max_polls:
+            raise TimeoutError("start_after monitor never triggered")
+
+    return _sleep
+
 
 # -- Tests
 
@@ -839,6 +880,291 @@ def test_run_uninterrupted_get_call_options(
         _assert_files_recovered(files_check_list)
     except AssertionError as e:
         pytest.fail(e_msg + str(e))
+
+
+@pytest.mark.timeout(35)
+@pytest.mark.parametrize(
+    "run_mode, members, num_chunks, expected_db_entries",
+    [
+        ("start_time", None, 1, 1),
+        ("start_time", None, 3, 3),
+        ("start_after", None, 1, 1),
+        ("start_after", None, 3, 3),
+        ("run_only_members", "fc0 fc1", 1, 1),
+        ("run_only_members", "fc0 fc1", 3, 3),
+    ],
+    ids=[
+        "start_time-1chunk",
+        "start_time-3chunks",
+        "start_after-1chunk",
+        "start_after-3chunks",
+        "run_only_members-1chunk",
+        "run_only_members-3chunks",
+    ],
+)
+def test_run_with_run_modes(
+    autosubmit_exp,
+    general_data,
+    prepare_scratch,
+    run_mode: str,
+    members: str | None,
+    num_chunks: int,
+    expected_db_entries: int,
+    monkeypatch,
+):
+    """Test the different ``autosubmit run`` trigger/filter flags.
+
+    - ``-st`` / ``--start_time``: the run waits until the given time.
+    - ``-sa`` / ``--start_after``: the run starts when the given experiment completes.
+    - ``-rom`` / ``--run_only_members``: only the given members are submitted.
+
+    Each mode is exercised with 1- and 3-chunk workflows so the run-totals and
+    member-filtering logic is covered for different job counts.
+    """
+    yaml = YAML(typ="rt")
+    jobs_data = dedent(
+        f"""\
+    EXPERIMENT:
+        NUMCHUNKS: '{num_chunks}'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+                sleep 1
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """
+    )
+    experiment_data = yaml.load(jobs_data)
+    if members:
+        experiment_data["EXPERIMENT"]["MEMBERS"] = members
+
+    as_exp = autosubmit_exp(
+        experiment_data=general_data | experiment_data,
+        include_jobs=False,
+        create=True,
+    )
+    prepare_scratch(expid=as_exp.expid)
+    as_exp.as_conf.set_last_as_command("run")
+
+    if run_mode == "start_time":
+        monkeypatch.setattr(
+            "autosubmit.helpers.autosubmit_helper.sleep", lambda _: None
+        )
+        start_time = (datetime.now() + timedelta(seconds=3)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        exit_code = run(expid=as_exp.expid, start_time=start_time)
+        _assert_exit_code("COMPLETED", exit_code)
+    elif run_mode == "run_only_members":
+        exit_code = run(expid=as_exp.expid, run_only_members="fc0")
+        _assert_exit_code("COMPLETED", exit_code)
+    elif run_mode == "start_after":
+        # Experiment A finishes first; experiment B is launched waiting for A's
+        # completion via `start_after=A`.
+        as_exp_a = autosubmit_exp(
+            experiment_data=general_data | yaml.load(jobs_data),
+            include_jobs=False,
+            create=True,
+        )
+        prepare_scratch(expid=as_exp_a.expid)
+        as_exp_a.as_conf.set_last_as_command("run")
+        exit_code_a = run(expid=as_exp_a.expid)
+        _assert_exit_code("COMPLETED", exit_code_a)
+        # Speed up the `handle_start_after` poll (sleeps 60s per iteration) and
+        # bound it so the thread does not leak if B never starts.
+        monkeypatch.setattr(
+            "autosubmit.helpers.autosubmit_helper.sleep", _bounded_poll_sleep()
+        )
+        # Avoid hanging the test if B can't start after A finishes
+        thread, result, _ = run_in_thread(
+            run, expid=as_exp.expid, start_after=as_exp_a.expid
+        )
+        thread.join(timeout=15)
+        assert (
+            not thread.is_alive()
+        ), "Experiment B never started after experiment A finished"
+        assert result["exception"] is None
+        exit_code = result["exit_code"]
+        _assert_exit_code("COMPLETED", exit_code)
+        last_run_a = _get_last_run_row(as_exp_a.expid)
+        assert last_run_a is not None
+        assert last_run_a["finish"] > 0
+        assert last_run_a["total"] > 0
+        assert last_run_a["total"] == last_run_a["completed"]
+    else:
+        raise AssertionError(f"Unknown run_mode: {run_mode}")
+
+    # Check and display results
+    run_tmpdir = Path(as_exp.as_conf.basic_config.LOCAL_ROOT_DIR)
+    db_check_list = _check_db_fields(run_tmpdir, expected_db_entries, as_exp.expid)
+    _assert_db_fields(db_check_list)
+
+
+@pytest.mark.parametrize("scenario", ["failed_job", "not_completed"])
+def test_start_after_does_not_start(
+    autosubmit_exp,
+    general_data,
+    prepare_scratch,
+    scenario: str,
+    monkeypatch,
+):
+    """B must NOT start when experiment A did not complete all its jobs.
+
+    ``handle_start_after`` only triggers once A's run is finished
+    (``finish > 0``) and all its jobs reached a terminal state
+    (``total == completed + suspended``). If A has a failed job, or it was
+    interrupted before completing, B must keep waiting.
+    """
+    yaml = YAML(typ="rt")
+    if scenario == "failed_job":
+        jobs_data = dedent("""\
+        EXPERIMENT:
+            NUMCHUNKS: '1'
+        JOBS:
+            job:
+                SCRIPT: |
+                    d_echo "Hello World with id=FAILED"
+                PLATFORM: LOCAL
+                RUNNING: chunk
+                wallclock: 00:01
+                retrials: 1
+        """)
+    else:  # not_completed
+        # job2 depends on job1. job1 sleeps long enough so that job2 never runs
+        # before the run is interrupted.
+        jobs_data = dedent("""\
+        EXPERIMENT:
+            NUMCHUNKS: '1'
+        JOBS:
+            job:
+                SCRIPT: |
+                    sleep 60
+                PLATFORM: LOCAL
+                RUNNING: chunk
+                wallclock: 00:05
+            job2:
+                SCRIPT: |
+                    echo "Hello World with id=NOT_RUN"
+                DEPENDENCIES:
+                    job:
+                PLATFORM: LOCAL
+                RUNNING: chunk
+                wallclock: 00:01
+        """)
+
+    as_exp_a = autosubmit_exp(
+        experiment_data=general_data | yaml.load(jobs_data),
+        include_jobs=False,
+        create=True,
+    )
+    prepare_scratch(expid=as_exp_a.expid)
+    as_exp_a.as_conf.set_last_as_command("run")
+
+    if scenario == "failed_job":
+        exit_code_a = run(expid=as_exp_a.expid)
+        _assert_exit_code("FAILED", exit_code_a)
+    else:  # not_completed
+        # Run A in a child process and interrupt it while job1 is still running,
+        # so job2 (dependent on job1) never runs. `stop` cannot be used here: it
+        # matches processes by their `autosubmit run <expid>` command line,
+        # which does not apply to a Python-call child process.
+        exp_path = Path(BasicConfig.LOCAL_ROOT_DIR, as_exp_a.expid)
+        lock_file = exp_path / BasicConfig.LOCAL_TMP_DIR / "autosubmit.lock"
+        process = Process(target=run, args=(as_exp_a.expid,))
+        process.start()
+        wait_locker(lock_file, expect_locked=True, timeout=60)
+        process.terminate()
+        process.join(timeout=30)
+        if process.is_alive():
+            process.kill()
+            process.join()
+        wait_locker(lock_file, expect_locked=False, timeout=60)
+
+    # A's run must not be finalized: `finish` is only set on a successful run,
+    # which is why B can never satisfy the start_after condition.
+    last_run_a = _get_last_run_row(as_exp_a.expid)
+    assert last_run_a is not None
+    assert last_run_a["finish"] == 0
+    if scenario == "not_completed":
+        assert last_run_a["completed"] < last_run_a["total"]
+
+    # B waits for A and must never start.
+    as_exp_b = autosubmit_exp(
+        experiment_data=general_data | yaml.load(jobs_data),
+        include_jobs=False,
+        create=True,
+    )
+    prepare_scratch(expid=as_exp_b.expid)
+    as_exp_b.as_conf.set_last_as_command("run")
+    # Speed up and bound the `handle_start_after` poll so the thread finishes.
+    monkeypatch.setattr(
+        "autosubmit.helpers.autosubmit_helper.sleep", _bounded_poll_sleep()
+    )
+    thread, result, _ = run_in_thread(
+        run, expid=as_exp_b.expid, start_after=as_exp_a.expid
+    )
+    thread.join(timeout=15)
+    # B never started: its run did not complete and no job was submitted.
+    assert (
+        result["exception"] is not None
+    ), "B started even though A did not complete all its jobs"
+    assert _count_job_data_entries(as_exp_b.expid) == 0
+
+
+def test_run_only_members_invalid_member(autosubmit_exp, general_data, prepare_scratch):
+    """An invalid member in ``-rom`` must fail before the run starts."""
+    yaml = YAML(typ="rt")
+    jobs_data = dedent("""\
+    EXPERIMENT:
+        NUMCHUNKS: '1'
+        MEMBERS: 'fc0 fc1'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+    as_exp = autosubmit_exp(
+        experiment_data=general_data | yaml.load(jobs_data),
+        include_jobs=False,
+        create=True,
+    )
+    prepare_scratch(expid=as_exp.expid)
+    as_exp.as_conf.set_last_as_command("run")
+
+    with pytest.raises(AutosubmitCritical, match="do not exist"):
+        run(expid=as_exp.expid, run_only_members="nonexistent")
+
+
+def test_start_after_inexistent_experiment(autosubmit_exp, general_data, prepare_scratch):
+    """``start_after`` pointing to a non-existent experiment must not block the run."""
+    yaml = YAML(typ="rt")
+    jobs_data = dedent("""\
+    EXPERIMENT:
+        NUMCHUNKS: '1'
+    JOBS:
+        job:
+            SCRIPT: |
+                echo "Hello World"
+            PLATFORM: LOCAL
+            RUNNING: chunk
+            wallclock: 00:01
+    """)
+    as_exp = autosubmit_exp(
+        experiment_data=general_data | yaml.load(jobs_data),
+        include_jobs=False,
+        create=True,
+    )
+    prepare_scratch(expid=as_exp.expid)
+    as_exp.as_conf.set_last_as_command("run")
+
+    exit_code = run(expid=as_exp.expid, start_after="a000")
+
+    _assert_exit_code("COMPLETED", exit_code)
 
 
 @pytest.mark.parametrize(

--- a/test/integration/commands/run/test_run_local_scenarios.py
+++ b/test/integration/commands/run/test_run_local_scenarios.py
@@ -1256,7 +1256,7 @@ def test_run_only_members_invalid_member(autosubmit_exp, general_data, prepare_s
         run(expid=as_exp.expid, run_only_members="nonexistent")
 
 
-def test_start_after_inexistent_experiment(autosubmit_exp, general_data, prepare_scratch):
+def test_start_after_inexistent_experiment(autosubmit_exp, general_data, prepare_scratch, monkeypatch):
     """``start_after`` pointing to a non-existent experiment must not block the run."""
     yaml = YAML(typ="rt")
     jobs_data = dedent("""\
@@ -1278,6 +1278,8 @@ def test_start_after_inexistent_experiment(autosubmit_exp, general_data, prepare
     prepare_scratch(expid=as_exp.expid)
     as_exp.as_conf.set_last_as_command("run")
 
+    # Skip the warning pause that keeps the message readable on screen.
+    monkeypatch.setattr("autosubmit.helpers.autosubmit_helper.sleep", lambda _: None)
     exit_code = run(expid=as_exp.expid, start_after="a000")
 
     _assert_exit_code("COMPLETED", exit_code)

--- a/test/unit/test_autosubmit_helper.py
+++ b/test/unit/test_autosubmit_helper.py
@@ -133,8 +133,8 @@ def test_handle_start_after(mocker, autosubmit_config: Callable, time: str,
     experiment_history2.__bool__ = lambda _: True
 
     mocked_exp_history = mocker.Mock()
-    mocked_exp_history.manager.get_experiment_run_dc_with_max_id.side_effect = [experiment_history, experiment_history2,
-                                                                                None]
+    mocked_exp_history.manager.get_experiment_run_dc_with_max_id_or_none.side_effect = [experiment_history,
+                                                                                       experiment_history2, None]
     mocked_exp_history.is_header_ready.return_value = header_skip
     mock_experiment_history.return_value = mocked_exp_history
 
@@ -143,5 +143,5 @@ def test_handle_start_after(mocker, autosubmit_config: Callable, time: str,
 
     helper.handle_start_after(time, _EXPID)
     if header_skip is True and experiment_exists is True:
-        assert mocked_exp_history.manager.get_experiment_run_dc_with_max_id.called
+        assert mocked_exp_history.manager.get_experiment_run_dc_with_max_id_or_none.called
     assert mocked_sleep.has_been_called()

--- a/test/unit/test_history.py
+++ b/test/unit/test_history.py
@@ -55,6 +55,42 @@ def test_get_current_datetime():
     assert re.match(pattern, current_datetime) is not None
 
 
+def test_get_status_counts_from_job_list_counts_in_memory_jobs():
+    """get_status_counts_from_job_list computes the counts from the plain job list."""
+    exp_history = ExperimentHistory.__new__(ExperimentHistory)
+    jobs = [
+        job("a000_20000101_fc0_1_JOB", "2000-01-01 00:00:00", "fc0", "COMPLETED", ""),
+        job("a000_20000101_fc0_2_JOB", "2000-01-01 00:00:00", "fc0", "RUNNING", ""),
+        job("a000_20000101_fc0_3_JOB", "2000-01-01 00:00:00", "fc0", "WAITING", ""),
+    ]
+    result = exp_history.get_status_counts_from_job_list(jobs)
+    assert result["COMPLETED"] == 1
+    assert result["RUNNING"] == 1
+    assert result["TOTAL"] == 3
+
+
+def test_update_counts_uses_provided_status_counts():
+    """When status_counts is provided, update_counts uses it instead of computing
+    from the (possibly incomplete) in-memory job list."""
+    from unittest.mock import Mock
+
+    exp_history = ExperimentHistory.__new__(ExperimentHistory)
+    exp_history.manager = Mock()
+    run_dc = Mock()
+    counts = {
+        "COMPLETED": 3, "FAILED": 0, "QUEUING": 0,
+        "SUBMITTED": 0, "RUNNING": 0, "SUSPENDED": 0, "TOTAL": 3,
+    }
+
+    result = exp_history.update_counts_on_experiment_run_dc(run_dc, job_list=[], status_counts=counts)
+
+    assert result == exp_history.manager.update_experiment_run_dc_by_id.return_value
+    assert run_dc.completed == 3
+    assert run_dc.total == 3
+    exp_history.manager.update_experiment_run_dc_by_id.assert_called_once_with(run_dc)
+
+
+
 @pytest.mark.skip()
 @pytest.mark.skip(
     'TODO: another test that uses actual data. See if there is anything useful, and extract into functional/integration/unit tests that run on any machine')

--- a/test/unit/test_job_list.py
+++ b/test/unit/test_job_list.py
@@ -108,6 +108,21 @@ def test_save_jobs(as_conf, setup_job_list, tmp_path):
     assert len(db_edges) == len(job_list.graph.edges)
 
 
+def test_get_status_counts(as_conf, setup_job_list, tmp_path):
+    """get_status_counts counts jobs from the DB, including jobs not in memory."""
+    _jobs, _edges, job_list = setup_job_list
+    job_list.save_jobs()
+    counts = job_list.get_status_counts()
+    assert counts["COMPLETED"] == 1  # job1
+    assert counts["RUNNING"] == 1  # job2
+    assert counts["FAILED"] == 1  # job4
+    assert counts["QUEUING"] == 0
+    assert counts["SUBMITTED"] == 0
+    assert counts["SUSPENDED"] == 0
+    # READY (job3) and WAITING (job5, job6) still count.
+    assert counts["TOTAL"] == 6
+
+
 @pytest.mark.parametrize(
     "full_load,load_failed_jobs",
     [

--- a/test/unit/test_job_list.py
+++ b/test/unit/test_job_list.py
@@ -109,6 +109,21 @@ def test_save_jobs(as_conf, setup_job_list, tmp_path):
     assert len(db_edges) == len(job_list.graph.edges)
 
 
+def test_get_status_counts(as_conf, setup_job_list, tmp_path):
+    """get_status_counts counts jobs from the DB, including jobs not in memory."""
+    _jobs, _edges, job_list = setup_job_list
+    job_list.save_jobs()
+    counts = job_list.get_status_counts()
+    assert counts["COMPLETED"] == 1  # job1
+    assert counts["RUNNING"] == 1  # job2
+    assert counts["FAILED"] == 1  # job4
+    assert counts["QUEUING"] == 0
+    assert counts["SUBMITTED"] == 0
+    assert counts["SUSPENDED"] == 0
+    # READY (job3) and WAITING (job5, job6) still count.
+    assert counts["TOTAL"] == 6
+
+
 @pytest.mark.parametrize(
     "full_load,load_failed_jobs",
     [


### PR DESCRIPTION
closes #3151
closes #2273

Fix --start-after and --run-only-members

- --start-after: the waiting experiment never started. Run totals were recomputed from the in-memory job list, which gets emptied as jobs finish, so the monitored run ended up with total=0 and the trigger never fired. Totals now come from the jobs DB. Also pointing to a non-existent experiment now warns correctly

- --run-only-members: all members ran. The filter was applied after the graph was loaded and nothing pruned the already-loaded jobs. The filter is now applied at load time.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
