### PR TITLE
Pt2: Refactor experiment status traceability (Pt 1: https://github.com/BSC-ES/autosubmit/pull/2980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ several bug fixes and enhancements to improve the overall user experience.
 - [enhancement] Allow recovery to update current running/ready jobs #1251
 - `autosubmit` Bash autocomplete #1227 #3171
 - Added "Did you mean 'run'" when an unknown sub-command is similar (e.g., "rum") to a valid one. #3194 #3171
+- Extended possible experiment statuses in `experiment_status` table, added `last_heartbeat` column as a keep-alive signal for running experiments #2947
 
 **Migration from `job_list.pkl` to Database**
 

--- a/autosubmit/config/configcommon.py
+++ b/autosubmit/config/configcommon.py
@@ -2360,7 +2360,7 @@ class AutosubmitConfig:
             return self.experiment_data["DEFAULT"]["HPCARCH"].upper()
         except KeyError:
             raise AutosubmitCritical(
-                "Defaul HPCARCH not defined in the configuration file", 7014
+                "Default HPCARCH not defined in the configuration file", 7014
             )
         except Exception as exc:
             raise AutosubmitCritical(
@@ -2739,7 +2739,7 @@ class AutosubmitConfig:
         if not datelist or not chunks:
             return
 
-        if isinstance(datelist, str) or isinstance(datelist, int):
+        if isinstance(datelist, (str, int)):
             datelist = str(datelist).split()
 
         for section_name, section_data in self.jobs_data.items():

--- a/autosubmit/database/db_common.py
+++ b/autosubmit/database/db_common.py
@@ -23,13 +23,14 @@ import sqlite3
 import subprocess
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import delete, func, insert, select, text, update
+from sqlalchemy import Connection, delete, func, insert, select, update
 from sqlalchemy.schema import CreateTable
 
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database import session, tables
+from autosubmit.history.experiment_status import ExperimentStatus
 from autosubmit.log.log import AutosubmitCritical, Log
 
 if TYPE_CHECKING:
@@ -318,14 +319,12 @@ def last_name_used(test=False, operational=False, evaluation=False):
     return result
 
 
-def delete_experiment(experiment_id):
+def delete_experiment(experiment_id: str) -> bool:
     """
-    Removes experiment from database. Anti-lock version.
+    Marks experiment as deleted in metadata tables. Anti-lock version.
 
     :param experiment_id: experiment identifier
-    :type experiment_id: str
-    :return: True if delete is successful
-    :rtype: bool
+    :return: True if operation is successful
     """
     fn = _delete_experiment
     if BasicConfig.DATABASE_BACKEND == 'postgres':
@@ -595,29 +594,24 @@ def _last_name_used(test=False, operational=False, evaluation=False):
     return row[0]
 
 
-def _delete_experiment(experiment_id):
+def _delete_experiment(experiment_id: str) -> bool:
     """
-    Removes experiment from database
+    Marks an experiment as deleted in database while preserving
+    the experiment row to avoid reusing assigned experiment IDs.
 
     :param experiment_id: experiment identifier
-    :type experiment_id: str
-    :return: True if delete is successful
-    :rtype: bool
+    :return: True if operation is successful
     """
-    check_db()
-
-    if not _check_experiment_exists(experiment_id, False):  # Reference the no anti-lock version.
+    if not _check_experiment_exists(
+        experiment_id, False
+    ):  # Reference the no anti-lock version.
         return True
     try:
-        (conn, cursor) = open_conn()
-    except DbException as e:
-        raise AutosubmitCritical("Could not establish a connection to database", 7001, str(e))
-    cursor.execute('DELETE FROM experiment '
-                   'WHERE name=:name', {'name': experiment_id})
-    row = cursor.fetchone()
-    if row is None:
-        Log.debug(f'The experiment {experiment_id} has been deleted!!!')
-    close_conn(conn, cursor)
+        ExperimentStatus(experiment_id).set_as_deleted()
+    except Exception as e:
+        raise AutosubmitCritical("Could not mark experiment as deleted", 7001, str(e))
+
+    Log.debug(f"The experiment {experiment_id} has been marked as deleted.")
     return True
 
 
@@ -860,30 +854,13 @@ def _delete_experiment_sqlalchemy(experiment_id: str) -> bool:
         experiment_id, False
     ):  # Reference the no anti-lock version.
         return True
+    try:
+        ExperimentStatus(experiment_id).set_as_deleted()
+    except Exception as e:
+        raise AutosubmitCritical("Could not mark experiment as deleted", 7001, str(e))
 
-    with _get_sqlalchemy_conn() as conn:
-        with conn.begin():
-            # Delete from experiment table
-            query = delete(tables.ExperimentTable).where(
-                tables.ExperimentTable.c.name == experiment_id  # type: ignore
-            )
-            result = conn.execute(query)
-
-            # Drop schema
-            conn.execute(text(f'DROP SCHEMA IF EXISTS "{experiment_id}" CASCADE'))
-
-            # Delete from experiment_status table
-            try:
-                query = delete(tables.ExperimentStatusTable).where(
-                    tables.ExperimentStatusTable.c.name == experiment_id  # type: ignore
-                )
-                conn.execute(query)
-            except Exception as e:
-                Log.debug(f"The experiment {experiment_id} has no status: {str(e)}")
-
-        if cast(int, result.rowcount) > 0:
-            Log.debug(f"The experiment {experiment_id} has been deleted!!!")
-        return True
+    Log.debug(f"The experiment {experiment_id} has been marked as deleted.")
+    return True
 
 
 def _get_experiment_id_sqlalchemy(name: str) -> int:

--- a/autosubmit/database/session.py
+++ b/autosubmit/database/session.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
 # This file is part of Autosubmit.
 #
@@ -42,7 +42,7 @@ def _resolve_engine(connection_url: str) -> Engine:
 class PostgreSQLEngineSingleton:
     """Singleton class to manage a single instance of the PostgreSQL engine."""
 
-    _instance: Engine = None
+    _instance: Engine | None = None
     _lock: threading.Lock = threading.Lock()
 
     @classmethod
@@ -53,6 +53,14 @@ class PostgreSQLEngineSingleton:
                 connection_url = BasicConfig.DATABASE_CONN_URL
                 cls._instance = _resolve_engine(connection_url)
         return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Dispose the cached engine if it exists, so a new one is built on next use."""
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance.dispose()
+                cls._instance = None
 
 
 def get_engine(db_path: str | Path) -> Engine:

--- a/autosubmit/database/tables.py
+++ b/autosubmit/database/tables.py
@@ -61,6 +61,7 @@ ExperimentStatusTable = Table(
     Column("status", Text, nullable=False),
     Column("seconds_diff", Integer, nullable=False),
     Column("modified", Text, nullable=False),
+    Column("last_heartbeat", Text, nullable=True),
 )
 """Stores the status of the experiments."""
 
@@ -153,7 +154,7 @@ JobDataTable = Table(
 
 """All these tables will go inside the $expid/db/job_list.db."""
 # Jobs table
-"""Table that holds the minium neccesary info about the experiment jobs."""
+"""Table that holds the minium necessary info about the experiment jobs."""
 JobsTable = Table(
     "jobs",
     metadata_obj,

--- a/autosubmit/experiment/manage.py
+++ b/autosubmit/experiment/manage.py
@@ -64,6 +64,7 @@ from autosubmit.helpers.version import get_version
 from autosubmit.history.experiment_history import (
     ExperimentHistory,
 )
+from autosubmit.history.experiment_status import ExperimentStatus
 from autosubmit.job.job_common import get_job_status
 from autosubmit.job.job_grouping import JobGrouping
 from autosubmit.job.job_list import JobList, load_job_list
@@ -335,6 +336,14 @@ def expid_fn(
         )
         Log.debug(f"Error calling save_update_details: {str(e)}")
 
+    try:
+        ExperimentStatus(exp_id).set_as_not_running()
+    except Exception as e:
+        Log.warning(
+            f"Could not update the status of experiment {exp_id}. "
+            f"The status will be fixed by the API worker. Error: {str(e)}"
+        )
+
     Log.result(f"Experiment {exp_id} created")
     return exp_id
 
@@ -441,13 +450,6 @@ def _delete_experiment(expid: str, force: bool) -> None:
 
     Log.info(f"Deleting experiment {expid}")
 
-    # Try to delete the experiment details
-    try:
-        ExperimentDetails(expid).delete_details()
-    except Exception as e:
-        Log.warning(f"Failed to delete DB details for experiment {expid}: {str(e)}")
-        raise
-
     try:
         _delete_expid(expid, force)
         Log.info(f"Experiment {expid} has been deleted")
@@ -458,7 +460,7 @@ def _delete_experiment(expid: str, force: bool) -> None:
 
 
 def _delete_expid(expid_delete: str, force: bool = False) -> None:
-    """Removes an experiment from the path and database.
+    """Removes an experiment from the path and marks it as deleted in the database.
 
     If the current user is eadmin and the -f flag has been sent, it deletes regardless of experiment owner.
 
@@ -517,7 +519,7 @@ def _delete_expid(expid_delete: str, force: bool = False) -> None:
             )
 
     message_parts = [
-        f"The {expid_delete} experiment was removed from the local disk and from the database.",
+        f"The {expid_delete} experiment was removed from local disk and marked as deleted in the database.",
         "Note that this action does not delete any data written by the experiment.",
         "Complete list of files/directories deleted:",
         "",
@@ -565,13 +567,6 @@ def _perform_deletion(
 
     is_sqlite = BasicConfig.DATABASE_BACKEND == "sqlite"
 
-    Log.info(f"Deleting experiment from {BasicConfig.DATABASE_BACKEND} database...")
-    try:
-        db_common.delete_experiment(expid_delete)
-        Log.result(f"Experiment {expid_delete} deleted from database")
-    except Exception as e:
-        error_message.append(f"Cannot delete experiment entry: {e}")
-
     Log.info("Removing experiment directory...")
     try:
         rmtree(experiment_path)
@@ -591,6 +586,17 @@ def _perform_deletion(
         db_path.unlink(missing_ok=True)
         sql_path.unlink(missing_ok=True)
         Log.info(f"Experiment {expid_delete} job_data db deleted")
+
+    # Mark experiment status as deleted only after cleanup successful
+    if not error_message:
+        Log.info(
+            f"Updating experiment status in {BasicConfig.DATABASE_BACKEND} database..."
+        )
+        try:
+            db_common.delete_experiment(expid_delete)
+            Log.result(f"Experiment {expid_delete} marked as deleted in database")
+        except Exception as e:
+            error_message.append(f"Cannot update experiment metadata: {e}")
 
     return "\n".join(error_message)
 
@@ -1055,6 +1061,13 @@ def create(
                 )
             Log.result("\nJob list created successfully")
             Log.warning("Remember to MODIFY the MODEL config files!")
+            try:
+                ExperimentStatus(expid).set_as_not_running()
+            except Exception as e:
+                Log.warning(
+                    f"Could not update the status of experiment {expid}. "
+                    f"The status will be fixed by the API worker. Error: {str(e)}"
+                )
             fh.flush()
             os.fsync(fh.fileno())
             if detail:
@@ -1078,6 +1091,11 @@ def archive(expid: str, noclean=True, uncompress=True, create_rocrate=False) -> 
     :param create_rocrate: flag to enable RO-Crate
     :return: ``True`` if the experiment has been successfully archived. ``False`` otherwise.
     """
+    if process_id(expid) is not None:
+        raise AutosubmitCritical(
+            "Ensure no processes are running in the experiment directory", 7076
+        )
+
     exp_folder = Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(expid)
 
     if not noclean:
@@ -1159,6 +1177,13 @@ def archive(expid: str, noclean=True, uncompress=True, create_rocrate=False) -> 
                 )
 
     Log.result("Experiment archived successfully")
