### PR TITLE
fix: update Docker Python version to 3.10.20

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,7 +126,7 @@ USER $MAMBA_USER
 # Install Python
 RUN micromamba install --yes --name base --channel conda-forge \
       git=2.41.0 \
-      python=3.9.16 && \
+      python=3.10.20 && \
     micromamba clean --all --yes && \
     /usr/local/bin/_activate_current_env.sh
 


### PR DESCRIPTION
Closes #3225

## Summary

This PR updates the Python version used in the Docker image from 3.9.16 to 3.10.20.

The Docker build was failing because Autosubmit 4.2.0 requires Python 3.10+, while the Dockerfile was pinned to Python 3.9.16.

## Validation

- Docker image builds successfully.
- `autosubmit configure` completes successfully.
- Verified the image uses Python 3.10.20.

## Checklist

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes.
- [x] Does not contain off-topic changes.
- [ ] Applied any dependency changes to `pyproject.toml`.
- [ ] Tests are included (not needed for this Dockerfile-only version change).
- [ ] Changelog entry included in `CHANGELOG.md` (not needed for this CI/Docker fix).
- [ ] Documentation updated (not needed).
- [x] If this is a bug fix, PR includes a link to the issue (`Closes #3225`).