### PR TITLE
Fix platform exclusivity during job refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ several bug fixes and enhancements to improve the overall user experience.
 
 **Bug fixes:**
 
+- Preserve platform exclusivity when refreshing job parameters #3234
 - Remove the unrelated `--filter_status` option from `autosubmit expid` #3241
 - Fix timeout guard is silently disabled for login/local jobs #3081
 - Fix CI ruff lint job failing on deleted files or single-commited branches #3166

--- a/autosubmit/job/job.py
+++ b/autosubmit/job/job.py
@@ -2071,8 +2071,9 @@ class Job:
             self.shape = parameters.get("CURRENT_SHAPE", "")
             self.processors_per_node = parameters.get("CURRENT_PROCESSORS_PER_NODE", "1")
             self.nodes = parameters.get("CURRENT_NODES", "")
-            # FIXME: Should be ``CURRENT_EXCLUSIVITY`` instead of ``CURRENT_EXCLUSIVE`` to match the platform parameter?
-            self.exclusive = parameters.get("CURRENT_EXCLUSIVE", False)
+            self.exclusive = parameters.get(
+                "CURRENT_EXCLUSIVE", parameters.get("CURRENT_EXCLUSIVITY", False)
+            )
             self.threads = parameters.get("CURRENT_THREADS", "1")
             self.tasks = parameters.get("CURRENT_TASKS", "0")
             self.reservation = parameters.get("CURRENT_RESERVATION", "")

--- a/test/unit/test_job.py
+++ b/test/unit/test_job.py
@@ -2534,7 +2534,8 @@ def test_check_completion(completed_names, default_status, expected, mocker):
     platform.get_completed_job_names.assert_called_once_with([job.name])
 
 
-def test_update_platform_associated_parameters(mocker):
+@pytest.mark.parametrize("exclusivity_key", ["CURRENT_EXCLUSIVE", "CURRENT_EXCLUSIVITY"])
+def test_update_platform_associated_parameters(mocker, exclusivity_key):
     job = Job("A", 1, Status.WAITING, 0)
     as_conf = mocker.MagicMock(spec=AutosubmitConfig)
     as_conf.get_project_type.return_value = "none"
@@ -2548,7 +2549,7 @@ def test_update_platform_associated_parameters(mocker):
         "CURRENT_SHAPE": "rect",
         "CURRENT_PROCESSORS_PER_NODE": "2",
         "CURRENT_NODES": "1",
-        "CURRENT_EXCLUSIVE": True,
+        exclusivity_key: True,
         "CURRENT_THREADS": "8",
         "CURRENT_TASKS": "16",
         "CURRENT_RESERVATION": "resv",


### PR DESCRIPTION
## Summary

- use the platform `CURRENT_EXCLUSIVITY` value when a job-specific `CURRENT_EXCLUSIVE` override is absent
- preserve the existing job-level override behavior
- cover both parameter sources in the job refresh regression

## Validation

- `.venv/bin/pytest test/unit/test_job.py -q` (229 passed)
- `.venv/bin/ruff check autosubmit/job/job.py test/unit/test_job.py`
- `.venv/bin/python -m build`

Closes #3234

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>