+    try:
+        ExperimentStatus(expid).set_as_archived()
+    except Exception as e:
+        Log.warning(
+            f"Could not mark experiment {expid} as archived. "
+            f"The status will be fixed by the API worker. Error: {str(e)}"
+        )
     return True
 
 
@@ -1218,6 +1243,14 @@ def unarchive(experiment_id: str, uncompressed=True, create_rocrate=False) -> bo
         return False
 
     Log.info("Unpacking finished")
+
+    try:
+        ExperimentStatus(experiment_id).set_as_not_running()
+    except Exception as e:
+        Log.warning(
+            f"Could not update the status of experiment {experiment_id}. "
+            f"The status will be fixed by the API worker. Error: {str(e)}"
+        )
 
     try:
         archive_path.unlink()

--- a/autosubmit/history/database_managers/database_manager.py
+++ b/autosubmit/history/database_managers/database_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
 # This file is part of Autosubmit.
 #
@@ -55,6 +55,8 @@ class DatabaseManager(metaclass=ABCMeta):
     def _create_database_file(self, path):
         # type : (str) -> None
         """ creates a database files with full permissions """
+        # FIXME: umask is never restored. Every file
+        # created after this will also lose umask filtering (too permissive).
         os.umask(0)
         if not Path(path).parent.exists():
             Path(path).parent.mkdir(parents=True, exist_ok=True)
@@ -66,28 +68,43 @@ class DatabaseManager(metaclass=ABCMeta):
         # type : (str, str) -> None
         """ Executes a statement on a database file specified by path. """
         conn = self.get_connection(path)
-        cursor = conn.cursor()
-        cursor.execute(statement)
-        conn.commit()
-        conn.close()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(statement)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def execute_statement_with_arguments_on_dbfile(self, path, statement, arguments):
         # type : (str, str, Tuple) -> None
         """ Executes a statement with arguments on a database file specified by path. """
         conn = self.get_connection(path)
-        cursor = conn.cursor()
-        cursor.execute(statement, arguments)
-        conn.commit()
-        conn.close()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(statement, arguments)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def execute_many_statement_with_arguments_on_dbfile(self, path, statement, arguments_list):
         # type : (str, str, List[Tuple]) -> None
         """ Executes many statements from a list of arguments specified by a path. """
         conn = self.get_connection(path)
-        cursor = conn.cursor()
-        cursor.executemany(statement, arguments_list)
-        conn.commit()
-        conn.close()
+        try:
+            cursor = conn.cursor()
+            cursor.executemany(statement, arguments_list)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def execute_many_statements_on_dbfile(self, path, statements):
         # type : (str, List[str]) -> None
@@ -107,35 +124,42 @@ class DatabaseManager(metaclass=ABCMeta):
         # type : (str, str) -> List[Tuple]
         """ Get the rows from a statement with no arguments """
         conn = self.get_connection(path)
-        conn.text_factory = str
-        cursor = conn.cursor()
-        cursor.execute(statement)
-        statement_rows = cursor.fetchall()
-        conn.close()
-        return statement_rows
+        try:
+            conn.text_factory = str
+            cursor = conn.cursor()
+            cursor.execute(statement)
+            return cursor.fetchall()
+        finally:
+            conn.close()
 
     def get_from_statement_with_arguments(self, path, statement, arguments):
         # type : (str, str, Tuple) -> List[Tuple]
         """ Get the rows from a statement with arguments """
         conn = self.get_connection(path)
-        conn.text_factory = str
-        cursor = conn.cursor()
-        cursor.execute(statement, arguments)
-        statement_rows = cursor.fetchall()
-        conn.close()
-        return statement_rows
+        try:
+            conn.text_factory = str
+            cursor = conn.cursor()
+            cursor.execute(statement, arguments)
+            return cursor.fetchall()
+        finally:
+            conn.close()
 
     def insert_statement_with_arguments(self, path, statement, arguments):
         # type : (str, str, Tuple) -> int
         """ Insert statement with arguments into path """
         conn = self.get_connection(path)
-        conn.text_factory = str
-        cursor = conn.cursor()
-        cursor.execute(statement, arguments)
-        lastrow_id = cursor.lastrowid
-        conn.commit()
-        conn.close()
-        return lastrow_id
+        try:
+            conn.text_factory = str
+            cursor = conn.cursor()
+            cursor.execute(statement, arguments)
+            lastrow_id = cursor.lastrowid
+            conn.commit()
+            return lastrow_id
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def get_built_select_statement(self, table_name, conditions=None):
         # type : (str, namedtuple, str) -> str

--- a/autosubmit/history/database_managers/database_models.py
+++ b/autosubmit/history/database_managers/database_models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2015-2020 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 # This file is part of Autosubmit.
 
 # Autosubmit is free software: you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import collections
+from enum import Enum
 
 JobDataRow = collections.namedtuple('JobDataRow', ['id', 'counter', 'job_name', 'created', 'modified', 'submit', 'start', 'finish',
                                                    'status', 'rowtype', 'ncpus', 'wallclock', 'qos', 'energy', 'date', 'section', 'member',
@@ -29,7 +30,9 @@ ExperimentRunRow = collections.namedtuple('ExperimentRunRow', [
     'run_id', 'created', 'modified', 'start', 'finish', 'chunk_unit', 'chunk_size', 'completed', 'total', 'failed', 'queuing', 'running', 'submitted', 'suspended', 'metadata'])
 
 ExperimentStatusRow = collections.namedtuple(
-    'ExperimentStatusRow', ['exp_id', 'name', 'status', 'seconds_diff', 'modified'])
+    "ExperimentStatusRow",
+    ["exp_id", "name", "status", "seconds_diff", "modified", "last_heartbeat"],
+)
 
 ExperimentRow = collections.namedtuple('ExperimentRow', ["id", "name", "autosubmit_version", "description"])
 
@@ -37,9 +40,13 @@ PragmaVersion = collections.namedtuple('PragmaVersion', ['version'])
 MaxCounter = collections.namedtuple('MaxCounter', ['maxcounter'])
 
 
-class RunningStatus:
+class RunningStatus(str, Enum):
+    """Enum representing the possible status of an experiment."""
+
     RUNNING = "RUNNING"
     NOT_RUNNING = "NOT RUNNING"
+    ARCHIVED = "ARCHIVED"
+    DELETED = "DELETED"
 
 
 class RowType:

--- a/autosubmit/history/database_managers/experiment_status_db_manager.py
+++ b/autosubmit/history/database_managers/experiment_status_db_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
 # This file is part of Autosubmit.
 #
@@ -19,9 +19,7 @@ import textwrap
 from pathlib import Path
 from typing import Protocol, cast
 
-from sqlalchemy import select, update
-from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy import delete, func, insert, inspect, select, text, update
 from sqlalchemy.schema import CreateTable
 
 import autosubmit.history.utils as HUtils
@@ -33,6 +31,7 @@ from autosubmit.history.database_managers.database_manager import (
     DEFAULT_LOCAL_ROOT_DIR,
     DatabaseManager,
 )
+from autosubmit.log.log import Log
 
 
 class ExperimentStatusDbManager(DatabaseManager):
@@ -55,31 +54,51 @@ class ExperimentStatusDbManager(DatabaseManager):
         self._validate_status_database()
 
     def _validate_status_database(self):
-        """ Creates experiment_status table if it does not exist """
-        create_table_query = textwrap.dedent(
-            '''CREATE TABLE
+        """Creates experiment_status table if it does not exist"""
+        create_table_query = textwrap.dedent("""CREATE TABLE
                 IF NOT EXISTS experiment_status (
                 exp_id integer PRIMARY KEY,
                 name text NOT NULL,
                 status text NOT NULL,
                 seconds_diff integer NOT NULL,
-                modified text NOT NULL
-            );'''
-        )
+                modified text NOT NULL,
+                last_heartbeat text
+            );""")
         self.execute_statement_on_dbfile(self._as_times_file_path, create_table_query)
 
-    def set_existing_experiment_status_as_running(self, expid: str) -> None:
-        """ Set the experiment_status row as running. """
-        self.update_exp_status(expid, Models.RunningStatus.RUNNING)
+        # backward compatibility
+        self._add_column_if_missing("last_heartbeat", "text")
 
-    def create_experiment_status_as_running(self, experiment: Models.ExperimentRow) -> None:
-        """ Create a new experiment_status row for the Models.Experiment item."""
-        self.create_exp_status(experiment.id, experiment.name, Models.RunningStatus.RUNNING)
+        # keep only latest row by name
+        self.execute_statement_on_dbfile(
+            self._as_times_file_path,
+            """DELETE FROM experiment_status
+               WHERE exp_id NOT IN (
+                   SELECT MAX(exp_id)
+                   FROM experiment_status
+                   GROUP BY name
+               );""",
+        )
 
-    def get_experiment_status_row_by_expid(self, expid: str) -> Models.ExperimentStatusRow | None:
-        """Get Models.ExperimentRow by expid."""
-        experiment_row = self.get_experiment_row_by_expid(expid)
-        return self.get_experiment_status_row_by_exp_id(experiment_row.id)
+        # enforce name as a unique index
+        self.execute_statement_on_dbfile(
+            self._as_times_file_path,
+            """CREATE UNIQUE INDEX IF NOT EXISTS uq_experiment_status_name ON experiment_status(name);""",
+        )
+
+    def _add_column_if_missing(self, column_name: str, column_type: str) -> None:
+        """Add a column to the experiment_status table if it is missing."""
+        if not self._column_exists(self._as_times_file_path, column_name):
+            alter_query = (
+                f"ALTER TABLE experiment_status ADD COLUMN {column_name} {column_type};"
+            )
+            self.execute_statement_on_dbfile(self._as_times_file_path, alter_query)
+
+    def _column_exists(self, path: str, column_name: str) -> bool:
+        """Check whether a column exists in the experiment_status table for SQLite."""
+        query = "PRAGMA table_info(experiment_status);"
+        current_columns = [row[1] for row in self.get_from_statement(path, query)]
+        return column_name in current_columns
 
     def get_experiment_row_by_expid(self, expid: str) -> Models.ExperimentRow:
         """Get the experiment from ecearth.db by expid as Models.ExperimentRow."""
@@ -101,30 +120,68 @@ class ExperimentStatusDbManager(DatabaseManager):
         return Models.ExperimentStatusRow(*current_rows[0])
 
     def create_exp_status(self, exp_id: int, expid: str, status: str) -> int:
-        """Create experiment status."""
-        statement = ''' INSERT INTO experiment_status(exp_id, name,
-        status, seconds_diff, modified) VALUES(?,?,?,?,?) '''
-        arguments = (exp_id, expid, status, 0, HUtils.get_current_datetime())
-        return self.insert_statement_with_arguments(self._as_times_file_path, statement, arguments)
+        """Insert a new experiment status row in the database.
 
