### PR TITLE
Fix multi-member PJM job lookup parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ several bug fixes and enhancements to improve the overall user experience.
 
 **Bug fixes:**
 
+- Fix multi-member PJM job lookup output parsing #3255
 - Remove the unrelated `--filter_status` option from `autosubmit expid` #3241
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166

--- a/autosubmit/platforms/pjmplatform.py
+++ b/autosubmit/platforms/pjmplatform.py
@@ -16,6 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+import shlex
 import textwrap
 from pathlib import Path
 from time import sleep
@@ -156,7 +157,7 @@ class PJMPlatform(ParamikoPlatform):
             return status
         return status[0]
 
-    def parse_job_list(self, job_list: list[list["Job"]]) -> str:
+    def parse_job_list(self, job_list: list["Job"]) -> str:
         """Convert a list of job_list to job_list_cmd.
 
         :param job_list: list of jobs
@@ -362,21 +363,20 @@ class PJMPlatform(ParamikoPlatform):
         if not job_names:
             return ""
 
-        commands = "; ".join(
-            f'pjstat -v --choose jid,jnam --filter "jnam={job_name}"'
-            for job_name in job_names
-        )
+        commands = []
+        for job_name in job_names:
+            job_filter = shlex.quote(f"jnam={job_name}")
+            awk_job_name = shlex.quote(job_name)
+            commands.append(
+                f"pjstat -v --choose jid,jnam --filter {job_filter} | "
+                f"awk -v job_name={awk_job_name} '$1 ~ /^[0-9]+$/ {{"
+                'ids = ids ? ids "," $1 : $1'
+                "} END {"
+                'if (ids) print job_name ":" ids'
+                "}'"
+            )
 
-        return (
-            f"{commands} | "
-            "awk '$1 ~ /^[0-9]+$/ {"
-            "job_name = $NF; "
-            "sub(/\\.cmd$/, \"\", job_name); "
-            "jobs[job_name] = jobs[job_name] ? jobs[job_name] \",\" $1 : $1"
-            "} END {"
-            "for (name in jobs) print name \":\" jobs[name]"
-            "}'"
-        )
+        return f"{{ {'; '.join(commands)}; }}"
 
     def cancel_jobs(self, job_ids: list[str]) -> None:
         """Cancel PJM jobs by their IDs.

--- a/test/unit/platforms/test_pjm.py
+++ b/test/unit/platforms/test_pjm.py
@@ -16,6 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import subprocess
 from collections import OrderedDict
 from pathlib import Path
 
@@ -290,14 +291,50 @@ def test_get_job_names_cmd_empty_list_returns_empty(
 def test_get_job_names_cmd_nonempty(
         pjm_platform: PJMPlatform,
 ) -> None:
-    """grouping for a non-empty job-name list.
+    """Group each query under the requested, untruncated job name.
 
     :param pjm_platform: PJM platform under test.
     """
-    cmd = pjm_platform._get_job_names_cmd(["job_a", "job_b"])
+    job_a = "abnk_20120101_fc1_ENSEMBLE_INI"
+    job_b = "abnk_20120101_fc2_ENSEMBLE_INI"
+    cmd = pjm_platform._get_job_names_cmd([job_a, job_b])
 
-    assert "job_a" in cmd
-    assert "job_b" in cmd
+    assert cmd.startswith("{ ")
+    assert cmd.endswith("; }")
+    assert cmd.count("pjstat -v --choose jid,jnam") == 2
+    assert cmd.count("| awk -v job_name=") == 2
+    assert f"-v job_name={job_a}" in cmd
+    assert f"-v job_name={job_b}" in cmd
+    assert "$NF" not in cmd
+
+
+def test_get_job_names_cmd_preserves_names_when_pjstat_truncates_them(
+        pjm_platform: PJMPlatform,
+) -> None:
+    """Use requested names instead of PJM's truncated display column."""
+    job_a = "abnk_20120101_fc1_ENSEMBLE_INI"
+    job_b = "abnk_20120101_fc2_ENSEMBLE_INI"
+    cmd = pjm_platform._get_job_names_cmd([job_a, job_b])
+    fake_pjstat = r'''
+pjstat() {
+    case "$*" in
+        *fc1*) printf 'JOB_ID JOB_NAME\n51509743 abnk_20120\n51509744 abnk_20120\n' ;;
+        *fc2*) printf 'JOB_ID JOB_NAME\n51509745 abnk_20120\n' ;;
+    esac
+}
+'''
+
+    result = subprocess.run(
+        ["bash", "-c", f"{fake_pjstat}\n{cmd}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert set(result.stdout.splitlines()) == {
+        f"{job_a}:51509743,51509744",
+        f"{job_b}:51509745",
+    }
 
 
 def test_cancel_jobs_empty_list_sends_no_command(


### PR DESCRIPTION
Closes #3255.

PJM's duplicate-job lookup joined multiple `pjstat` commands with semicolons and appended one pipe. Shell precedence therefore sent only the final query through AWK; earlier queries emitted raw headers and rows, which caused `_parse_job_names()` to raise while unpacking its expected `name:ids` format.

This change groups every `pjstat` query before piping their combined output through the existing AWK normalizer. The regression verifies that both queried job names occur upstream of the pipe.

Validation:

- `pytest test/unit/platforms/test_pjm.py test/unit/platforms/test_paramiko_platform.py -q` (132 passed)
- `ruff check autosubmit/platforms/pjmplatform.py test/unit/platforms/test_pjm.py`
- `python -m build`

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>
