### PR TITLE
Fix does not exist grammar in logs and errors

### DIFF
--- a/autosubmit/platforms/paramiko_platform.py
+++ b/autosubmit/platforms/paramiko_platform.py
@@ -595,7 +595,7 @@ class ParamikoPlatform(Platform):
                     Log.printlog(f"File {filename} seems to no exists (skipping)", 5004)
             if must_exist:
                 if not ignore_log:
-                    Log.printlog(f"File {filename} does not exists", 6004)
+                    Log.printlog(f"File {filename} does not exist", 6004)
             else:
                 if not ignore_log:
                     Log.printlog(f"Log file couldn't be retrieved: {filename}", 5000)
@@ -650,18 +650,18 @@ class ParamikoPlatform(Platform):
             return True
         except OSError as e:
             if str(e) in "Garbage":
-                raise AutosubmitError(f'File {os.path.join(path_root, src)} does not exists, something went '
+                raise AutosubmitError(f'File {os.path.join(path_root, src)} does not exist, something went '
                                       f'wrong with the platform', 6004, str(e))
             if must_exist:
-                raise AutosubmitError(f"File {os.path.join(path_root, src)} does not exists", 6004, str(e))
+                raise AutosubmitError(f"File {os.path.join(path_root, src)} does not exist", 6004, str(e))
             else:
-                Log.debug(f"File {path_root} doesn't exists ")
+                Log.debug(f"File {path_root} doesn't exist ")
                 return False
         except Exception as e:
             if str(e) in "Garbage":
-                raise AutosubmitError(f'File {os.path.join(self.get_files_path(), src)} does not exists', 6004, str(e))
+                raise AutosubmitError(f'File {os.path.join(self.get_files_path(), src)} does not exist', 6004, str(e))
             if must_exist:
-                raise AutosubmitError(f"File {os.path.join(self.get_files_path(), src)} does not exists", 6004, str(e))
+                raise AutosubmitError(f"File {os.path.join(self.get_files_path(), src)} does not exist", 6004, str(e))
             else:
                 Log.printlog(f"Log file couldn't be moved: {os.path.join(self.get_files_path(), src)}", 5001)
                 return False


### PR DESCRIPTION
Closes #3213

Logs and errors used "does not exists" and "doesn't exists". The missing-file message on Paramiko platforms is the one from the issue, and the same wording showed up in local platform code, config checks, and a docs comment.

This switches those strings to "does not exist" / "doesn't exist", updates the unit test list that carried the old text, and notes it in the 4.2.0 changelog.

**Check List**

- [x] I have read CONTRIBUTING.md.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to pyproject.toml.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in CHANGELOG.md if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
