### PR TITLE
fix: clean statistics files from stats directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ several bug fixes and enhancements to improve the overall user experience.
 - Remove the unrelated `--filter_status` option from `autosubmit expid` #3241
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166
+- Fix `clean` command to correctly delete files with `--stats` and `--plots` #3254 (thanks @Ha1baraA11)
 
 **New Features:**
 
@@ -47,6 +48,7 @@ several bug fixes and enhancements to improve the overall user experience.
 - The documentation of CLI commands are synced automatically with the Sphinx docs #3171 #1344
 - Most `autosubmit` sub-commands now support the `--profiler`` to run with cProfile #1094 #3171
 - Every command now prints traceability information (AS/Python version, Linux, user name, ...) #2795 #3171
+- Improved provenance documentation, describing the inputs, outputs, how options are merged, etc. #3232
 
 ### 4.1.17: Bug fixes and enhancements
 

--- a/autosubmit/monitor/monitor.py
+++ b/autosubmit/monitor/monitor.py
@@ -258,17 +258,21 @@ def _check_final_status(
     return edge_color, label, fail_ok
 
 
-def _delete_stats_files_but_two_newest(expid: str, _filter: Callable[[Path], bool]) -> None:
-    """Function to clean space on ``BasicConfig.LOCAL_ROOT_DIR/plot`` directory.
+def _delete_files_but_two_newest(
+        expid: str, directory: str, _filter: Callable[[Path], bool]
+) -> None:
+    """Clean files in an experiment directory while keeping the newest two.
 
-    Removes all plots that pass the filter, keeping the newest two files only.
+    Removes all files that pass the filter, keeping the newest two files only.
 
     :param expid: Experiment ID.
     :type expid: str
-    :param _filter: A filter to apply to each file located in the plot directory.
+    :param directory: Directory below the experiment root to clean.
+    :type directory: str
+    :param _filter: A filter to apply to each file in the directory.
     :type _filter: Callable[[Path], bool]
     """
-    search_dir = Path(BasicConfig.LOCAL_ROOT_DIR, expid, "plot")
+    search_dir = Path(BasicConfig.LOCAL_ROOT_DIR, expid, directory)
     search_dir_files = [
         f for f in search_dir.iterdir()
         if f.is_file()
@@ -291,18 +295,18 @@ def clean_plot(expid: str) -> None:
     :param expid: experiment's identifier
     :type expid: str
     """
-    _delete_stats_files_but_two_newest(expid, lambda f: 'statistics' not in f.name)
+    _delete_files_but_two_newest(expid, "plot", lambda f: 'statistics' not in f.name)
 
 
 def clean_stats(expid: str) -> None:
     """
-    Function to clean space on BasicConfig.LOCAL_ROOT_DIR/plot directory.
-    Removes all stats' plots except the last two.
+    Function to clean space on BasicConfig.LOCAL_ROOT_DIR/stats directory.
+    Removes all stats except the last two.
 
     :param expid: experiment's identifier
     :type expid: str
     """
-    _delete_stats_files_but_two_newest(expid, lambda f: 'statistics' in f.name)
+    _delete_files_but_two_newest(expid, "stats", lambda f: 'statistics' in f.name)
 
 
 # TODO: This class can be replaced by module-level functions. There is no need to have

--- a/test/integration/scripts/test_clean.py
+++ b/test/integration/scripts/test_clean.py
@@ -70,42 +70,36 @@ def test_clean_plots(autosubmit_exp):
 def test_clean_stats(autosubmit_exp):
     """Test cleaning statistics files in an Autosubmit experiment.
 
-    The test case contains five files, four plots, and one statistics file.
-
-    Cleaning statistics files without specifying the ``-plots`` results
-    in only statistics files deleted (anything that contains "statistics"
-    in the name is kept).
-
-    So, the command will keep the plot file, as well as the two newest
-    statistics files. Everything else will be deleted.
+    Statistics are written to the experiment's ``stats`` directory. Cleaning
+    them keeps the two newest statistics files and leaves plots untouched.
     """
     exp = autosubmit_exp(experiment_data={})
 
+    stats_dir = Path(exp.as_conf.basic_config.LOCAL_ROOT_DIR, f"{exp.expid}/stats/")
     plots_dir = Path(exp.as_conf.basic_config.LOCAL_ROOT_DIR, f"{exp.expid}/plot/")
+    stats_dir.mkdir(parents=True, exist_ok=True)
+    plots_dir.mkdir(parents=True, exist_ok=True)
+    (plots_dir / "plot_a.pdf").touch()
 
-    for i, plot in enumerate(
+    for i, stats_file in enumerate(
         [
-            "plot_a.pdf",
-            "plot_b.pdf",
-            "plot_c.pdf",
-            "plot_d.pdf",
             f"{exp.expid}_statistics_1.pdf",
             f"{exp.expid}_statistics_2.pdf",
             f"{exp.expid}_statistics_3.pdf",
         ]
     ):
-        p = Path(plots_dir / plot)
+        p = Path(stats_dir / stats_file)
         p.touch()
         utime(str(p), (i, i))
 
     _autosubmit(["clean", exp.expid, "--stats"])
 
-    plots = list(plots_dir.iterdir())
+    stats = list(stats_dir.iterdir())
 
-    # keeps plot files and two newest statistics files
-    assert len(plots) == 6
-    assert Path(plots_dir / f"{exp.expid}_statistics_2.pdf").exists()
-    assert Path(plots_dir / f"{exp.expid}_statistics_3.pdf").exists()
+    assert len(stats) == 2
+    assert Path(stats_dir / f"{exp.expid}_statistics_2.pdf").exists()
+    assert Path(stats_dir / f"{exp.expid}_statistics_3.pdf").exists()
+    assert Path(plots_dir / "plot_a.pdf").exists()
 
 
 def test_clean_dummy_project(autosubmit_exp, mocker):

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -614,40 +614,37 @@ def test_clean_plot(mocker, tmp_path: LocalPath):
 
 
 def test_clean_stats(mocker, tmp_path: LocalPath):
-    """Verify that ``clean_plot`` deletes the *statistics* plot files.
-
-     It must leave the latest 2 statistics files, and the plot files untouched."""
+    """Verify that ``clean_stats`` deletes the oldest statistics files."""
     expid = 't000'
-    search_dir = Path(tmp_path / expid / 'plot')
-    search_dir.mkdir(parents=True, exist_ok=True)
+    stats_dir = Path(tmp_path / expid / 'stats')
+    stats_dir.mkdir(parents=True, exist_ok=True)
+    plot_dir = Path(tmp_path / expid / 'plot')
+    plot_dir.mkdir(parents=True, exist_ok=True)
 
     for i, stats_file in enumerate([
-        'plot_a.pdf',
         f'{expid}_statistics_19900101.csv',
-        'plot_b.pdf',
         f'{expid}_statistics_19900102.csv',
-        'plot_c.pdf',
         f'{expid}_statistics_19900103.csv',
     ]):
-        Path(search_dir / stats_file).touch()
+        Path(stats_dir / stats_file).touch()
         # Here we set the atime, mtime tuple to the enumeration index, so that
         # the generated files do not have the same milliseconds, making this test
         # deterministic.
-        utime(Path(search_dir / stats_file), (i, i))
+        utime(Path(stats_dir / stats_file), (i, i))
 
-    assert len(list(Path(search_dir).iterdir())) == 6
+    plot_file = plot_dir / 'plot_a.pdf'
+    plot_file.touch()
+    assert len(list(stats_dir.iterdir())) == 3
 
     mocker.patch('autosubmit.monitor.monitor.BasicConfig.LOCAL_ROOT_DIR', str(tmp_path))
 
     clean_stats(expid)
 
-    assert len(list(Path(search_dir).iterdir())) == 5
+    assert len(list(stats_dir.iterdir())) == 2
     # <EXPID>_statistics_19900101.csv had the earliest atime, mtime, so it was deleted and only the two newest kept.
-    assert Path(search_dir / f'{expid}_statistics_19900102.csv').exists()
-    assert Path(search_dir / f'{expid}_statistics_19900103.csv').exists()
-    assert Path(search_dir / 'plot_a.pdf').exists()
-    assert Path(search_dir / 'plot_b.pdf').exists()
-    assert Path(search_dir / 'plot_c.pdf').exists()
+    assert Path(stats_dir / f'{expid}_statistics_19900102.csv').exists()
+    assert Path(stats_dir / f'{expid}_statistics_19900103.csv').exists()
+    assert plot_file.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #3199.

Statistics files are written under `<expid>/stats/`, but `autosubmit clean --stats` was scanning `<expid>/plot/`. Make the cleanup helper receive its target directory, so statistics cleanup retains the two newest files in `stats/` without touching plots.

## Testing

- `pytest -n 0 test/unit/monitor/test_monitor.py -q` — 64 passed
- Ruff, compile and diff checks passed
- The focused integration clean tests are blocked locally before assertions by an existing macOS multiprocessing database-path failure; the unmodified baseline fails at the same point.