-    def update_exp_status(self, expid: str, status="RUNNING") -> None:
+        Raises IntegrityError if a row with the same exp_id (primary key)
+        or the same name (unique index uq_experiment_status_name) already exists.
         """
-        Update status, seconds_diff, modified in experiment_status.
+        statement = """
+            INSERT INTO experiment_status(exp_id, name, status, seconds_diff, modified)
+            VALUES(?, ?, ?, ?, ?)
         """
-        statement = ''' UPDATE experiment_status SET status = ?, 
-        seconds_diff = ?, modified = ? WHERE name = ? '''
-        arguments = (status, 0, HUtils.get_current_datetime(), expid)
+        arguments = (exp_id, expid, status, 0, HUtils.get_current_datetime())
+        return self.insert_statement_with_arguments(
+            self._as_times_file_path, statement, arguments
+        )
+
+    def update_exp_status(
+        self, expid: str, status=Models.RunningStatus.RUNNING
+    ) -> None:
+        """Update status, seconds_diff, modified in experiment_status."""
+        now = HUtils.get_current_datetime()
+        statement = """
+            UPDATE experiment_status SET status = ?,
+            seconds_diff = ?, modified = ?,
+            last_heartbeat = CASE WHEN ? = ? THEN ? ELSE last_heartbeat END
+            WHERE name = ?
+        """
+        arguments = (status, 0, now, status, Models.RunningStatus.RUNNING, now, expid)
         self.execute_statement_with_arguments_on_dbfile(
-            self._as_times_file_path, statement, arguments)
+            self._as_times_file_path, statement, arguments
+        )
+
+    def set_exp_status(self, expid: str, status: str) -> None:
+        try:
+            exp_row = self.get_experiment_row_by_expid(expid)
+        except ValueError as e:
+            Log.warning(
+                f"Experiment {expid} not found when trying to set status. Exception: {str(e)}"
+            )
+            return
+
+        exp_status_now = self.get_experiment_status_row_by_exp_id(exp_row.id)
+
+        # if it already exists, update
+        if exp_status_now:
+            self.update_exp_status(expid, status)
+            return
+
+        # if it does not exist, create
+        self.create_exp_status(exp_row.id, expid, status)
+        if status == Models.RunningStatus.RUNNING:
+            self.update_heartbeat(expid)
+
+    def update_heartbeat(self, expid: str) -> None:
+        now = HUtils.get_current_datetime()
+        statement = """ UPDATE experiment_status SET last_heartbeat = ?, modified = ?
+        WHERE name = ?"""
+        arguments = (now, now, expid)
+        self.execute_statement_with_arguments_on_dbfile(
+            self._as_times_file_path, statement, arguments
+        )
 
 
 class ExperimentStatusDatabaseManager(Protocol):
-
-    def set_existing_experiment_status_as_running(self, expid: str) -> None: ...
-
-    def create_experiment_status_as_running(self, experiment: Models.ExperimentRow) -> None: ...
-
-    def get_experiment_status_row_by_expid(self, expid: str) -> Models.ExperimentStatusRow | None: ...
 
     def get_experiment_row_by_expid(self, expid: str) -> Models.ExperimentRow: ...
 
@@ -132,7 +189,11 @@ class ExperimentStatusDatabaseManager(Protocol):
 
     def create_exp_status(self, exp_id: int, expid: str, status: str) -> int: ...
 
-    def update_exp_status(self, expid: str, status="RUNNING") -> None: ...
+    def set_exp_status(self, expid: str, status: str) -> None: ...
+
+    def update_exp_status(self, expid: str, status=Models.RunningStatus.RUNNING) -> None: ...
+
+    def update_heartbeat(self, expid: str) -> None: ...
 
 
 class SqlAlchemyExperimentStatusDbManager:
@@ -151,18 +212,64 @@ class SqlAlchemyExperimentStatusDbManager:
         self.engine = session.get_engine(
             db_path=Path(BasicConfig.DB_DIR, BasicConfig.AS_TIMES_DB)
         )
+        self._validate_status_database()
+
+    def _validate_status_database(self) -> None:
+        """Creates experiment_status table if it does not exist"""
         with self.engine.connect() as conn, conn.begin():
             conn.execute(CreateTable(ExperimentStatusTable, if_not_exists=True))
 
-    def set_existing_experiment_status_as_running(self, expid):
-        self.update_exp_status(expid, Models.RunningStatus.RUNNING)
+        self._add_column_if_missing("last_heartbeat", "TEXT")
 
-    def create_experiment_status_as_running(self, experiment):
-        self.create_exp_status(experiment.id, experiment.name, Models.RunningStatus.RUNNING)
+        # keep only latest row by name
+        ranked = select(
+            ExperimentStatusTable.c.exp_id,
+            func.row_number()
+            .over(
+                partition_by=ExperimentStatusTable.c.name,
+                order_by=(
+                    ExperimentStatusTable.c.modified.desc(),
+                    ExperimentStatusTable.c.exp_id.desc(),
+                ),
+            )
+            .label("rn"),
+        ).subquery()
 
-    def get_experiment_status_row_by_expid(self, expid: str) -> Models.ExperimentStatusRow | None:
-        experiment_row = self.get_experiment_row_by_expid(expid)
-        return self.get_experiment_status_row_by_exp_id(experiment_row.id)
+        dedup_query = delete(ExperimentStatusTable).where(
+            ExperimentStatusTable.c.exp_id.in_(
+                select(ranked.c.exp_id).where(ranked.c.rn > 1)
+            )
+        )
+
+        with self.engine.connect() as conn, conn.begin():
+            conn.execute(dedup_query)
+
+        # enforce name as a unique index
+        with self.engine.connect() as conn, conn.begin():
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_experiment_status_name "
+                    "ON experiment_status(name)"
+                )
+            )
+
+    def _add_column_if_missing(self, column_name: str, column_type: str) -> None:
+        """Add a column to the experiment_status table if it is missing."""
+        if not self._column_exists(column_name):
+            with self.engine.connect() as conn, conn.begin():
+                conn.execute(
+                    text(
+                        f"ALTER TABLE experiment_status ADD COLUMN {column_name} {column_type};"
+                    )
+                )
+
+    def _column_exists(self, column_name: str) -> bool:
+        """Check whether a column exists in the experiment_status table for SQLAlchemy backends."""
+        inspector = inspect(self.engine)
+        return any(
+            column["name"] == column_name
+            for column in inspector.get_columns("experiment_status")
+        )
 
     def get_experiment_row_by_expid(self, expid: str) -> Models.ExperimentRow:
         query = (
@@ -187,46 +294,65 @@ class SqlAlchemyExperimentStatusDbManager:
         return Models.ExperimentStatusRow(*row)
 
     def create_exp_status(self, exp_id: int, expid: str, status: str) -> int:
-        """Upsert a new experiment status row in the database. If the row already exists, it will be updated."""
-        if BasicConfig.DATABASE_BACKEND == "postgres":
-            _insert_fn = pg_insert
-        else:
-            _insert_fn = sqlite_insert
-        query = (
-            _insert_fn(ExperimentStatusTable)
-            .values(
-                exp_id=exp_id,
-                name=expid,
-                status=status,
-                seconds_diff=0,
-                modified=HUtils.get_current_datetime(),
-            )
-            .on_conflict_do_update(
-                index_elements=[ExperimentStatusTable.c.exp_id],  # type: ignore
-                set_={
-                    "name": expid,
-                    "status": status,
-                    "seconds_diff": 0,
-                    "modified": HUtils.get_current_datetime(),
-                },
-            )
+        """Insert a new experiment status row in the database.
+
+        Raises IntegrityError if a row with the same exp_id (primary key)
+        or the same name (unique index uq_experiment_status_name) already exists.
+        """
+        query = insert(ExperimentStatusTable).values(
+            exp_id=exp_id,
+            name=expid,
+            status=status,
+            seconds_diff=0,
+            modified=HUtils.get_current_datetime(),
         )
-        with self.engine.connect() as conn:
-            with conn.begin():
-                result = conn.execute(query)
-                # NOTE: SQLite == rowcount(), PG == rowcount. Intriguing.
-                row_count = result.rowcount() if callable(result.rowcount) else result.rowcount
+        with self.engine.connect() as conn, conn.begin():
+            row_count = conn.execute(query).rowcount
         return row_count
 
-    def update_exp_status(self, expid: str, status="RUNNING") -> None:
+    def update_exp_status(self, expid: str, status=Models.RunningStatus.RUNNING) -> None:
+        """Update the status of an existing experiment."""
+        now = HUtils.get_current_datetime()
         query = (
-            update(ExperimentStatusTable).
-            where(ExperimentStatusTable.c.name == expid).  # type: ignore
-            values(
+            update(ExperimentStatusTable)
+            .where(ExperimentStatusTable.c.name == expid)  # type: ignore
+            .values(
                 status=status,
                 seconds_diff=0,
-                modified=HUtils.get_current_datetime()
+                modified=now,
+                last_heartbeat=now if status == Models.RunningStatus.RUNNING else ExperimentStatusTable.c.last_heartbeat,  # type: ignore
             )
+        )
+        with self.engine.connect() as conn, conn.begin():
+            conn.execute(query)
+
+    def set_exp_status(self, expid: str, status: str) -> None:
+        try:
+            exp_row = self.get_experiment_row_by_expid(expid)
+        except ValueError as e:
+            Log.warning(
+                f"Experiment {expid} not found when trying to set status. Exception: {str(e)}"
+            )
+            return
+
+        exp_status_now = self.get_experiment_status_row_by_exp_id(exp_row.id)
+
+        # if it already exists, update
+        if exp_status_now:
+            self.update_exp_status(expid, status)
+            return
+
+        # if it does not exist, create
+        self.create_exp_status(exp_row.id, expid, status)
+        if status == Models.RunningStatus.RUNNING:
+            self.update_heartbeat(expid)
+
+    def update_heartbeat(self, expid: str) -> None:
+        now = HUtils.get_current_datetime()
+        query = (
+            update(ExperimentStatusTable)
+            .where(ExperimentStatusTable.c.name == expid)  # type: ignore
+            .values(last_heartbeat=now, modified=now)
         )
         with self.engine.connect() as conn, conn.begin():
             conn.execute(query)

--- a/autosubmit/history/experiment_history.py
+++ b/autosubmit/history/experiment_history.py
@@ -12,9 +12,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-import os
 import traceback
 from time import time
+from pathlib import Path
 
 import autosubmit.history.database_managers.database_models as Models
 import autosubmit.history.utils as HUtils
@@ -525,8 +525,10 @@ def get_historical_database(expid, job_list, as_conf):
     try:
         ExperimentStatus(expid).set_as_running()
     except Exception as e:
-        # Connection to status database ec_earth.db can fail.
+        # Connection to status database as_times.db can fail.
         # API worker will fix the status.
-        Log.debug(f"Autosubmit couldn't set your experiment as running on the autosubmit times database: "
-                  f"{os.path.join(BasicConfig.DB_DIR, BasicConfig.AS_TIMES_DB)}. Exception: {str(e)}", 7003)
+        Log.debug(
+            f"Autosubmit couldn't set your experiment as running on the autosubmit times database: "
+            f"{Path(BasicConfig.DB_DIR) / BasicConfig.AS_TIMES_DB}. Exception: {str(e)}"
+        )
     return exp_history

--- a/autosubmit/history/experiment_history.py
+++ b/autosubmit/history/experiment_history.py
@@ -13,8 +13,8 @@
 # GNU General Public License for more details.
 
 import traceback
-from time import time
 from pathlib import Path
+from time import time
 
 import autosubmit.history.database_managers.database_models as Models
 import autosubmit.history.utils as HUtils

--- a/autosubmit/history/experiment_status.py
+++ b/autosubmit/history/experiment_status.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 Earth Sciences Department, BSC-CNS
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
 #
 # This file is part of Autosubmit.
 #
@@ -15,9 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
+import threading
 import traceback
 
+from typing_extensions import Self
+
 from autosubmit.config.basicconfig import BasicConfig
+from autosubmit.history.database_managers import database_models as Models
 from autosubmit.history.database_managers.database_manager import (
     DEFAULT_HISTORICAL_LOGS_DIR,
     DEFAULT_LOCAL_ROOT_DIR,
@@ -26,36 +30,206 @@ from autosubmit.history.database_managers.experiment_status_db_manager import (
     create_experiment_status_db_manager,
 )
 from autosubmit.history.internal_logging import Logging
+from autosubmit.log.log import Log
+
+
+class ExperimentHeartBeatMonitor:
+    """Keeps the experiment heartbeat active while the experiment is running."""
+
+    def __init__(self, status_tracker: "ExperimentStatus", interval_seconds: int = 120):
+        self._status_tracker = status_tracker
+        self._interval_seconds = max(1, interval_seconds)
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._ping_lock = threading.Lock()
+        self._last_ping_failed = False
+
+    def __enter__(self) -> Self:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> bool:
+        self.stop()
+        return False
+
+    def _run(self) -> None:
+        """Background thread method that updates the heartbeat at regular intervals."""
+        while not self._stop_event.wait(self._interval_seconds):
+            self.ping()
+
+    def ping(self) -> bool:
+        """Ping the heartbeat to update the last_heartbeat timestamp in the database.
+
+        Only the first failure is logged, so a continuous failure does not spam
+        the log messages on every interval.
+        """
+        # Use lock to prevent concurrent updates of the heartbeat, prevent race conditions
+        with self._ping_lock:
+            try:
+                self._status_tracker.update_heartbeat()
+            except Exception as exc:
+                if not self._last_ping_failed:
+                    Log.warning(
+                        f"Failed to update heartbeat for experiment {self._status_tracker.expid}: {exc}"
+                    )
+                self._last_ping_failed = True
+                return False
+            else:
+                if self._last_ping_failed:
+                    Log.info(
+                        f"Heartbeat recovered for experiment {self._status_tracker.expid}."
+                    )
+                self._last_ping_failed = False
+                return True
+
+    def start(self) -> bool:
+        """Start the background thread that updates the heartbeat.
+
+        :return: True if the thread started successfully, False otherwise.
+        :rtype: bool
+        """
+        # If the thread is already running, do nothing
+        if self._thread is not None and self._thread.is_alive():
+            return True
+
+        # clear the stop event in case it was previously set
+        self._stop_event.clear()
+        if not self.ping():
+            self._stop_event.set()
+            return False
+        try:
+            # Initialize the background thread
+            self._thread = threading.Thread(
+                target=self._run,
+                name=f"autosubmit-heartbeat-{self._status_tracker.expid}",
+                daemon=True,
+            )  # set thread as daemon to automatically stop when the parent process exits
+            self._thread.start()
+            return True
+        except Exception:
+            self._thread = None
+            self._stop_event.set()
+            Log.warning(
+                f"Failed to start the heartbeat thread for experiment {self._status_tracker.expid}."
+            )
+            return False
+
+    def stop(self, timeout: float = 10.0) -> None:
+        """Stop the background thread that updates the heartbeat.
+
+        :param timeout: Maximum time to wait for the thread to stop in seconds.
+        :type timeout: float
+        """
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            # Wait for the thread to finish
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                Log.warning(
+                    f"Heartbeat thread for experiment {self._status_tracker.expid} did not stop within the timeout."
+                )
+        self._thread = None
 
 
 class ExperimentStatus:
     """Represents the Experiment Status Mechanism that keeps track of currently active experiments."""
 
-    def __init__(self, expid, local_root_dir_path=DEFAULT_LOCAL_ROOT_DIR,
-                 historiclog_dir_path=DEFAULT_HISTORICAL_LOGS_DIR):
+    def __init__(
+        self,
+        expid,
+        local_root_dir_path=DEFAULT_LOCAL_ROOT_DIR,
+        historiclog_dir_path=DEFAULT_HISTORICAL_LOGS_DIR,
+    ):
         # type : (str) -> None
         self.expid = expid  # type : str
         BasicConfig.read()
         try:
             options = {
-                'expid': self.expid,
-                'db_dir_path': BasicConfig.DB_DIR,
-                'main_db_name': BasicConfig.DB_FILE,
-                'local_root_dir_path': BasicConfig.LOCAL_ROOT_DIR,
+                "expid": self.expid,
+                "db_dir_path": BasicConfig.DB_DIR,
+                "main_db_name": BasicConfig.DB_FILE,
+                "local_root_dir_path": BasicConfig.LOCAL_ROOT_DIR,
             }
-            self.manager = create_experiment_status_db_manager(BasicConfig.DATABASE_BACKEND, **options)
+            self.manager = create_experiment_status_db_manager(
+                BasicConfig.DATABASE_BACKEND, **options
+            )
         except Exception:
-            message = f"Error while trying to update {str(self.expid)} in experiment_status."
-            Logging(self.expid, BasicConfig.HISTORICAL_LOG_DIR).log(message, traceback.format_exc())
-            self.manager = None
+            message = (
+                f"Error while trying to update {str(self.expid)} in experiment_status."
+            )
+            Logging(self.expid, BasicConfig.HISTORICAL_LOG_DIR).log(
+                message, traceback.format_exc()
+            )
+            raise
 
-    def set_as_running(self):
-        # type : () -> None
-        """ Set the status of the experiment in experiment_status of as_times.db as RUNNING. Creates the database, table and row if necessary."""
-        if self.manager:
-            exp_status_row = self.manager.get_experiment_status_row_by_expid(self.expid)
-            if exp_status_row:
-                self.manager.set_existing_experiment_status_as_running(exp_status_row.name)
-            else:
-                exp_row = self.manager.get_experiment_row_by_expid(self.expid)
-                self.manager.create_experiment_status_as_running(exp_row)
+    def set_status(self, status: str) -> None:
+        """
+        Sets the status of the experiment in experiment_status of as_times.db.
+        Creates the database, table and row if necessary.
+
+        :param status: The status to set for the experiment.
+        :dtype status: Models.RunningStatus
+        :return: None
+        """
+        self.manager.set_exp_status(self.expid, status)
+
+    def set_as_running(self) -> None:
+        """
+        Set the status of the experiment in experiment_status as RUNNING.
+        Creates the database, table and row if necessary.
+
+        :param status: The status to set for the experiment.
+        :dtype status: str
+        :return: None
+        """
+        self.manager.set_exp_status(self.expid, Models.RunningStatus.RUNNING)
+
+    def set_as_not_running(self) -> None:
+        """
+        Set the status of the experiment in experiment_status as NOT_RUNNING.
+        Creates the database, table and row if necessary.
+
+        :param status: The status to set for the experiment.
+        :dtype status: str
+        :return: None
+        """
+        self.manager.set_exp_status(self.expid, Models.RunningStatus.NOT_RUNNING)
+
+    def set_as_deleted(self) -> None:
+        """
+        Set the status of the experiment in experiment_status as DELETED.
+        Creates the database, table and row if necessary.
+
+        :param status: The status to set for the experiment.
+        :dtype status: str
+        :return: None
+        """
+        self.manager.set_exp_status(self.expid, Models.RunningStatus.DELETED)
+
+    def set_as_archived(self) -> None:
+        """
+        Set the status of the experiment in experiment_status of as_times.db as ARCHIVED.
+        Creates the database, table and row if necessary.
+
+        :param status: The status to set for the experiment.
+        :dtype status: str
+        :return: None
+        """
+        self.manager.set_exp_status(self.expid, Models.RunningStatus.ARCHIVED)
+
+    def update_heartbeat(self) -> None:
+        """Refresh the heartbeat timestamp for the experiment in as_times.db."""
+        self.manager.update_heartbeat(self.expid)
+
+    def heartbeat_monitor(
+        self, interval_seconds: int = 120
+    ) -> ExperimentHeartBeatMonitor:
+        """Creates an ExperimentHeartBeatMonitor for the experiment with the specified interval for updating the heartbeat.
+
+        :param interval_seconds: The interval in seconds at which the heartbeat should be updated. Default is 120 seconds.
+        :type interval_seconds: int
+        :return: An instance of ExperimentHeartBeatMonitor for the experiment.
+        :rtype: ExperimentHeartBeatMonitor
+        """
+        return ExperimentHeartBeatMonitor(self, interval_seconds)

--- a/autosubmit/install.py
+++ b/autosubmit/install.py
@@ -295,10 +295,6 @@ def configure(
                 )
 
             except OSError as e:
-                raise AutosubmitCritical(
-                    f"Can not write config file: {e.message}", 7012
-                )
-            except OSError as e:
                 raise AutosubmitCritical(f"Can not write config file: {e}", 7012)
     except (AutosubmitCritical, AutosubmitError):
         raise

--- a/autosubmit/log/log.py
+++ b/autosubmit/log/log.py
@@ -378,7 +378,7 @@ class Log:
         """Sends debug information to the log.
 
         :param msg: message to show
