### PR TITLE
4.1.17.1 wrappers issue

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz
     - sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   those states on its own.
 - QOL: `updated_list` and `setstatus` now call the same functions to manage status.
 
-### 4.1.17: Submission and Job Tracking Overhaul, Bug Fixes, and Enhancements                                                                                                                                                               
+### 4.1.17: Submission and Job Tracking Overhaul, Bug Fixes, and Enhancements
 
 **Bug fixes:**
 
@@ -64,7 +64,8 @@
 - Fixed `CPU per task` for new version of autosubmit #2897
 - Fixed issue overwritting expid config variables with the ones from the github repo #2877
 - Fixed inspect infinite loop when PLATFORMS.TOTALJOBS or PLATFORMS.MAX_WAITING_JOBS is set to 0 #2749
-
+- Fixed vertical wrappers computing the wrong per-job timeout. Each inner job now gets the
+  longest wrapped job's wallclock to finish. #3210
 
 **Enhancements:**
 
@@ -110,7 +111,11 @@
 - Expanded ECPlatform, paramiko platform support, and platform code cleanup #3007
 - Changed JOBS_IN_WRAPPER unknown job from critical error to warning #3006
 - Added ``ECACCESS_RETRIES`` platform config key to configure SSL retries for ecaccess platforms. Defaults to 100 #3059
-
+- Moved wallclock parsing into shared helpers (`wallclock_to_seconds` and
+  `max_wallclock_seconds`) so the time parsing lives in one single place.
+- Renamed the misleading `level` variable (now a scan index) in the
+  vertical wrapper packager and removed dead code that was no longer
+  called.
 
 ### 4.1.16: Postgres (experimental) support, bug fixes, and enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 4.1.17.1: Large experiments support: ssh-recovery and updated_list
+### 4.1.17.1: Large experiments support: ssh-recovery and updated_list 
 
 **Bug fixes:**
 

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -36,7 +36,7 @@ from autosubmit.config.configcommon import AutosubmitConfig
 from autosubmit.helpers.enums import ChunkUnit
 from autosubmit.helpers.parameters import autosubmit_parameter, autosubmit_parameters
 from autosubmit.history.experiment_history import ExperimentHistory
-from autosubmit.job.job_common import Status, increase_wallclock_by_chunk
+from autosubmit.job.job_common import Status, increase_wallclock_by_chunk, wallclock_to_seconds
 from autosubmit.job.job_utils import get_split_size_unit, get_split_size
 from autosubmit.job.metrics_processor import UserMetricProcessor
 from autosubmit.job.template import get_template_snippet, Language
@@ -173,7 +173,7 @@ class Job(object):
         'ec_queue', 'platform_name', '_serial_platform',
         'submitter', '_shape', '_x11', '_x11_options', '_hyperthreading',
         '_scratch_free_space', '_delay_retrials', '_custom_directives',
-        'packed_during_building', 'workflow_commit', '_validate_template', 'first_wrapped_level', 'finished_time'
+        'packed_during_building', 'workflow_commit', '_validate_template', 'finished_time'
     )
 
     def __setstate__(self, state):
@@ -216,7 +216,6 @@ class Job(object):
         self.rerun_only = False
         self.delay_end = None
         self.wrapper_type = None
-        self.first_wrapped_level = False
         self._wrapper_queue = None
         self._platform: 'ParamikoPlatform' = None
         self._queue = None
@@ -339,7 +338,6 @@ class Job(object):
         self.rerun_only = False
         self.delay_end = None
         self.wrapper_type = None
-        self.first_wrapped_level = False
         self._wrapper_queue = None
         self._queue = None
         self._partition = None
@@ -1437,9 +1435,9 @@ class Job(object):
 
     def _max_possible_wallclock(self):
         if self.platform and self.platform.max_wallclock:
-            wallclock = self.parse_time(self.platform.max_wallclock)
-            if wallclock:
-                return int(wallclock.total_seconds())
+            seconds = wallclock_to_seconds(self.platform.max_wallclock)
+            if seconds:
+                return seconds
         return None
 
     def _time_in_seconds_and_margin(self, wallclock: datetime.timedelta) -> int:
