### PR TITLE
Fix expid accepting unrelated status filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ several bug fixes and enhancements to improve the overall user experience.
 
 **Bug fixes:**
 
+- Remove the unrelated `--filter_status` option from `autosubmit expid` #3241
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166
 

--- a/autosubmit/scripts/expid.py
+++ b/autosubmit/scripts/expid.py
@@ -60,7 +60,6 @@ class ExpidCommandOptions(DefaultOptions):
     testcase: bool
     dummy: bool
     minimal_configuration: bool
-    filter_status: str
     copy: bool
     git_repo: str
     git_branch: str
@@ -104,22 +103,6 @@ def args_parser() -> ArgumentParser:
         "--minimal_configuration",
         action="store_true",
         help="Create a new experiment with minimal configuration, usually combined with -repo.",
-    )
-    # TODO: This looks like a copy-pasta bug!
-    group.add_argument(
-        "-fs",
-        "--filter_status",
-        type=str,
-        choices=(
-            "Any",
-            "READY",
-            "COMPLETED",
-            "WAITING",
-            "SUSPENDED",
-            "FAILED",
-            "UNKNOWN",
-        ),
-        help="Select the original status to filter the list of jobs.",
     )
     parser.add_argument("-y", "--copy", help="Make a copy of the specified experiment.")
     parser.add_argument(

--- a/test/unit/scripts/test_expid.py
+++ b/test/unit/scripts/test_expid.py
@@ -1,0 +1,30 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for the ``autosubmit.scripts.expid`` module."""
+
+from autosubmit.scripts.expid import args_parser
+
+
+def test_expid_does_not_accept_filter_status():
+    """The expid command must not expose the unrelated job-status filter."""
+    option_strings = {
+        option for action in args_parser()._actions for option in action.option_strings
+    }
+
+    assert "-fs" not in option_strings
+    assert "--filter_status" not in option_strings


### PR DESCRIPTION
Closes #3241.

`autosubmit expid` exposed `-fs`/`--filter_status` even though experiment creation never consumes a job-status filter. This removes the argument and its unused option annotation, and adds a parser regression to keep both aliases out of the command.

The user-visible removal is recorded in the changelog.

**Validation**

- `pytest -q test/unit/scripts/test_expid.py test/unit/scripts` (124 passed)
- `ruff check autosubmit/scripts/expid.py test/unit/scripts/test_expid.py`
- `ruff format --check autosubmit/scripts/expid.py test/unit/scripts/test_expid.py`
- `python -m build`

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes.
- [x] Does not contain off-topic changes.
- [x] No dependency changes.
- [x] Tests are included.
- [x] Changelog entry included.
- [x] No separate documentation update is needed; the generated command help no longer lists the invalid option.
- [x] Links the bug issue.

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>
