### PR TITLE
fix: remove all unused imports (ruff F401) (#3186)

### DIFF
--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -39,7 +39,7 @@ from contextlib import suppress
 from importlib.resources import files as read_files
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, cast
 
 from bscearth.utils.date import date2str
 from portalocker import Lock

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -29,7 +29,7 @@ from collections.abc import Iterable
 from contextlib import suppress
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 from bscearth.utils.date import parse_date
 from pyparsing import nested_expr

--- a/autosubmit/config/upgrade_scripts.py
+++ b/autosubmit/config/upgrade_scripts.py
@@ -20,7 +20,6 @@
 import locale
 import re
 import shutil
-from collections import defaultdict
 from io import StringIO
 from pathlib import Path
 from typing import Any

--- a/autosubmit/database/db_common.py
+++ b/autosubmit/database/db_common.py
@@ -22,7 +22,7 @@ import os
 import sqlite3
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import Connection, delete, func, insert, select, text, update
 from sqlalchemy.schema import CreateTable

--- a/autosubmit/database/session.py
+++ b/autosubmit/database/session.py
@@ -17,7 +17,6 @@
 
 import threading
 from pathlib import Path
-from typing import Union
 
 from sqlalchemy import Engine, NullPool
 from sqlalchemy import create_engine as sqlalchemy_create_engine

--- a/autosubmit/git/autosubmit_git.py
+++ b/autosubmit/git/autosubmit_git.py
@@ -23,7 +23,6 @@ import subprocess
 from pathlib import Path
 from shutil import rmtree
 from time import time
-from typing import Union
 
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.config.configcommon import AutosubmitConfig

--- a/autosubmit/helpers/autosubmit_helper.py
+++ b/autosubmit/helpers/autosubmit_helper.py
@@ -18,7 +18,7 @@
 import datetime
 import sys
 from time import sleep
-from typing import Any, Union
+from typing import Any
 
 from autosubmit.config.configcommon import AutosubmitConfig
 from autosubmit.database.db_common import check_experiment_exists

--- a/autosubmit/helpers/utils.py
+++ b/autosubmit/helpers/utils.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable
 from contextlib import suppress
 from itertools import zip_longest
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.log.log import AutosubmitCritical, Log

--- a/autosubmit/history/utils.py
+++ b/autosubmit/history/utils.py
@@ -19,7 +19,7 @@
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 LOCAL_TZ = datetime.now(timezone.utc).astimezone().tzinfo
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%z'

--- a/autosubmit/job/job_dict.py
+++ b/autosubmit/job/job_dict.py
@@ -17,7 +17,6 @@
 
 import datetime
 import re
-from typing import Union
 
 from bscearth.utils.date import date2str
 

--- a/autosubmit/log/log.py
+++ b/autosubmit/log/log.py
@@ -20,7 +20,7 @@ import os
 import sys
 from datetime import datetime
 from time import sleep
-from typing import Any, Union, cast
+from typing import Any, cast
 
 
 class AutosubmitError(Exception):

--- a/autosubmit/log/utils.py
+++ b/autosubmit/log/utils.py
@@ -18,7 +18,6 @@
 import gzip
 import lzma
 from pathlib import Path
-from typing import Union
 
 
 def compress_xz(

--- a/autosubmit/metrics/cpmip_metrics.py
+++ b/autosubmit/metrics/cpmip_metrics.py
@@ -16,7 +16,7 @@
 # along with Autosubmit. If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
-from typing import Any, Union
+from typing import Any
 
 from autosubmit.log.log import Log
 

--- a/autosubmit/platforms/headers/slurm_header.py
+++ b/autosubmit/platforms/headers/slurm_header.py
@@ -18,7 +18,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import textwrap
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from autosubmit.log.log import Log
 

--- a/autosubmit/platforms/locplatform.py
+++ b/autosubmit/platforms/locplatform.py
@@ -20,7 +20,7 @@ import os
 import subprocess
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import autosubmit.log.utils as log_utils
 from autosubmit.config.basicconfig import BasicConfig

--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -23,7 +23,6 @@ import os
 import random
 import re
 import select
-import socket
 import sys
 from contextlib import suppress
 from io import BufferedReader

--- a/autosubmit/platforms/platform.py
+++ b/autosubmit/platforms/platform.py
@@ -28,7 +28,7 @@ from multiprocessing.synchronize import Event
 # noinspection PyProtectedMember
 from os import _exit  # type: ignore
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import setproctitle
 

--- a/autosubmit/platforms/slurmplatform.py
+++ b/autosubmit/platforms/slurmplatform.py
@@ -25,7 +25,7 @@ import re
 from contextlib import suppress
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Any, Union
+from typing import Any
 
 from autosubmit.log.log import AutosubmitCritical, AutosubmitError, Log
 from autosubmit.platforms.execution_mode import ExecutionMode

--- a/autosubmit/provenance/rocrate.py
+++ b/autosubmit/provenance/rocrate.py
@@ -30,7 +30,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from rocrate.model.contextentity import ContextEntity
 from rocrate.rocrate import File, ROCrate

--- a/autosubmit/scripts/autosubmit.py
+++ b/autosubmit/scripts/autosubmit.py
@@ -20,11 +20,9 @@
 import argparse
 import traceback
 from contextlib import suppress
-from os import _exit
 
 # noinspection PyProtectedMember
 from pathlib import Path
-from typing import Union
 
 from portalocker.exceptions import BaseLockException
 

--- a/autosubmit/statistics/statistics.py
+++ b/autosubmit/statistics/statistics.py
@@ -16,7 +16,6 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/
 
 from datetime import datetime, timedelta
-from typing import Union
 
 from autosubmit.job.job import Job
 from autosubmit.statistics.jobs_stat import JobStat

--- a/docs/source/ext/autosubmitfigure.py
+++ b/docs/source/ext/autosubmitfigure.py
@@ -9,7 +9,7 @@
 from html import escape
 from pathlib import Path
 from shutil import copy, move
-from typing import Optional, cast
+from typing import cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node

--- a/docs/source/ext/runcmd.py
+++ b/docs/source/ext/runcmd.py
@@ -14,7 +14,6 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 from docutils import nodes
 from docutils.nodes import Node

--- a/test/integration/commands/run/conftest.py
+++ b/test/integration/commands/run/conftest.py
@@ -29,7 +29,7 @@ import sqlite3
 from collections.abc import Callable
 from pathlib import Path
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 

--- a/test/integration/commands/test_auto_splits.py
+++ b/test/integration/commands/test_auto_splits.py
@@ -1,5 +1,3 @@
-import pytest
-
 
 def test_auto_splits_dependency_creates(autosubmit_exp):
     config =  {

--- a/test/integration/database/test_db_manager.py
+++ b/test/integration/database/test_db_manager.py
@@ -35,7 +35,6 @@ from autosubmit.database.db_common import (
     open_conn,
 )
 from autosubmit.database.db_manager import DbManager
-from autosubmit.database.session import get_engine
 from autosubmit.database.tables import DBVersionTable, ExperimentTable
 from autosubmit.log.log import AutosubmitCritical
 

--- a/test/integration/test_cpmip_metrics.py
+++ b/test/integration/test_cpmip_metrics.py
@@ -23,10 +23,7 @@ from typing import Any
 import pytest
 from ruamel.yaml import YAML
 
-from test.integration.test_mail import (
-    configured_mail,
-    fake_smtp_server,
-)
+from test.integration.test_mail import configured_mail
 from test.integration.test_utils.docker_utils import get_mailhog_messages
 
 # The experiment runs one SIM chunk of exactly one calendar year, so simulated

--- a/test/integration/test_expid.py
+++ b/test/integration/test_expid.py
@@ -24,7 +24,7 @@ from getpass import getuser
 from itertools import permutations, product
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from ruamel.yaml import YAML

--- a/test/integration/test_mail.py
+++ b/test/integration/test_mail.py
@@ -16,7 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>. 
 
 from collections.abc import Callable, Generator
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import pytest
 

--- a/test/integration/test_paramiko_platform.py
+++ b/test/integration/test_paramiko_platform.py
@@ -20,12 +20,11 @@
 Note that tests will start and destroy an SSH server. For unit tests, see ``test_paramiko_platform.py``
 in the ``test/unit`` directory."""
 
-import socket
 from collections.abc import Callable
 from dataclasses import dataclass
 from getpass import getuser
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, Union, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import paramiko
 import pytest

--- a/test/integration/test_utils/misc.py
+++ b/test/integration/test_utils/misc.py
@@ -19,7 +19,6 @@
 
 from pathlib import Path
 from time import sleep, time
-from typing import TYPE_CHECKING
 
 from portalocker import AlreadyLocked, Lock, LockException
 

--- a/test/notebooks/rocrate-validate.ipynb
+++ b/test/notebooks/rocrate-validate.ipynb
@@ -26,7 +26,7 @@
     "from pathlib import Path\n",
     "from shutil import rmtree\n",
     "from tempfile import TemporaryDirectory\n",
-    "from typing import Any, Optional\n",
+    "from typing import Any\n",
     "\n",
     "from rocrate.model.contextentity import ContextEntity  # type: ignore\n",
     "from rocrate.rocrate import File, ROCrate  # type: ignore\n",

--- a/test/unit/config/conftest.py
+++ b/test/unit/config/conftest.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import TYPE_CHECKING
 
 import pytest
 

--- a/test/unit/database/test_db_manager.py
+++ b/test/unit/database/test_db_manager.py
@@ -21,7 +21,6 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from autosubmit.database.db_manager import DbManager
-from autosubmit.database.session import get_engine
 from autosubmit.database.tables import ExperimentTable
 
 

--- a/test/unit/database/test_session.py
+++ b/test/unit/database/test_session.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
 
 import pytest
 

--- a/test/unit/helpers/test_utils.py
+++ b/test/unit/helpers/test_utils.py
@@ -16,7 +16,6 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from typing import Union
 
 import pytest
 

--- a/test/unit/platforms/test_ecplatform.py
+++ b/test/unit/platforms/test_ecplatform.py
@@ -22,7 +22,6 @@
 import datetime
 import subprocess
 from pathlib import Path
-from typing import Union
 
 import pytest
 from _pytest._py.path import LocalPath

--- a/test/unit/platforms/wrappers/test_wrapper_factory.py
+++ b/test/unit/platforms/wrappers/test_wrapper_factory.py
@@ -17,8 +17,6 @@
 
 """Unit tests for the wrapper_factory module."""
 
-from typing import Union
-
 import pytest
 
 from autosubmit.platforms.slurmplatform import SlurmPlatform

--- a/test/unit/test_autosubmit_helper.py
+++ b/test/unit/test_autosubmit_helper.py
@@ -19,7 +19,6 @@
 
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Union
 
 import pytest
 

--- a/test/unit/test_utils/__init__.py
+++ b/test/unit/test_utils/__init__.py
@@ -19,7 +19,6 @@
 
 import re
 from pathlib import Path
-from typing import Union
 
 XZ_MAGIC = "FD 37 7A 58 5A 00"
 GZIP_MAGIC = "1F 8B"


### PR DESCRIPTION
Removes all 44 unused imports flagged by ruff rule F401 across 40 files in autosubmit/, docs/, and test/. Closes #3186