@@ -1469,19 +1467,22 @@ class Job(object):
 
     @staticmethod
     def parse_time(wallclock):
+        """Convert a ``HH:MM[:SS]`` wallclock to a :class:`datetime.timedelta`.
+
+        :param wallclock: Wallclock to convert, e.g. ``'07:30'`` or ``'07:30:00'``.
+        :type wallclock: str
+        :return: The wallclock as a timedelta, or ``None`` if it cannot be parsed. ``'00:00'``
+            yields a zero-duration timedelta (not ``None``). Non-string values return a one-day
+            timedelta as a test workaround.
+        :rtype: Optional[datetime.timedelta]
+        """
         # TODO This is a workaround for the time being, just defined for tests passing without more issues
         if type(wallclock) is not str:
             return datetime.timedelta(24 * 60 * 60)
-        regex = re.compile(r'(((?P<hours>\d+):)((?P<minutes>\d+)))(:(?P<seconds>\d+))?')
-        parts = regex.match(wallclock)
-        if not parts:
+        seconds = wallclock_to_seconds(wallclock)
+        if seconds is None:
             return None
-        parts = parts.groupdict()
-        time_params = {}
-        for name, param in parts.items():
-            if param:
-                time_params[name] = int(param)
-        return datetime.timedelta(**time_params)
+        return datetime.timedelta(seconds=seconds)
 
     def is_over_wallclock(self, effective_wallclock=None) -> bool:
         """Check if the job is over the wallclock time, it is an alternative method to avoid platform issues."""
@@ -1533,13 +1534,6 @@ class Job(object):
                 )
 
         return self.status
-
-    def update_children_status(self):
-        children = list(self.children)
-        for child in children:
-            if child.level == 0 and child.status in [Status.SUBMITTED, Status.RUNNING, Status.QUEUING, Status.UNKNOWN]:
-                child.status = Status.FAILED
-                children += list(child.children)
 
     def check_completion(self, default_status=Status.FAILED):
         """Check whether a COMPLETED file exists on the platform.

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -1466,7 +1466,7 @@ class Job(object):
         return int(wallclock_delta.total_seconds())
 
     @staticmethod
-    def parse_time(wallclock):
+    def parse_time(wallclock) -> datetime.timedelta | None:
         """Convert a ``HH:MM[:SS]`` wallclock to a :class:`datetime.timedelta`.
 
         :param wallclock: Wallclock to convert, e.g. ``'07:30'`` or ``'07:30:00'``.
@@ -1474,7 +1474,6 @@ class Job(object):
         :return: The wallclock as a timedelta, or ``None`` if it cannot be parsed. ``'00:00'``
             yields a zero-duration timedelta (not ``None``). Non-string values return a one-day
             timedelta as a test workaround.
-        :rtype: Optional[datetime.timedelta]
         """
         # TODO This is a workaround for the time being, just defined for tests passing without more issues
         if type(wallclock) is not str:

--- a/autosubmit/job/job_common.py
+++ b/autosubmit/job/job_common.py
@@ -18,18 +18,16 @@
 import datetime
 import re
 from collections.abc import Iterable
-from typing import Optional
 
 _WALLCLOCK_RE = re.compile(r'(((?P<hours>\d+):)((?P<minutes>\d+)))(:(?P<seconds>\d+))?')
 
 
-def wallclock_to_seconds(wallclock: Optional[str]) -> Optional[int]:
+def wallclock_to_seconds(wallclock: str | None) -> int | None:
     """Convert a ``HH:MM[:SS]`` wallclock to seconds.
 
     :param wallclock: Wallclock to convert, e.g. ``'07:30'`` or ``'07:30:00'``.
     :type wallclock: str
     :return: The wallclock in seconds, or ``None`` if it is empty, not a string or cannot be parsed.
