### PR TITLE
[Documentation] Fix SCRATCH_DIR in new platform example

### DIFF
--- a/docs/source/userguide/configure/index.rst
+++ b/docs/source/userguide/configure/index.rst
@@ -369,7 +369,7 @@ To add a new platform, open the ``platforms_<EXPID>.yml`` file and add:
             HOST: <host_name>
             PROJECT: <project>
             USER: <user>
-            SCRATCH: <scratch_dir>
+            SCRATCH_DIR: <scratch_dir>
             MAX_WALLCLOCK: <HH:MM>
             QUEUE: <hpc_queue>
             # OPTIONAL


### PR DESCRIPTION
Closes #3222

The `new_platform` example used `SCRATCH`, while Autosubmit's platform configuration and the parameter table immediately below require `SCRATCH_DIR`. This updates the example so copying it no longer produces an invalid platform configuration.

## Validation

- extracted the YAML example and parsed it with PyYAML
- verified `PLATFORMS.new_platform` contains `SCRATCH_DIR` and not `SCRATCH`
- `git diff --check`

A separate test was not added because this is a one-key documentation correction; no runtime code or dependencies changed.

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes were needed.
- [x] Tests are included (or explain why tests are not needed).
- [x] No changelog entry is needed for this documentation-only correction.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).