### PR TITLE
4.1.17.1 set status fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Fixed `CPU per task` for new version of autosubmit #2897
 - Fixed issue overwritting expid config variables with the ones from the github repo #2877
 - Fixed inspect infinite loop when PLATFORMS.TOTALJOBS or PLATFORMS.MAX_WAITING_JOBS is set to 0 #2749
+- `setstatus` no longer recovers stale job data when the target status is not final.
 - Fixed vertical wrappers computing the wrong per-job timeout. Each inner job now gets the
   longest wrapped job's wallclock to finish. #3210
 

--- a/autosubmit/autosubmit.py
+++ b/autosubmit/autosubmit.py
@@ -5411,11 +5411,12 @@ class Autosubmit:
                 job_list.update_list(as_conf, False, True)
                 start = time.time()
                 if save and wrongExpid == 0:
-                    job_list.recover_last_data(final_list)
-                    try:
-                        recover_stale_job_data(expid, as_conf, platforms)
-                    except Exception as e:
-                        Log.debug(f"Error while recovering stale job data: {str(e)}")
+                    if final_status in job_list._FINAL_STATUSES:
+                        job_list.recover_last_data(final_list)
+                        try:
+                            recover_stale_job_data(expid, as_conf, platforms)
+                        except Exception as e:
+                            Log.debug(f"Error while recovering stale job data: {str(e)}")
                     job_list.save()
                     end = time.time()
                     Log.info(f"JobList saved in {end - start:.2f} seconds.")

--- a/test/integration/commands/test_set_status.py
+++ b/test/integration/commands/test_set_status.py
@@ -880,3 +880,33 @@ def test_update_from_file_skips_active_job_without_connection(job_list, mocker, 
     job.platform.cancel_jobs.assert_not_called()
     assert job.status == active_status
     assert any("connection" in call.args[0] for call in mock_warning.call_args_list)
+
+@pytest.mark.parametrize("target, recovery_expected", [
+    ("COMPLETED", True),
+    ("FAILED", True),
+    ("WAITING", False),
+    ("READY", False),
+], ids=["completed", "failed", "waiting", "ready"])
+def test_set_status_recovery_only_for_final_targets(as_exp, mocker, target, recovery_expected):
+    """Test that stale job data recovery only runs when the target status is a final status."""
+    db_manager = SqlAlchemyExperimentHistoryDbManager(
+        as_exp.expid, BasicConfig.JOBDATA_DIR, f"job_data_{as_exp.expid}.db"
+    )
+    db_manager.initialize()
+
+    reset(as_exp, "WAITING")
+
+    mock_recover_stale = mocker.patch("autosubmit.autosubmit.recover_stale_job_data")
+    mock_recover_last_data = mocker.patch(
+        "autosubmit.job.job_list.JobList.recover_last_data"
+    )
+
+    job_names = " ".join(
+        job.name for job in as_exp.autosubmit.load_job_list(
+            as_exp.expid, as_exp.as_conf, new=False
+        ).get_job_list()
+    )
+    do_setstatus(as_exp, fl=job_names, target=target)
+
+    assert mock_recover_stale.called is recovery_expected
+    assert mock_recover_last_data.called is recovery_expected


### PR DESCRIPTION
Another minor fix for the 4.1.17 patch, commented in https://gitlab.earth.bsc.es/digital-twins/de_340-3/workflow/-/work_items/1725

This one avoids the recovery of the jobs if the status set by the user is not a final one 

Ready to review cc: @VindeeR; this one is simpler, after this I can upload the patch I believe


**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