-    :rtype: Optional[int]
     """
     if not wallclock or not isinstance(wallclock, str):
         return None
@@ -43,7 +41,7 @@ def wallclock_to_seconds(wallclock: Optional[str]) -> Optional[int]:
     return hours * 3600 + minutes * 60 + seconds
 
 
-def max_wallclock_seconds(wallclocks: Iterable[str], platform_max_wallclock: Optional[str] = None,
+def max_wallclock_seconds(wallclocks: Iterable[str], platform_max_wallclock: str | None = None,
                           fallback: int = 0) -> int:
     """Return the longest wallclock (seconds) among the given ones.
 

--- a/autosubmit/job/job_common.py
+++ b/autosubmit/job/job_common.py
@@ -16,6 +16,52 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+import re
+from collections.abc import Iterable
+from typing import Optional
+
+_WALLCLOCK_RE = re.compile(r'(((?P<hours>\d+):)((?P<minutes>\d+)))(:(?P<seconds>\d+))?')
+
+
+def wallclock_to_seconds(wallclock: Optional[str]) -> Optional[int]:
+    """Convert a ``HH:MM[:SS]`` wallclock to seconds.
+
+    :param wallclock: Wallclock to convert, e.g. ``'07:30'`` or ``'07:30:00'``.
+    :type wallclock: str
+    :return: The wallclock in seconds, or ``None`` if it is empty, not a string or cannot be parsed.
+    :rtype: Optional[int]
+    """
+    if not wallclock or not isinstance(wallclock, str):
+        return None
+    match = _WALLCLOCK_RE.match(wallclock)
+    if not match:
+        return None
+    parts = match.groupdict()
+    hours = int(parts['hours'])
+    minutes = int(parts['minutes']) if parts['minutes'] else 0
+    seconds = int(parts['seconds']) if parts['seconds'] else 0
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def max_wallclock_seconds(wallclocks: Iterable[str], platform_max_wallclock: Optional[str] = None,
+                          fallback: int = 0) -> int:
+    """Return the longest wallclock (seconds) among the given ones.
+
+    Entries without a wallclock (empty, unparseable or ``'00:00'``) fall back to the platform
+    maximum wallclock. If no wallclock is available at all, ``fallback`` is returned.
+
+    :param wallclocks: Wallclocks to evaluate.
+    :type wallclocks: Iterable[str]
+    :param platform_max_wallclock: Platform maximum wallclock to use as fallback.
+    :type platform_max_wallclock: str
+    :param fallback: Value returned when no wallclock is available.
+    :type fallback: int
+    :return: The longest wallclock in seconds.
+    :rtype: int
+    """
+    platform_max = wallclock_to_seconds(platform_max_wallclock) or 0
+    longest = max((wallclock_to_seconds(wallclock) or platform_max for wallclock in wallclocks), default=0)
+    return longest or fallback
 
 
 class Status:

--- a/autosubmit/job/job_packager.py
+++ b/autosubmit/job/job_packager.py
@@ -20,7 +20,7 @@ import operator
 from contextlib import suppress
 from math import ceil
 from operator import attrgetter
-from typing import List, TYPE_CHECKING, Union
+from typing import List, Optional, TYPE_CHECKING, Union
 
 from bscearth.utils.date import sum_str_hours
 
@@ -996,23 +996,22 @@ class JobPackagerVertical(object):
         self.max_wallclock = max_wallclock
         self.wrapper_info = wrapper_info
 
-    def build_vertical_package(self, job, wrapper_info):
-        """
-        Goes through the job and all the related jobs (children, or part of the same date member ordered group), finds those suitable
+    def build_vertical_package(self, job: Job, wrapper_info: list) -> list[Job]:
+        """Goes through the job and all the related jobs (children, or part of the same date member ordered group), finds those suitable
         and groups them together into a wrapper. (iterative-version)
 
         :param job: Job to be wrapped.