-        :param args: arguments for message formating (it will be done using format() method on str)
+        :param args: arguments for message formatting (it will be done using format() method on str)
         """
         msg = Log._verify_args_message(msg, *args)
         Log.log.log(Log.DEBUG, msg)
@@ -398,7 +398,7 @@ class Log:
         """Sends results information to the log. It will be shown in green in the console.
 
         :param msg: message to show
-        :param args: arguments for message formating (it will be done using format() method on str)
+        :param args: arguments for message formatting (it will be done using format() method on str)
         """
         msg = Log._verify_args_message(msg, *args)
         Log.log.log(Log.RESULT, msg)

--- a/autosubmit/workflow/manage.py
+++ b/autosubmit/workflow/manage.py
@@ -24,12 +24,13 @@ import signal
 import threading
 import time
 from collections.abc import Iterable
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING
 
 from portalocker import Lock
+from portalocker.exceptions import BaseLockException
 
 import autosubmit.helpers.autosubmit_helper as AutosubmitHelper
 from autosubmit.config.basicconfig import BasicConfig
@@ -43,12 +44,17 @@ from autosubmit.experiment.manage import (
 )
 from autosubmit.experiment.utils import print_job_details
 from autosubmit.git.autosubmit_git import check_unpushed_changes
+from autosubmit.history.database_managers import database_models as Models
 from autosubmit.history.database_managers.experiment_history_db_manager import (
     get_last_run_id,
 )
 from autosubmit.history.experiment_history import (
     ExperimentHistory,
     get_historical_database,
+)
+from autosubmit.history.experiment_status import (
+    ExperimentHeartBeatMonitor,
+    ExperimentStatus,
 )
 from autosubmit.job.filters import (
     apply_job_filters,
@@ -89,6 +95,46 @@ def _signal_handler(signal_received, frame) -> None:
     """
     Log.info("Autosubmit will interrupt at the next safe occasion")
     Scheduler.exit = True
