### PR TITLE
Fix split grouping mutating the job list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ several bug fixes and enhancements to improve the overall user experience.
 
 **Bug fixes:**
 
+- Preserve the job list while calculating automatic split groups #3238
 - Remove the unrelated `--filter_status` option from `autosubmit expid` #3241
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166

--- a/autosubmit/job/job_grouping.py
+++ b/autosubmit/job/job_grouping.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
 
 class JobGrouping:
 
-    def __init__(self, group_by: str, jobs: list["Job"], job_list: "JobList", expand_list: list | None = None,
-                 expanded_status: list | None = None):
+    def __init__(self, group_by: str, jobs: list["Job"], job_list: "JobList", expand_list: str | None = None,
+                 expanded_status: list[int] | None = None):
         if not expand_list:
-            expand_list = []
+            expand_list = ""
         if not expanded_status:
             expanded_status = []
 
@@ -42,17 +42,17 @@ class JobGrouping:
         self.expand_list = expand_list
         self.expand_status = expanded_status
         self.automatic = False
-        self.group_status_dict = {}
-        self.ungrouped_jobs = []
+        self.group_status_dict: dict[str, Any] = {}
+        self.ungrouped_jobs: list[str] = []
 
     def group_jobs(self) -> dict[str, Any]:
         if self.expand_list:
             self._set_expanded_jobs()
 
-        jobs_group_dict = {}
-        blacklist = []
+        jobs_group_dict: dict[str, list[str]] = {}
+        blacklist: list[str] = []
 
-        groups_map = {}
+        groups_map: dict[str, str] = {}
         if self.group_by == 'automatic':
             self.automatic = True
             jobs_group_dict = self._automatic_grouping(groups_map)
@@ -63,7 +63,7 @@ class JobGrouping:
                 status = self._set_group_status(statuses)
                 self.group_status_dict[group] = status
 
-        final_jobs_group = {}
+        final_jobs_group: dict[str, list[str]] = {}
         for job, groups in jobs_group_dict.items():
             for group in groups:
                 if group not in blacklist:
@@ -178,7 +178,7 @@ class JobGrouping:
         for i in reversed(range(len(self.jobs))):
             job = self.jobs[i]
 
-            groups = []
+            groups: list[str] = []
             if not self._check_synchronized_job(job, groups):
                 if self.group_by == 'split':
                     if job.split is not None and job.split > 0:
@@ -249,10 +249,8 @@ class JobGrouping:
         :return: Mapping of job names to the list of resolved groups.
         """
         split_groups, split_groups_status = self._create_splits_groups()
-        # TODO: (See why) Apparently, the splits_groups depletes the self.jobs, so we need to restore it
-        self.jobs = self.job_list.job_list
-        blacklist = []
-        jobs_group_dict = {}
+        blacklist: list[str] = []
+        jobs_group_dict: dict[str, list[str]] = {}
         self.group_status_dict = {}
         self.group_by = 'chunk'
 
@@ -276,10 +274,14 @@ class JobGrouping:
         return jobs_group_dict
 
     def _create_splits_groups(self):
-        jobs_group_dict = {}
-
-        self.group_by = 'split'
-        self._create_groups(jobs_group_dict, [])
+        jobs_group_dict: dict[str, list[str]] = {}
+        jobs = self.jobs
+        self.jobs = jobs.copy()
+        try:
+            self.group_by = 'split'
+            self._create_groups(jobs_group_dict, [])
+        finally:
+            self.jobs = jobs
         return jobs_group_dict, self.group_status_dict
 
     def _fix_splits_automatic_grouping(self, split_groups, split_groups_status, jobs_group_dict):

--- a/test/unit/test_job_grouping.py
+++ b/test/unit/test_job_grouping.py
@@ -283,6 +283,24 @@ def test_automatic_grouping_all(job_list, mocker):
     assert grouped["jobs"] == groups_dict["jobs"]
 
 
+def test_create_splits_groups_preserves_jobs(job_list):
+    job_list.add_job(_create_dummy_job(
+        'expid_19000101_m1_1_1_CMORATM',
+        Status.WAITING,
+        '19000101',
+        'm1',
+        1,
+        1))
+    jobs = job_list.get_job_list()
+    original_jobs = jobs.copy()
+    job_grouping = JobGrouping('automatic', jobs, job_list)
+
+    job_grouping._create_splits_groups()
+
+    assert job_grouping.jobs is jobs
+    assert job_grouping.jobs == original_jobs
+
+
 def test_automatic_grouping_not_ini(job_list, mocker):
     job_list.get_job_by_name('expid_19000101_m1_INI').status = Status.READY
     job_list.get_job_by_name('expid_19000101_m2_INI').status = Status.READY


### PR DESCRIPTION
Closes #3238.

`_create_splits_groups()` passed the shared job list to `_create_groups()`, which removes grouped jobs in place. Automatic grouping then restored `self.jobs` by assigning `job_list.job_list`, making correctness depend on that separate alias.

This change performs split grouping on a temporary shallow copy and restores the original list object in a `finally` block. The caller-side repair is no longer needed. A focused regression verifies both list identity and contents after split grouping.

Validation:

- `pytest test/unit/test_job_grouping.py -q` (21 passed)
- `ruff check autosubmit/job/job_grouping.py test/unit/test_job_grouping.py`
- `python -m build`
- Full unit run: 2,394 passed, 41 skipped; three unrelated environment failures (two local-clone failures caused by the partial checkout's unavailable promisor object, and one CLI lookup failure because the virtualenv bin directory was not on `PATH`)

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>