-        :type job: Job Object
+        :param wrapper_info: Wrapper parameters (type, policy, method, jobs in wrapper, extensible wallclock and configuration).
         :return: List of jobs that are wrapped together.
         :rtype: List() of Job Object
         """
         self.total_wallclock = job.wallclock  # reset total wallclock for package
         stack = [(job, 0)]
         while stack:
-            job, level = stack.pop()
+            job, scan_index = stack.pop()
             # Less verbose
-            if level % 50 == 0 and level > 0:
-                Log.info(f"Wrapper package creation is still ongoing. So far {level} jobs have been wrapped.")
+            if scan_index % 50 == 0 and scan_index > 0:
+                Log.info(f"Wrapper package creation is still ongoing. So far {scan_index} jobs have been scanned.")
                 for event in job.platform.worker_events:  # keep alive log retrieval workers.
                     if not event.is_set():
                         event.set()
@@ -1021,7 +1020,7 @@ class JobPackagerVertical(object):
                     self.wrapper_limits["max_by_section"][job.section] or len(self.jobs_list) >= self.wrapper_limits[
                 "max"]:
                 continue
-            child, level = self.get_wrappable_child(job, level)
+            child, scan_index = self.get_wrappable_child(job, scan_index)
             if child is not None and len(str(child)) > 0:
                 child.update_parameters(wrapper_info[-1], set_attributes=True)
 
@@ -1029,23 +1028,23 @@ class JobPackagerVertical(object):
                 # Local jobs could not have a wallclock defined
                 if self.total_wallclock <= self.max_wallclock or not self.max_wallclock:
                     child.packed_during_building = True
-                    child.level = level
                     self.jobs_list.append(child)
-                    stack.append((child, level))
+                    stack.append((child, scan_index))
         return self.jobs_list
 
-    def get_wrappable_child(self, job: Job, level: int) -> Job:
+    def get_wrappable_child(self, job: Job, scan_index: int) -> tuple[Optional[Job], int]:
         """Goes through the jobs with the same date and member as the input job, and returns the first that satisfies self._is_wrappable().
 
         :param job: Job to be evaluated.
         :type job: Job
-        :return: Job that is wrappable, or None if no such job is found.
-        :rtype: Optional[Any]
+        :param scan_index: Position in sorted_jobs from which to start looking for the next wrappable job.
+        :return: The wrappable job (or ``None``) and the next scan position.
+        :rtype: tuple[Optional[Job], int]
         """
         sorted_jobs = self.sorted_jobs
         child = None
-        index = level
-        for index in range(level, len(sorted_jobs)):
+        index = scan_index
+        for index in range(scan_index, len(sorted_jobs)):
             child_ = sorted_jobs[index]
             if child_.name != job.name and self._is_wrappable(child_):
                 child = child_
@@ -1114,18 +1113,19 @@ class JobPackagerVerticalMixed(JobPackagerVertical):
         # sort by chunk number
         self.index = 0
 
-    def get_wrappable_child(self, job: Job, level: int) -> Job:
+    def get_wrappable_child(self, job: Job, scan_index: int) -> tuple[Optional[Job], int]:
         """Goes through the jobs with the same date and member as the input job, and returns the first that satisfies self._is_wrappable().
 
         :param job: Job to be evaluated.
         :type job: Job
-        :return: Job that is wrappable, or None if no such job is found.
-        :rtype: Optional[Any]
+        :param scan_index: Position in sorted_jobs from which to start looking for the next wrappable job.
+        :return: The wrappable job (or ``None``) and the next scan position.
+        :rtype: tuple[Optional[Job], int]
         """
         sorted_jobs = self.sorted_jobs
         child = None
-        index = level
-        for index in range(level, len(sorted_jobs)):
+        index = scan_index
+        for index in range(scan_index, len(sorted_jobs)):
             child_ = sorted_jobs[index]
             if child_.name != job.name and self._is_wrappable(child_):
                 child = child_

--- a/autosubmit/job/job_packager.py
+++ b/autosubmit/job/job_packager.py
@@ -20,7 +20,7 @@ import operator
 from contextlib import suppress
 from math import ceil
 from operator import attrgetter
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import List, TYPE_CHECKING, Union
 
 from bscearth.utils.date import sum_str_hours
 
@@ -1032,14 +1032,13 @@ class JobPackagerVertical(object):
                     stack.append((child, scan_index))
         return self.jobs_list
 
-    def get_wrappable_child(self, job: Job, scan_index: int) -> tuple[Optional[Job], int]:
+    def get_wrappable_child(self, job: Job, scan_index: int) -> tuple[Job | None, int]:
         """Goes through the jobs with the same date and member as the input job, and returns the first that satisfies self._is_wrappable().
 
         :param job: Job to be evaluated.
         :type job: Job
         :param scan_index: Position in sorted_jobs from which to start looking for the next wrappable job.
         :return: The wrappable job (or ``None``) and the next scan position.