+
+
+def _set_experiment_status(status_tracker: ExperimentStatus, status) -> None:
+    """Update the experiment status, warning if the update cannot be performed."""
+    try:
+        # TODO: Separate NOT_RUNNING into FAILED, COMPLETED and PAUSED statuses.
+        # Currently it's all treated as NOT_RUNNING for simplicity.
+        status_tracker.set_status(status)
+    except Exception as e:
+        Log.warning(
+            f"Autosubmit couldn't update the final experiment status for "
+            f"{status_tracker.expid}: {str(e)}"
+        )
+
+
+@contextmanager
+def _finalise_experiment_status(
+    status_tracker: ExperimentStatus,
+    heartbeat_monitor: ExperimentHeartBeatMonitor,
+):
+    """Finalise the experiment status and stop the heartbeat on block exit.
+
+    The experiment is marked as ``NOT_RUNNING`` on both success and error. If a
+    ``BaseLockException`` is raised (e.g. another instance holds the lock), the
+    status is left untouched so the running instance is not overwritten.
+    """
+    try:
+        yield
+    except BaseLockException:
+        # Multiple instances of Autosubmit running the same experiment, or a
+        # previous instance that did not release the lock file. In both cases we
+        # do not want to overwrite the experiment status (API/GUI consistency).
+        raise
+    except BaseException:
+        _set_experiment_status(status_tracker, Models.RunningStatus.NOT_RUNNING)
+        raise
+    else:
+        _set_experiment_status(status_tracker, Models.RunningStatus.NOT_RUNNING)
+    finally:
+        heartbeat_monitor.stop(timeout=10)
 
 
 def _prepare_run(
@@ -609,6 +655,8 @@ def run(
     :return: An integer representing the command exit status.
     """
     Scheduler.exit = False
+    status_tracker = ExperimentStatus(expid)
+    heartbeat_monitor = status_tracker.heartbeat_monitor(interval_seconds=120)
 
     # TODO: We can probably delete this? The CLI validators should be checking these paths already?
     # Initialize common folders'
@@ -622,7 +670,10 @@ def run(
             str(e),
         )
 
-    with Lock(os.path.join(tmp_path, "autosubmit.lock"), timeout=1):
+    with (
+        Lock(os.path.join(tmp_path, "autosubmit.lock"), timeout=1),
+        _finalise_experiment_status(status_tracker, heartbeat_monitor),
+    ):
         try:
             Log.debug("Preparing run")
             # This function is called only once, when the experiment is started.
@@ -646,6 +697,19 @@ def run(
         git_operational_check_enabled = as_conf_config.get(
             "GIT_OPERATIONAL_CHECK_ENABLED", True
         )
+
+        try:
+            status_tracker.set_as_running()
+        except Exception as e:
+            Log.warning(
+                f"Autosubmit couldn't set your experiment as running on the autosubmit times database: "
+                f"{Path(BasicConfig.DB_DIR) / BasicConfig.AS_TIMES_DB}. Exception: {str(e)}"
+            )
+
+        if not heartbeat_monitor.start():
+            Log.warning(
+                f"Heartbeat monitor could not start for experiment {expid}. Experiment status updates may not work."
+            )
 
         if git_operational_check_enabled:
             Log.debug("Checking for dirty local Git repository")
@@ -693,6 +757,7 @@ def run(
         job_list.load_wrappers()
         while job_list.continue_run():
             try:
+                heartbeat_monitor.ping()
                 if profiler is not None:
                     Scheduler.exit = profiler.iteration_checkpoint(
                         loaded_jobs, loaded_edges

--- a/docs/source/database/index.rst
+++ b/docs/source/database/index.rst
@@ -38,7 +38,7 @@ Core databases
 +===================+====================================+==========================================================================================================+
 | ``autosubmit.db`` | ``$HOME/autosubmit/autosubmit.db`` | The main database of Autosubmit. The location can be customized in the ``autosubmitrc`` file.            |
 +-------------------+------------------------------------+----------------------------------------------------------------------------------------------------------+
-| ``as_times.db``   | ``$HOME/autosubmit/as_times.db``   | Deprecated API. Used by Autosubmit API with Autosubmit ``3.x``. Kept for backward compatibility for now. |
+| ``as_times.db``   | ``$HOME/autosubmit/as_times.db``   | The secondary database of Autosubmit. Used to keep track of the experiment status.                       |
 +-------------------+------------------------------------+----------------------------------------------------------------------------------------------------------+
 
 Auxiliary databases

--- a/docs/source/userguide/expids.rst
+++ b/docs/source/userguide/expids.rst
@@ -27,7 +27,7 @@ last available experiment ID. The code below shows an example of the latter:
 
 .. code-block:: python
 
-    from autosubmit.experiment.experiment_common import next_experiment_id
+    from autosubmit.experiment.utils import next_experiment_id
 
     expid = next_experiment_id('a000’)
     print(expid)  # prints 'a001’

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -38,6 +38,7 @@ from testcontainers.core.container import DockerContainer  # type: ignore
 
 from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.config.configcommon import AutosubmitConfig
+from autosubmit.database.session import PostgreSQLEngineSingleton
 from autosubmit.experiment.manage import create as create_fn
 from autosubmit.experiment.manage import expid_fn
 from autosubmit.experiment.utils import next_experiment_id
@@ -518,7 +519,7 @@ def as_db(request: "FixtureRequest", tmp_path: "LocalPath", postgres_server: "Do
         engine = create_engine(f'postgresql://{user}:{password}@localhost:{port}/postgres')
         with engine.connect() as conn:
             conn.execution_options(isolation_level="AUTOCOMMIT").execute(
-                text(f"CREATE DATABASE {db}")
+                text(f'CREATE DATABASE "{db}"')
             )
 
         # And now replace the INI settings that have the default value set to SQLite.
@@ -539,12 +540,23 @@ def as_db(request: "FixtureRequest", tmp_path: "LocalPath", postgres_server: "Do
         raise ValueError(f'Unsupported database backend: {backend}')
 
     BasicConfig.read()
+    if backend == "postgres":
+        PostgreSQLEngineSingleton.reset()
     # TODO: check which functions call as_db twice or if this is used in
     #  combination other fixture that calls autosubmit.install)
     with suppress(AutosubmitCritical):
         install()
 
-    return backend
+    yield backend
+
+    # drop the per-test database so they do not accumulate in the
+    # Postgres container
+    if backend == "postgres":
+        with engine.connect() as conn:
+            conn.execution_options(isolation_level="AUTOCOMMIT").execute(
+                text(f'DROP DATABASE IF EXISTS "{db}" WITH (FORCE)')
+            )
+        engine.dispose()
 
 
 @pytest.fixture(scope='function', autouse=True)

--- a/test/integration/experiment/test_experiment_common.py
+++ b/test/integration/experiment/test_experiment_common.py
@@ -63,12 +63,12 @@ def test_delete_experiment_removes_directory_metadata_update(
     # We can update the metadata successfully, so db_common.delete_experiment should be called without exceptions
     if update_metadata:
         mocked_delete_metadata = mocker.patch(
-            "autosubmit.experiment.manage.delete_experiment"
+            "autosubmit.database.db_common.delete_experiment"
         )
     # We simulate a failure updating the metadata, so db_common.delete_experiment should be called but raise an exception
     else:
         mocked_delete_metadata = mocker.patch(
-            "autosubmit.experiment.manage.delete_experiment",
+            "autosubmit.database.db_common.delete_experiment",
             side_effect=Exception("metadata update failed"),
         )
 

--- a/test/integration/experiment/test_experiment_common.py
+++ b/test/integration/experiment/test_experiment_common.py
@@ -16,6 +16,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 """Integration tests for ``experiment_common.py``."""
+import pytest
 
 from autosubmit.experiment.manage import delete_experiment
 
@@ -37,6 +38,7 @@ def test_delete_experiment_cancelled(autosubmit_exp, mocker):
 
 
 def test_delete_experiment_failed(autosubmit_exp, mocker):
+    """Test that if the experiment deletion fails, the experiment is not deleted."""
     exp = autosubmit_exp(experiment_data={})
     mocker.patch('autosubmit.experiment.manage._delete_experiment', side_effect=ValueError)
 
@@ -44,14 +46,48 @@ def test_delete_experiment_failed(autosubmit_exp, mocker):
 
 
 def test_delete_experiment_that_is_running(autosubmit_exp, mocker):
+    """Test that if the experiment is running, the experiment is not deleted."""
     exp = autosubmit_exp(experiment_data={})
     mocker.patch('autosubmit.experiment.manage.process_id', return_value=True)
 
     assert not delete_experiment(exp.expid, force=True)
 
 
-def test_delete_experiment_fails_db_details(autosubmit_exp, mocker):
+@pytest.mark.parametrize("update_metadata", [True, False], ids=["metadata update succeeds", "metadata update fails"])
+def test_delete_experiment_removes_directory_metadata_update(
+    autosubmit_exp, mocker, update_metadata
+):
+    """Test that the experiment directory is removed after deletion and logs are displayed."""
     exp = autosubmit_exp(experiment_data={})
-    mocker.patch('autosubmit.experiment.manage.ExperimentDetails', side_effect=ValueError)
+    mocked_log = mocker.patch("autosubmit.experiment.manage.Log")
+    # We can update the metadata successfully, so db_common.delete_experiment should be called without exceptions
+    if update_metadata:
+        mocked_delete_metadata = mocker.patch(
+            "autosubmit.experiment.manage.delete_experiment"
+        )
+    # We simulate a failure updating the metadata, so db_common.delete_experiment should be called but raise an exception
+    else:
+        mocked_delete_metadata = mocker.patch(
+            "autosubmit.experiment.manage.delete_experiment",
+            side_effect=Exception("metadata update failed"),
+        )
 
-    assert not delete_experiment(exp.expid, force=True)
+    # Check that the experiment directory is correctly removed
+    assert exp.exp_path.exists()
+    result = delete_experiment(exp.expid, force=True)
+    assert not exp.exp_path.exists()
+    mocked_log.info.assert_any_call("Removing experiment directory...")
+    mocked_log.info.assert_any_call("Updating experiment status in sqlite database...")
+
+    # Check that metadata update is attempted in both cases
+    if update_metadata:
+        assert result
+        mocked_delete_metadata.assert_called_once_with(exp.expid)
+        mocked_log.info.assert_any_call(f"Experiment {exp.expid} has been deleted")
+        mocked_log.result.assert_any_call(
+            f"Experiment {exp.expid} marked as deleted in database"
+        )
+    else:
+        assert not result
+        mocked_delete_metadata.assert_called_once_with(exp.expid)
+        mocked_log.error.assert_called()

--- a/test/integration/history/database_managers/test_experiment_status_db_manager.py
+++ b/test/integration/history/database_managers/test_experiment_status_db_manager.py
@@ -17,12 +17,15 @@
 
 """Integration tests for the experiment status DB managers."""
 
+import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
-from sqlalchemy import inspect
+import sqlalchemy.exc
+from sqlalchemy import create_engine, inspect, text
 
+from autosubmit.config.basicconfig import BasicConfig
 from autosubmit.database.tables import ExperimentStatusTable
 from autosubmit.history.database_managers.database_models import (
     ExperimentRow,
@@ -33,24 +36,72 @@ from autosubmit.history.database_managers.experiment_status_db_manager import (
     SqlAlchemyExperimentStatusDbManager,
     create_experiment_status_db_manager,
 )
-from autosubmit.job.job_common import Status
 
 if TYPE_CHECKING:
     # noinspection PyProtectedMember
     from _pytest._py.path import LocalPath
+    
+def _create_experiment_status_db_manager_and_rows(
+    as_db: str,
+    tmp_path: Path,
+    expids: list[str],
+    autosubmit_exp=None,
+):
+    """Create a status manager and the experiment rows for sqlite or postgres."""
+    options = {"expid": expids[0]}
 
+    if as_db == "sqlite":
+        db_dir = tmp_path / "db"
+        db_dir.mkdir()
+        local_root_dir = tmp_path / "local"
+        local_root_dir.mkdir()
 
-def test_create_experiment_status_db_manager_invalid_value():
-    with pytest.raises(ValueError):
-        create_experiment_status_db_manager(None)  # type: ignore
+        autosubmit_db_path = db_dir / "test.db"
+        with sqlite3.connect(autosubmit_db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE experiment (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    autosubmit_version TEXT
+                )
+                """
+            )
+            cursor.executemany(
+                "INSERT INTO experiment (id, name, description, autosubmit_version) VALUES (?, ?, ?, ?)",
+                [(index + 1, expid, "test", "4.1.10") for index, expid in enumerate(expids)],
+            )
+            conn.commit()
+
+        options["db_dir_path"] = str(db_dir)
+        options["local_root_dir_path"] = str(local_root_dir)
+        options["main_db_name"] = "test.db"
+    else:
+        if autosubmit_exp is None:
+            raise ValueError("autosubmit_exp is required when using postgres")
+
+        for expid in expids:
+            autosubmit_exp(expid=expid, include_jobs=True)
+
+    database_manager = create_experiment_status_db_manager(as_db, **options)
+
+    if as_db == "postgres":
+        with database_manager.engine.begin() as conn:
+            for expid in expids:
+                conn.execute(text("DELETE FROM experiment_status WHERE name = :name"), {"name": expid})
+
+    experiment_rows = [database_manager.get_experiment_row_by_expid(expid) for expid in expids]
+    return database_manager, experiment_rows
 
 
 @pytest.mark.docker
 @pytest.mark.postgres
 def test_experiment_status_db_manager(tmp_path: 'LocalPath', as_db: str, use_sqlalchemy: bool, get_next_expid):
+    """Test that the experiment status DB manager can be created and performs basic operations (happy path)."""
     if as_db == "postgres" and not use_sqlalchemy:
         pytest.skip("Postgres only supports SQLAlchemy")
-
     expid = get_next_expid()
     options = {"expid": expid}
     tmp_test_dir = tmp_path / "test_status"
@@ -89,53 +140,342 @@ def test_experiment_status_db_manager(tmp_path: 'LocalPath', as_db: str, use_sql
     # Test methods
     # Create as RUNNING
     experiment = ExperimentRow(id=1, name=options["expid"], autosubmit_version="4.1.10", description="test")
-    database_manager.create_experiment_status_as_running(experiment)
+    database_manager.create_exp_status(experiment.id, experiment.name, "RUNNING")
 
     exp_status: ExperimentStatusRow = (database_manager.get_experiment_status_row_by_exp_id(exp_id=experiment.id))
     assert exp_status.status == "RUNNING"
 
     # Update status
-    database_manager.update_exp_status(experiment.name, "READY")
+    database_manager.update_exp_status(experiment.name, "NOT RUNNING")
     exp_status: ExperimentStatusRow = (database_manager.get_experiment_status_row_by_exp_id(exp_id=experiment.id))
-    assert exp_status.status == "READY"
+    assert exp_status.status == "NOT RUNNING"
 
     # Set back to RUNNING
-    database_manager.set_existing_experiment_status_as_running(exp_status.name)
+    database_manager.update_exp_status(exp_status.name, "RUNNING")
     exp_status: ExperimentStatusRow = (database_manager.get_experiment_status_row_by_exp_id(exp_id=experiment.id))
     assert exp_status.status == "RUNNING"
 
 
 @pytest.mark.docker
 @pytest.mark.postgres
-def test_get_experiment_status_row_by_expid(tmp_path: 'LocalPath', as_db: str, autosubmit_exp, get_next_expid):
+def test_experiment_status_name_is_unique(tmp_path: "LocalPath", as_db: str, autosubmit_exp, get_next_expid):
+    """Test that experiment_status.name is enforced as unique."""
+    database_manager, experiments = _create_experiment_status_db_manager_and_rows(
+        as_db=as_db,
+        tmp_path=tmp_path,
+        expids=["a000"],
+        autosubmit_exp=autosubmit_exp,
+    )
+
+    experiment = experiments[0]
+
+    database_manager.create_exp_status(
+        experiment.id,
+        experiment.name,
+        "RUNNING",
+    )
+
+    if as_db == "sqlite":
+        with pytest.raises(sqlite3.IntegrityError) as exc_info:
+            database_manager.create_exp_status(
+                experiment.id,
+                experiment.name,
+                "RUNNING",
+            )
+        assert "UNIQUE constraint failed: experiment_status.exp_id" in str(exc_info.value)
+    else:
+        with pytest.raises(sqlalchemy.exc.IntegrityError) as exc_info:
+            database_manager.create_exp_status(
+                experiment.id,
+                experiment.name,
+                "RUNNING",
+            )
+        assert "duplicate key value violates unique constraint" in str(exc_info.value)
+
+
+@pytest.mark.docker
+@pytest.mark.postgres
+def test_experiment_status_db_manager_adds_last_heartbeat_column_if_missing(
+    tmp_path: "LocalPath", as_db: str
+):
+    """Test that the manager adds last_heartbeat column into experiment_status table if it is missing."""
+    # SQLite
+    if as_db == "sqlite":
+        db_dir = tmp_path / "db"
+        db_dir.mkdir()
+        local_root_dir = tmp_path / "local"
+        local_root_dir.mkdir()
+
+        # Create the database and experiment_status table without last_heartbeat column
+        as_times_db_path = db_dir / "as_times.db"
+        with sqlite3.connect(as_times_db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                CREATE TABLE experiment_status (
+                    exp_id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    seconds_diff INTEGER NOT NULL,
+                    modified TEXT NOT NULL
+                )
+                """)
+            conn.commit()
+
+        # Initialize the manager
+        database_manager = ExperimentStatusDbManager(
+            expid="a000",
+            db_dir_path=str(db_dir),
+            main_db_name="as_times.db",
+            local_root_dir_path=str(local_root_dir),
+        )
+
+        # Get the columns of the experiment_status table for later verification
+        with sqlite3.connect(as_times_db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA table_info(experiment_status)")
+            columns = [row[1] for row in cursor.fetchall()]
+
+    # Postgres
+    else:
+        with create_engine(BasicConfig.DATABASE_CONN_URL).begin() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS experiment_status"))
+            conn.execute(text("""
+                    CREATE TABLE experiment_status (
+                        exp_id INTEGER PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        seconds_diff INTEGER NOT NULL,
+                        modified TEXT NOT NULL
+                    )
+                    """))
+        database_manager = create_experiment_status_db_manager("postgres")
+        inspector = inspect(database_manager.engine)
+        columns = [
+            col["name"]
+            for col in inspector.get_columns(
+                ExperimentStatusTable.name, schema="public"
+            )
+        ]
+
+    assert "last_heartbeat" in columns
+    if as_db == "sqlite":
+        assert isinstance(database_manager, ExperimentStatusDbManager)
+    else:
+        assert isinstance(database_manager, SqlAlchemyExperimentStatusDbManager)
+
+
+@pytest.mark.docker
+@pytest.mark.postgres
+def test_update_heartbeat_stores_last_heartbeat(tmp_path: "LocalPath", as_db: str, autosubmit_exp, mocker):
+    """Test that update_heartbeat() stores the last heartbeat timestamp in the database."""
+    database_manager, experiments = _create_experiment_status_db_manager_and_rows(
+        as_db=as_db,
+        tmp_path=tmp_path,
+        expids=["a000"],
+        autosubmit_exp=autosubmit_exp,
+    )
+
+    # Ensure heartbeat timestamps are deterministic, ordering stable across diff runs
+    timestamps = [
+        "2026-05-08T10:00:00+00:00",
+        "2026-05-08T10:00:01+00:00",
+        "2026-05-08T10:00:02+00:00",
+    ]
+    mocker.patch(
+        "autosubmit.history.database_managers.experiment_status_db_manager.HUtils.get_current_datetime",
+        side_effect=timestamps,
+    )
+
+    experiment = experiments[0]
+    exp_id = experiment.id
+    # Act
+    database_manager.create_exp_status(experiment.id, experiment.name, "RUNNING")
+    database_manager.update_heartbeat(experiment.name)
+    before = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    # Assert
+    assert before is not None
+    assert before.last_heartbeat == timestamps[1]
+
+    # Act
+    database_manager.update_heartbeat("a000")
+    after = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    # Assert
+    assert after is not None
+    assert after.last_heartbeat == timestamps[2]
+
+
+@pytest.mark.parametrize(
+    "exp_count,update_expids",
+    [
+        (1, ["a000", "a000"]),  # same experiment, concurrent updates
+        (2, ["a000", "a001"]),  # different experiments, concurrent updates
+    ],
+    ids=["same_experiment", "different_experiments"],
+)
+@pytest.mark.docker
+@pytest.mark.postgres
+def test_concurrent_heartbeat_updates(tmp_path: "LocalPath", as_db: str, autosubmit_exp, mocker, exp_count, update_expids):
+    """Test that concurrent heartbeat updates do not cause race conditions."""
+    unique_expids = list(dict.fromkeys(update_expids))
+    database_manager, experiments = _create_experiment_status_db_manager_and_rows(
+        as_db=as_db,
+        tmp_path=tmp_path,
+        expids=unique_expids,
+        autosubmit_exp=autosubmit_exp,
+    )
+
+    # Create status rows for experiments
+    for experiment in experiments:
+        database_manager.create_exp_status(experiment.id, experiment.name, "RUNNING")
+
+    # Mock update_heartbeat to synchronize concurrent calls
+    original_update_heartbeat = database_manager.update_heartbeat
+    import threading
+    start_barrier = threading.Barrier(2)
+
+    def delayed_update_heartbeat(expid: str):
+        start_barrier.wait()
+        original_update_heartbeat(expid)
+
+    mocker.patch.object(
+        database_manager, "update_heartbeat", side_effect=delayed_update_heartbeat
+    )
+
+    # Execute concurrent updates
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        thread1 = executor.submit(database_manager.update_heartbeat, update_expids[0])
+        thread2 = executor.submit(database_manager.update_heartbeat, update_expids[1])
+        thread1.result()
+        thread2.result()
+
+    # Verify all experiments have heartbeats
+    for experiment in experiments:
+        exp_status = database_manager.get_experiment_status_row_by_exp_id(experiment.id)
+        assert exp_status is not None
+        assert exp_status.last_heartbeat is not None
+
+
+@pytest.mark.docker
+@pytest.mark.postgres
+def test_update_exp_status_updates_last_heartbeat_only_when_running(
+    tmp_path: "LocalPath", as_db: str, autosubmit_exp, mocker
+):
+    """Test that RUNNING status creation and updates store a last_heartbeat value."""
+    database_manager, experiments = _create_experiment_status_db_manager_and_rows(
+        as_db=as_db,
+        tmp_path=tmp_path,
+        expids=["a000"],
+        autosubmit_exp=autosubmit_exp,
+    )
+
+    # Make it deterministic, ensure ordering is stable across diff runs
+    timestamps = [
+        "2026-05-08T10:00:00+00:00",
+        "2026-05-08T10:00:01+00:00",
+        "2026-05-08T10:00:02+00:00",
+        "2026-05-08T10:00:03+00:00",
+    ]
+    mocker.patch(
+        "autosubmit.history.database_managers.experiment_status_db_manager.HUtils.get_current_datetime",
+        side_effect=timestamps,
+    )
+
+    experiment = experiments[0]
+    exp_id = experiment.id
+
+    database_manager.create_exp_status(experiment.id, experiment.name, "RUNNING")
+    database_manager.update_heartbeat(experiment.name)
+
+    # Get initial status (RUNNING with last_heartbeat set)
+    exp_status = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    assert exp_status is not None
+    initial_heartbeat = exp_status.last_heartbeat
+    assert initial_heartbeat == timestamps[1]
+
+    # Update status to NOT RUNNING. Should not update last_heartbeat
+    database_manager.update_exp_status("a000", "NOT RUNNING")
+
+    after_not_running = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    assert after_not_running is not None
+    assert after_not_running.status == "NOT RUNNING"
+    assert after_not_running.last_heartbeat == initial_heartbeat
+
+    # Update again with RUNNING status. Should update last_heartbeat
+    database_manager.update_exp_status("a000", "RUNNING")
+
+    after_running = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    assert after_running is not None
+    assert after_running.status == "RUNNING"
+    assert after_running.last_heartbeat == timestamps[3]
+
+
+@pytest.mark.docker
+@pytest.mark.postgres
+def test_set_exp_status_creates_running_with_heartbeat(
+    tmp_path: "LocalPath", as_db: str, autosubmit_exp, mocker
+):
+    """Test that set_exp_status creates a new RUNNING status with heartbeat when status doesn't exist."""
+    database_manager, _ = _create_experiment_status_db_manager_and_rows(
+        as_db=as_db,
+        tmp_path=tmp_path,
+        expids=["a000"],
+        autosubmit_exp=autosubmit_exp,
+    )
+
+    # Make it deterministic, ensure ordering is stable across diff runs
+    timestamps = [
+        "2026-05-08T10:00:00+00:00",  # create_exp_status (modified)
+        "2026-05-08T10:00:01+00:00",  # update_heartbeat (called by set_exp_status)
+    ]
+    mocker.patch(
+        "autosubmit.history.database_managers.experiment_status_db_manager.HUtils.get_current_datetime",
+        side_effect=timestamps,
+    )
+
+    experiment = database_manager.get_experiment_row_by_expid("a000")
+    exp_id = experiment.id
+
+    # Verify no status row exists
+    initial_status = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    assert initial_status is None
+
+    # Act
+    database_manager.set_exp_status("a000", "RUNNING")
+
+    # Assert
+    final_status = database_manager.get_experiment_status_row_by_exp_id(exp_id)
+    assert final_status is not None
+    assert final_status.status == "RUNNING"
+    assert final_status.last_heartbeat == timestamps[1]
+
+
+@pytest.mark.docker
+@pytest.mark.postgres
+def test_set_exp_status_logs_warning(
+    tmp_path: "LocalPath", as_db: str, mocker, get_next_expid
+):
+    """Test lookup failure behavior: direct lookup raises, status setter logs warning."""
     expid = get_next_expid()
     options = {"expid": expid}
 
-    is_sqlalchemy = as_db == "sqlite"
-    if is_sqlalchemy:
+    if as_db == "sqlite":
         options["db_dir_path"] = tmp_path
         options["local_root_dir_path"] = tmp_path
         options["main_db_name"] = "tests.db"
 
     database_manager = create_experiment_status_db_manager(as_db, **options)
 
-    # An error as there is no such experiment ID in the database
+    warning_mock = mocker.patch(
+        "autosubmit.history.database_managers.experiment_status_db_manager.Log.warning"
+    )
+
+    # Calling directly get_exp_row_by_expid raises a ValueError
     with pytest.raises(ValueError):
-        database_manager.get_experiment_status_row_by_expid(expid)
+        database_manager.get_experiment_row_by_expid(expid)
 
-    # Create the experiment, but it still will not have any experiment status
-    exp = autosubmit_exp(expid=expid, include_jobs=True)
-    experiment_status_row = database_manager.get_experiment_status_row_by_expid(exp.expid)
-    assert experiment_status_row is None
+    # set_exp_status catches the ValueError and logs a warning
+    database_manager.set_exp_status(expid, "RUNNING")
 
-    # Get the experiment row
-    experiment_row = database_manager.get_experiment_row_by_expid(exp.expid)
-    experiment_db_id = experiment_row.id if experiment_row else None
-    assert experiment_db_id is not None
-
-    # Create the experiment status row and assert it is created
-    last_row_id = database_manager.create_exp_status(experiment_db_id, exp.expid, Status.SUBMITTED)
-    assert last_row_id > 0
-
-    experiment_status_row = database_manager.get_experiment_status_row_by_expid(exp.expid)
-    assert experiment_status_row
+    warning_mock.assert_called_once()
+    assert f"Experiment {expid} not found when trying to set status" in warning_mock.call_args[0][0]

--- a/test/integration/history/test_experiment_status.py
+++ b/test/integration/history/test_experiment_status.py
@@ -1,0 +1,223 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Integration tests for ExperimentStatus and ExperimentHeartBeatMonitor."""
+
+import pytest
+
+from autosubmit.history.experiment_status import (
+    ExperimentHeartBeatMonitor,
+    ExperimentStatus,
+)
+
+
+def test_heartbeat_monitor_starts_and_stops_correctly(mocker):
+    """Test __enter__ and __exit__ methods call start() and stop()."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    start_mock = mocker.patch.object(monitor, "start", return_value=True)
+    stop_mock = mocker.patch.object(monitor, "stop")
+
+    with monitor as returned_monitor:
+        assert returned_monitor is monitor
+
+    start_mock.assert_called_once_with()
+    stop_mock.assert_called_once_with()
+
+
+def test_heartbeat_monitor_run_calls_ping_at_intervals(mocker):
+    """Test that _run() calls ping() at the specified intervals."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=0.1)
+    ping_mock = mocker.patch.object(monitor, "ping", return_value=True)
+
+    wait_mock = mocker.patch.object(
+        monitor._stop_event,
+        "wait",
+        side_effect=[False, False, False, True],
+    )
+
+    # Act
+    monitor._run()
+
+    # Assert
+    assert (
+        ping_mock.call_count == 3
+    )  # Last call should not happen because wait returns True
+    assert wait_mock.call_count == 4
+
+
+def test_heartbeat_monitor_ping_returns_false_when_update_fails(mocker):
+    """Test ping() returns False and logs warning when update_heartbeat fails."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    status_tracker.update_heartbeat.side_effect = RuntimeError("DB error")
+    warning_error = mocker.patch("autosubmit.history.experiment_status.Log.warning")
+
+    assert monitor.ping() is False
+    warning_error.assert_called_once()
+
+
+def test_heartbeat_monitor_ping_blocks_concurrent_pings(mocker):
+    """Test that ping() correctly uses the lock to prevent concurrent updates."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    # Simulate update_heartbeat taking some time to complete
+    def slow_update():
+        import time
+
+        time.sleep(0.1)
+
+    status_tracker.update_heartbeat.side_effect = slow_update
+
+    # Start two threads that call ping() at the same time
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        thread_a = executor.submit(monitor.ping)
+        thread_b = executor.submit(monitor.ping)
+
+        result_a = thread_a.result()
+        result_b = thread_b.result()
+
+    # Assert
+    assert result_a is True
+    assert result_b is True
+    assert status_tracker.update_heartbeat.call_count == 2
+
+
+def test_heartbeat_monitor_start_when_thread_already_running(mocker):
+    """Test that start() does not start a new thread if one is already running."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    # Mock the thread to simulate it being alive
+    thread = mocker.Mock()
+    thread.is_alive.return_value = True
+    monitor._thread = thread
+
+    # Act
+    result = monitor.start()
+
+    # Assert
+    assert result is True
+    thread.is_alive.assert_called_once_with()
+
+
+def test_heartbeat_monitor_start_fails_when_first_ping_fails(mocker):
+    """Tets that start() fails if the initial ping() fails."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    # Simulate ping() failure on first call
+    ping_mock = mocker.patch.object(monitor, "ping", return_value=False)
+
+    # Assert
+    assert monitor.start() is False
+    ping_mock.assert_called_once_with()
+    assert monitor._thread is None
+    assert monitor._stop_event.is_set()
+
+
+def test_heartbeat_monitor_start_fails_when_thread_creation_fails(mocker):
+    """Test that start() fails if thread creation raises an exception."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    # Simulate successful ping() but thread creation failure
+    mocker.patch.object(monitor, "ping", return_value=True)
+    thread_mock = mocker.patch(
+        "threading.Thread", side_effect=RuntimeError("Thread error")
+    )
+
+    # Assert
+    assert monitor.start() is False
+    thread_mock.assert_called_once()
+    assert monitor._thread is None
+    assert monitor._stop_event.is_set()
+
+
+def test_heartbeat_monitor_stop_clears_thread(mocker):
+    """Test that stop() clears the thread reference."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    # Mock the thread to simulate being dead
+    thread = mocker.Mock()
+    thread.is_alive.return_value = False
+    monitor._thread = thread
+
+    # Act
+    monitor.stop()
+
+    # Assert
+    thread.join.assert_called_once_with(timeout=10.0)  # default timeout
+    assert monitor._thread is None
+
+
+def test_heartbeat_monitor_stop_logs_warning_if_thread_does_not_stop(mocker):
+    """Test that stop() logs a warning if the thread does not stop within the timeout."""
+    status_tracker = mocker.Mock(expid="a000")
+    monitor = ExperimentHeartBeatMonitor(status_tracker, interval_seconds=1)
+
+    # Mock the thread to simulate it being alive after join
+    thread = mocker.Mock()
+    thread.is_alive.return_value = True
+    monitor._thread = thread
+
+    warning_mock = mocker.patch("autosubmit.history.experiment_status.Log.warning")
+
+    # Act
+    monitor.stop(timeout=0.1)  # Use a short timeout for the test
+
+    # Assert
+    thread.join.assert_called_once_with(timeout=0.1)
+    warning_mock.assert_called_once()
+    assert monitor._thread is None
+
+
+def test_experiment_status_set_status_delegates_manager(mocker):
+    """Test that set_status() delegates to the status manager."""
+    manager = mocker.Mock()
+    mocker.patch(
+        "autosubmit.history.experiment_status.create_experiment_status_db_manager",
+        return_value=manager,
+    )
+    experiment_status = ExperimentStatus("a000")
+
+    # Act
+    experiment_status.set_status("RUNNING")
+
+    # Assert
+    manager.set_exp_status.assert_called_once_with("a000", "RUNNING")
+
+
+def test_experiment_status_init_raises_error_when_manager_creation_fails(mocker):
+    """Test that ExperimentStatus __init__ raises an error if the manager creation fails."""
+    logging_mock = mocker.patch("autosubmit.history.experiment_status.Logging")
+    mocker.patch(
+        "autosubmit.history.experiment_status.create_experiment_status_db_manager",
+        side_effect=RuntimeError("Error creating manager"),
+    )
+
+    with pytest.raises(RuntimeError, match="Error creating manager"):
+        ExperimentStatus("a000")
+
+    logging_mock.return_value.log.assert_called_once()

--- a/test/integration/test_expid.py
+++ b/test/integration/test_expid.py
@@ -43,6 +43,7 @@ from autosubmit.experiment.manage import (
     delete_experiment,
     describe,
     expid_fn,
+    get_experiment_owner,
     new_experiment,
 )
 from autosubmit.helpers.version import get_version
@@ -860,7 +861,7 @@ def test_delete_experiment(mocker, tmp_path, autosubmit_exp):
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
     cursor.execute(f"SELECT name FROM experiment WHERE name='{as_exp.expid}'")
-    assert cursor.fetchone() is None
+    assert cursor.fetchone() is not None
     cursor.close()
     # Test does not exist
 
@@ -868,6 +869,50 @@ def test_delete_experiment(mocker, tmp_path, autosubmit_exp):
     assert mocked_log.error.call_count > 0
     assert "Experiment does not exist" in mocked_log.error.call_args_list[0][0][0]
 
+
+def test_delete_experiment_not_owner(mocker, tmp_path, autosubmit_exp):
+    install()
+    as_exp = autosubmit_exp(experiment_data=_get_experiment_data(tmp_path))
+    run_dir = as_exp.as_conf.basic_config.LOCAL_ROOT_DIR
+    mocker.patch('autosubmit.experiment.manage.user_yes_no_query', return_value=True)
+    mocker.patch('pwd.getpwuid', side_effect=TypeError)
+    mocker.patch("autosubmit.experiment.manage.process_id", return_value=None)
+    mocked_log = mocker.patch("autosubmit.experiment.manage.Log")
+    current_owner, _, _, _ = get_experiment_owner(as_exp.expid)
+    assert current_owner is None
+    # test not owner not eadmin
+    _user = getuser()
+    mocker.patch(
+        "autosubmit.experiment.manage.get_experiment_owner",
+        return_value=(_user, 0, False, False),
+    )
+
+    delete_experiment(expids=f'{as_exp.expid}', force=True)
+    assert mocked_log.error.call_count > 0
+    assert 'Failed to delete experiment' in mocked_log.error.call_args_list[0][0][0]
+
+    # test eadmin
+    mocker.patch(
+        "autosubmit.experiment.manage.get_experiment_owner",
+        return_value=(_user, 0, False, True),
+    )
+    delete_experiment(expids=f'{as_exp.expid}', force=False)
+    assert mocked_log.error.call_count > 0
+    assert 'Failed to delete experiment' in mocked_log.error.call_args_list[0][0][0]
+
+    # test eadmin force
+    delete_experiment(expids=f'{as_exp.expid}', force=True)
+    assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}").iterdir())
+    assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/data").iterdir())
+    assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/logs").iterdir())
+    assert all(as_exp.expid not in Path(f).name for f in Path(f"{run_dir}/metadata/structures").iterdir())
+    # Consult if the expid is still in the database (tombstone)
+    db_path = Path(BasicConfig.DB_PATH)
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT name FROM experiment WHERE name='{as_exp.expid}'")
+        assert cursor.fetchone() is not None
+        cursor.close()
 
 @pytest.mark.parametrize(
     "expid_value",
@@ -919,16 +964,10 @@ def test_perform_deletion(mocker, tmp_path, autosubmit_exp):
         ]
     ):
         raise AutosubmitCritical("tmp not in path")
-    mocker.patch(
-        "autosubmit.database.db_common.delete_experiment", side_effect=FileNotFoundError
-    )
     err_message = _perform_deletion(
         experiment_path, structure_db_path, job_data_db_path, as_exp.expid
     )
-    assert all(
-        x in err_message
-        for x in ["Cannot delete experiment entry", "Cannot delete directory"]
-    )
+    assert "Cannot delete directory" in err_message
 
 
 def test_new_experiment_fails_for_some_unknown_reason(

--- a/test/regression/test_workflow_dependencies.py
+++ b/test/regression/test_workflow_dependencies.py
@@ -59,8 +59,7 @@ def prepare_custom_config_tests(default_yaml_file: dict[str, Any], project_yaml_
 @pytest.fixture()
 def prepare_basic_config(current_tmpdir):
     basic_conf = BasicConfig()
-    BasicConfig.DB_DIR = (current_tmpdir / "workflows")
-    BasicConfig.DB_FILE = "as_times.db"
+    BasicConfig.DB_DIR = current_tmpdir
     BasicConfig.LOCAL_ROOT_DIR = (current_tmpdir / "workflows")
     BasicConfig.LOCAL_TMP_DIR = "tmp"
     BasicConfig.LOCAL_ASLOG_DIR = "ASLOGS"

--- a/test/unit/database/test_db_common.py
+++ b/test/unit/database/test_db_common.py
@@ -105,3 +105,49 @@ def test_save_experiment_integrity_error(monkeypatch, tmp_path, mocker):
     with pytest.raises(AutosubmitCritical) as e:
         db_common.save_experiment('', '', '')
         assert "could not register experiment" in str(e.value)
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "postgres"])
+def test_delete_experiment_not_exists(engine, mocker):
+    """Test _delete_experiment and _delete_experiment_sqlalchemy returns True when the experiment does not exist."""
+    if engine == "sqlite":
+        mocker.patch('autosubmit.database.db_common._check_experiment_exists', return_value=False)
+        assert db_common._delete_experiment("non_existent_experiment_id")
+    else:
+        mocker.patch('autosubmit.database.db_common._check_experiment_exists_sqlalchemy', return_value=False)
+        assert db_common._delete_experiment_sqlalchemy("non_existent_experiment_id")
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "postgres"])
+def test_delete_experiment_exists(engine, mocker):
+    """Test _delete_experiment and _delete_experiment_sqlalchemy returns True when the experiment exists."""
+    if engine == "sqlite":
+        delete_fn = db_common._delete_experiment
+        mocker.patch('autosubmit.database.db_common._check_experiment_exists', return_value=True)
+    else:
+        delete_fn = db_common._delete_experiment_sqlalchemy
+        mocker.patch('autosubmit.database.db_common._check_experiment_exists_sqlalchemy', return_value=True)
+
+    mocked_status = mocker.patch('autosubmit.database.db_common.ExperimentStatus')
+    mocked_status.return_value.set_as_deleted.return_value = None
+
+    assert delete_fn("existing_experiment_id")
+    mocked_status.assert_called_once_with("existing_experiment_id")
+    mocked_status.return_value.set_as_deleted.assert_called_once()
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "postgres"])
+def test_delete_experiment_set_as_deleted_fails(engine, mocker):
+    """Test that if set_as_deleted fails, the experiment is not deleted."""
+    if engine == "sqlite":
+        delete_fn = db_common._delete_experiment
+        mocker.patch('autosubmit.database.db_common._check_experiment_exists', return_value=True)
+    else:
+        delete_fn = db_common._delete_experiment_sqlalchemy
+        mocker.patch('autosubmit.database.db_common._check_experiment_exists_sqlalchemy', return_value=True)
+
+    mocked_status = mocker.patch('autosubmit.database.db_common.ExperimentStatus')
+    mocked_status.return_value.set_as_deleted.side_effect = Exception('Failed to set as deleted')
+
+    with pytest.raises(AutosubmitCritical, match='Could not mark experiment as deleted'):
+        delete_fn("existing_experiment_id")

--- a/test/unit/history/database_managers/test_experiment_status_db_manager.py
+++ b/test/unit/history/database_managers/test_experiment_status_db_manager.py
@@ -1,0 +1,74 @@
+# Copyright 2015-2026 Earth Sciences Department, BSC-CNS
+#
+# This file is part of Autosubmit.
+#
+# Autosubmit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Autosubmit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for for the experiment status DB managers."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from autosubmit.history.database_managers.experiment_status_db_manager import (
+    ExperimentStatusDbManager,
+    create_experiment_status_db_manager,
+)
+
+if TYPE_CHECKING:
+    # noinspection PyProtectedMember
+    from _pytest._py.path import LocalPath
+
+
+def test_create_experiment_status_db_manager_invalid_value():
+    """Test that providing an invalid database type (diff from 'sqlite' and 'postgres') raises an error."""
+    with pytest.raises(ValueError):
+        create_experiment_status_db_manager(None)  # type: ignore
+
+
+def test_set_exp_status_logs_warning_on_lookup_failures(tmp_path: "LocalPath", mocker):
+    """Test that set_exp_status() logs a warning when experiment lookup fails."""
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    local_root_dir = tmp_path / "local"
+    local_root_dir.mkdir()
+
+    database_manager = ExperimentStatusDbManager(
+        expid="a000",
+        db_dir_path=str(db_dir),
+        main_db_name="test.db",
+        local_root_dir_path=str(local_root_dir),
+    )
+
+    warning_mock = mocker.patch(
+        "autosubmit.history.database_managers.experiment_status_db_manager.Log.warning"
+    )
+    # Simulate experiment lookup failure (this is the lookup used by set_exp_status)
+    mocker.patch.object(
+        database_manager,
+        "get_experiment_row_by_expid",
+        side_effect=ValueError("missing experiment row"),
+    )
+    create_status_mock = mocker.patch.object(database_manager, "create_exp_status")
+
+    # Act
+    database_manager.set_exp_status("a000", "RUNNING")
+
+    # Assert
+    warning_mock.assert_called_once()
+    assert (
+        "Experiment a000 not found when trying to set status"
+        in warning_mock.call_args[0][0]
+    )
+    create_status_mock.assert_not_called()


### PR DESCRIPTION
Part 1 of this pr (was incorrectly closed): https://github.com/BSC-ES/autosubmit/pull/2980
Closes #2049, #2137
Related to https://github.com/BSC-ES/autosubmit/issues/2957: `RunningStatus` is now an enum

**Things done**
- Extended available experiment status in `experiment_status` table. Possible experiment status are: `NOT_RUNNING`, `RUNNING`, `ARCHIVED` and `DELETED`.
- Experiments created (`expid` and `create`) are marked as `NOT_RUNNING`. Implementation left open if we want to add more states in the future.
- Keep traceability of deleted experiments in both `autosubmit.db` and `as_times.db`. Once the experiment is deleted, it's kept in the database with status `DELETED` (tombstone).
- Added column `last_heartbeat` to table `experiment_status`. Each experiment creates a daemon thread (autosubmit-heartbeat-{expid}) that updates the `last_heartbeat` timestamp every 2 min while the experiment is running.
- Enforce unique indx on `name` in `experiment_status` table, kept most recent one.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md`.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `pyproject.toml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included in `CHANGELOG.md` if this is a change that can affect users.
- [x] Documentation updated.
- [x] If this is a bug fix, PR should include a link to the issue (e.g. `Closes #1234`).