-        :rtype: tuple[Optional[Job], int]
         """
         sorted_jobs = self.sorted_jobs
         child = None
@@ -1113,14 +1112,13 @@ class JobPackagerVerticalMixed(JobPackagerVertical):
         # sort by chunk number
         self.index = 0
 
-    def get_wrappable_child(self, job: Job, scan_index: int) -> tuple[Optional[Job], int]:
+    def get_wrappable_child(self, job: Job, scan_index: int) -> tuple[Job | None, int]:
         """Goes through the jobs with the same date and member as the input job, and returns the first that satisfies self._is_wrappable().
 
         :param job: Job to be evaluated.
         :type job: Job
         :param scan_index: Position in sorted_jobs from which to start looking for the next wrappable job.
         :return: The wrappable job (or ``None``) and the next scan position.
-        :rtype: tuple[Optional[Job], int]
         """
         sorted_jobs = self.sorted_jobs
         child = None

--- a/autosubmit/job/job_packages.py
+++ b/autosubmit/job/job_packages.py
@@ -21,11 +21,9 @@ import json
 import locale
 import os
 import random
-import re
 import tarfile
 import time
 from contextlib import suppress
-from datetime import timedelta
 from pathlib import Path
 from threading import Thread
 from typing import Optional, TYPE_CHECKING
@@ -33,7 +31,7 @@ from typing import Optional, TYPE_CHECKING
 from bscearth.utils.date import sum_str_hours, date2str
 
 from autosubmit.job.job import Job
-from autosubmit.job.job_common import Status
+from autosubmit.job.job_common import Status, max_wallclock_seconds, wallclock_to_seconds
 from autosubmit.log.log import Log, AutosubmitCritical
 
 if TYPE_CHECKING:
@@ -578,63 +576,28 @@ class JobPackageVertical(JobPackageThread):
             self._wallclock = sum_str_hours(self._wallclock, job.wallclock)
         self.name = f"{self._expid}_{self.FILE_PREFIX}_{jobs_in_wrapper_str(configuration, self.current_wrapper_section)}_{str(int(time.time())) + str(random.randint(1, 10000))}_{self._num_processors}_{len(self._jobs)}"
 
-    def parse_time(self):
-        # TODO: Remove this function and use the one in the Job class or move the one in the job class into utils
-        # noinspection Annotator
-        regex = re.compile(r'(((?P<hours>\d+):)(?P<minutes>\d+))(:(?P<seconds>\d+))?')
-        parts = regex.match(self._wallclock)
-        if not parts:
-            return None
-        parts = parts.groupdict()
-        if int(parts['hours']) > 0:
-            format_ = "hour"
-        else:
-            format_ = "minute"
-        time_params = {}
-        for name, param in parts.items():
-            if param:
-                time_params[name] = int(param)
-        return timedelta(**time_params), format_
-
     def _common_script_content(self) -> str:
-        # TODO: normalize this logic to be the same as the one in the Job class
+        """Build the vertical wrapper script.
+
+        Computes the per-job timeout (the longest wrapped section wallclock, falling back to the
+        platform maximum wallclock for jobs without one), optionally extends the wrapper wallclock,
+        and delegates the script generation to the wrapper factory.
+
+        :return: The wrapper script content.
+        :rtype: str
+        """
         if self.jobs[0].wrapper_type == "vertical":
-            wallclock, format_ = self.parse_time()
-            original_wallclock_to_seconds = wallclock.days * 86400.0 + wallclock.seconds
-
-            if format_ == "hour":
-                total = wallclock.days * 24 + wallclock.seconds / 60 / 60
-            else:
-                total = wallclock.days * 24 + wallclock.seconds / 60
-
-            if format_ == "hour":
-                hour = int(total)
-                minute = int((total - int(total)) * 60.0)
-                second = int(((total - int(total)) * 60 -
-                              int((total - int(total)) * 60.0)) * 60.0)
-            else:
-                hour = 0
-                minute = int(total)
-                second = int((total - int(total)) * 60.0)
-            wallclock_delta = datetime.timedelta(hours=hour, minutes=minute, seconds=second)
-            wallclock_seconds = wallclock_delta.days * 24 * 60 * 60 + wallclock_delta.seconds
-            wallclock_by_level = wallclock_seconds / (self.jobs[-1].level + 1)
+            wallclock_seconds = wallclock_to_seconds(self._wallclock) or 0
+            wallclock_by_level = max_wallclock_seconds(
+                (job.wallclock for job in self.jobs),
+                platform_max_wallclock=self.platform.max_wallclock if self.platform else None,
+                fallback=wallclock_seconds,
+            )
             if self.extensible_wallclock > 0:
-                wallclock_seconds = int(original_wallclock_to_seconds + wallclock_by_level * self.extensible_wallclock)
-                wallclock_delta = datetime.timedelta(hours=0, minutes=0, seconds=wallclock_seconds)
-                total = wallclock_delta.days * 24 + wallclock_delta.seconds / 60 / 60
-                hh = int(total)
-                mm = int((total - int(total)) * 60.0)
-                if hh < 10:
-                    hh_str = '0' + str(hh)
-                else:
-                    hh_str = str(hh)
-                if mm < 10:
-                    mm_str = '0' + str(mm)
-                else:
-                    mm_str = str(mm)
-                self._wallclock = f"{hh_str}:{mm_str}"
-                Log.info(f"Submitting {self.name} with wallclock {hh_str}:{mm_str}")
+                wallclock_seconds = int(wallclock_seconds + wallclock_by_level * self.extensible_wallclock)
+                hh, mm = divmod(wallclock_seconds // 60, 60)
+                self._wallclock = f"{hh:02d}:{mm:02d}"
+                Log.info(f"Submitting {self.name} with wallclock {self._wallclock}")
         else:
             wallclock_by_level = 0
 

--- a/autosubmit/platforms/wrappers/wrapper_builder.py
+++ b/autosubmit/platforms/wrappers/wrapper_builder.py
@@ -556,10 +556,6 @@ class PythonVerticalWrapperBuilder(PythonWrapperBuilder):
 
             {os.linesep.ljust(13)}"""), 8)
             sequential_threads_launcher += self._indent(textwrap.dedent(f"""
-            from pathlib import Path
-            fail_count = 0
-            while fail_count <= job_retrials:
-                fail_count = fail_count + 1
             if not os.path.exists(completed_path):
                 open(failed_wrapper,'wb').close()
                 open(failed_path, 'wb').close()
@@ -597,7 +593,6 @@ class PythonVerticalWrapperBuilder(PythonWrapperBuilder):
                 print(f"Running job {{self.template}} with fail count {{self.fail_count}}")
                 if self.fail_count > 0:
                     filedata = filedata.replace('_STAT_0', f'_STAT_{{self.fail_count}}')
-                print(f"timeout {str(self.wallclock_by_level)} bash -s < <filedata> > {{out_path}} 2> {{err_path}}")
                 with open(out_path, 'w') as out_f, open(err_path, 'w') as err_f:
                     proc = subprocess.run(
                         ['timeout', '{str(self.wallclock_by_level)}', 'bash', '-s'],

--- a/test/unit/platforms/wrappers/test_wrappers.py
+++ b/test/unit/platforms/wrappers/test_wrappers.py
@@ -424,6 +424,49 @@ class TestWrappers:
             for i in range(0, len(returned_packages)):
                 assert returned_packages[i]._jobs == packages[i]._jobs
 
+    def test_vertical_packager_does_not_leak_scan_index_into_job_level(self):
+        """Vertical packaging must not write the sorted_jobs scan index into job.level."""
+        date_list = ["d1"]
+        member_list = ["m1"]
+        chunk_list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        for section, s_value in self.workflows['basic']['sections'].items():
+            self.as_conf.jobs_data[section] = s_value
+        self._createDummyJobs(self.workflows['basic'], date_list, member_list, chunk_list)
+
+        s2_jobs = [self.job_list.get_job_by_name(f'expid_d1_m1_{chunk}_s2') for chunk in chunk_list]
+        for job in s2_jobs[:8]:
+            job.status = Status.COMPLETED
+        for job in s2_jobs[8:]:
+            job.status = Status.READY
+
+        self.job_list._ordered_jobs_by_date_member["WRAPPERS"] = {}
+        self.job_list._ordered_jobs_by_date_member["WRAPPERS"]["d1"] = {}
+        self.job_list._ordered_jobs_by_date_member["WRAPPERS"]["d1"]["m1"] = s2_jobs
+
+        self.job_packager.current_wrapper_section = "WRAPPERS"
+        self.job_packager.retrials = 0
+        self.job_packager._platform.max_wallclock = '10:00'
+        self.job_packager.wrapper_type = 'vertical'
+
+        max_wrapped_job_by_section = dict.fromkeys(["s1", "s2", "s3", "s4"], 10)
+        wrapper_limits = {}
+        wrapper_limits["max"] = 10
+        wrapper_limits["max_v"] = 10
+        wrapper_limits["max_h"] = 10
+        wrapper_limits["min"] = 2
+        wrapper_limits["min_v"] = 2
+        wrapper_limits["min_h"] = 2
+        wrapper_limits["max_by_section"] = max_wrapped_job_by_section
+
+        with mock.patch("autosubmit.job.job.Job.update_parameters", return_value={}):
+            returned_packages = self.job_packager._build_vertical_packages(
+                [s2_jobs[8]], wrapper_limits, self.wrapper_info)
+
+        assert len(returned_packages) == 1
+        package = returned_packages[0]
+        assert [job.name for job in package.jobs] == ["expid_d1_m1_9_s2", "expid_d1_m1_10_s2"]
+        assert all(job.level == 0 for job in package.jobs)
+
     def test_returned_packages_max_wrapped_jobs(self):
         with mock.patch("autosubmit.job.job.Job.update_parameters", return_value={}):
 

--- a/test/unit/test_job_common.py
+++ b/test/unit/test_job_common.py
@@ -78,8 +78,9 @@ def test_wallclock_to_seconds(wallclock, expected):
         (['00:00', '', None], '24:00', 0, 86400),
         (['00:00', ''], None, 42, 42),
         ([], None, 42, 42),
+        ([123], None, 42, 42),
     ],
-    ids=['longest-section', 'platform-fallback', 'fallback-arg', 'empty']
+    ids=['longest-section', 'platform-fallback', 'fallback-arg', 'empty', 'not string']
 )
 def test_max_wallclock_seconds(wallclocks, platform_max_wallclock, fallback, expected):
     assert job_common.max_wallclock_seconds(

--- a/test/unit/test_job_common.py
+++ b/test/unit/test_job_common.py
@@ -48,3 +48,39 @@ def test_value_to_key_has_the_same_values_as_status_constants():
 )
 def test_parse_output_number(number, result):
     assert result == job_common.parse_output_number(number)
+
+
+@pytest.mark.parametrize(
+    'wallclock, expected',
+    [
+        ('00:10', 600),
+        ('07:30', 27000),
+        ('07:30:00', 27000),
+        ('24:00', 86400),
+        ('00:00', 0),
+        ('', None),
+        (None, None),
+        ('garbage', None),
+        ('0000', None),
+        (123, None),
+    ],
+    ids=['minutes', 'hour-minute', 'with-seconds', 'day', 'zero', 'empty', 'none',
+         'garbage', 'no-colon', 'non-string']
+)
+def test_wallclock_to_seconds(wallclock, expected):
+    assert job_common.wallclock_to_seconds(wallclock) == expected
+
+
+@pytest.mark.parametrize(
+    'wallclocks, platform_max_wallclock, fallback, expected',
+    [
+        (['00:10', '00:30', '00:15'], None, 0, 1800),
+        (['00:00', '', None], '24:00', 0, 86400),
+        (['00:00', ''], None, 42, 42),
+        ([], None, 42, 42),
+    ],
+    ids=['longest-section', 'platform-fallback', 'fallback-arg', 'empty']
+)
+def test_max_wallclock_seconds(wallclocks, platform_max_wallclock, fallback, expected):
+    assert job_common.max_wallclock_seconds(
+        wallclocks, platform_max_wallclock=platform_max_wallclock, fallback=fallback) == expected

--- a/test/unit/test_job_package.py
+++ b/test/unit/test_job_package.py
@@ -284,3 +284,30 @@ def test_job_package_send_files_uses_current_public_api(mocker, local, tmp_path)
         mocker.call("job1.cmd"),
         mocker.call("job2.cmd"),
     ]
+
+
+@pytest.mark.parametrize(
+    'wallclock0, wallclock1, level, expected',
+    [
+        ("00:10", "00:30", 2714, 1800),
+        ("00:00", "00:00", 0, 86400),
+    ],
+    ids=['max-section-ignores-level', 'platform-max-fallback']
+)
+def test_vertical_wrapper_wallclock_by_level(create_job_package_wrapper, jobs, mocker, wallclock0, wallclock1,
+                                             level, expected) -> None:
+    """Vertical per-job timeout must be the longest wrapped section, ignoring job.level."""
+    jobs[0].wrapper_type = "vertical"
+    jobs[0].wallclock = wallclock0
+    jobs[1].wallclock = wallclock1
+    jobs[-1].level = level # should be ignored now
+    package = create_job_package_wrapper({
+        'TYPE': "vertical",
+        'JOBS_IN_WRAPPER': "None",
+        'METHOD': "ASThread",
+        'POLICY': "flexible",
+        'EXTEND_WALLCLOCK': 0,
+    })
+    get_wrapper = mocker.patch.object(package._wrapper_factory, 'get_wrapper', return_value="")
+    package._common_script_content()
+    assert get_wrapper.call_args.kwargs['wallclock_by_level'] == expected


### PR DESCRIPTION
This is a fix for v4.1.17.1, master will need a sister branch to fix it. I'll open an issue for that

Ignore ruff because it is 4.1.17.1

Fixes #3210, cc @franra9 

In Francesc wrapper.cmd I found that Inner jobs inside a vertical wrapper had a 10 s timeout after starting, so the wrapper always ended FAILED because the job needed +20 min to finish.

The per-job timeout in the wrapper was calculated as total wallclock / (last_job.level + 1). Since a previous rework, level is no longer the position of the job inside the wrapper, but an index over the whole date/member job list. 

This was causing the bug to appear only when all the jobs don't fit in a single package: when they do, the last job index matches the number of wrapped jobs, and the old formula accidentally works. It can be tested easily using MAX_WRAPPED, which forces jobs to be split into multiple packages.

This fix includes:

The per-job timeout is now the longest wallclock among the wrapped jobs, so every inner job gets enough time to finish. Jobs without a wallclock fall back to the platform max.

also moved the wallclock calculations into reusable helpers in job_common.py (wallclock_to_seconds and max_wallclock_seconds), and made Job.parse_time and _max_possible_wallclock reuse them, so the time parsing lives in one single place.

and finally cleaned up the misleading level naming (renamed to scan_index) and removed dead code that was no longer called.


To test this: 

```yaml
Use this experiment config (on SLURM, e.g. the test container):
EXPERIMENT:
  NUMCHUNKS: '40'
JOBS:
  job:
    SCRIPT: |
      sleep 1
    PLATFORM: TEST_SLURM
    RUNNING: chunk
    WALLCLOCK: 00:20
wrappers:
  wrapper:
    type: vertical
    MAX_WRAPPED: 10
    JOBS_IN_WRAPPER: job
```
+ Run `autosubmit inspect $expid -cw -f` and check the wrapper.cmd of any of the four wrappers generated

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
